### PR TITLE
Multiprocess PASTIS matrix

### DIFF
--- a/Jupyter Notebooks/LUVOIR/18_comparison_matrices_multiprocessed.ipynb
+++ b/Jupyter Notebooks/LUVOIR/18_comparison_matrices_multiprocessed.ipynb
@@ -1,0 +1,254 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Comparing normal matrix results vs. multiprocessed matrix results\n",
+    "\n",
+    "Making sure the multiprocessing spits out the correct results. Verified on the LUVOIR case."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports\n",
+    "import os\n",
+    "from astropy.io import fits\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LogNorm\n",
+    "import hcipy as hc\n",
+    "\n",
+    "os.chdir('/Users/ilaginja/repos/PASTIS/pastis')\n",
+    "from config import CONFIG_INI\n",
+    "from e2e_simulators.luvoir_imaging import LuvoirAPLC\n",
+    "datadir = CONFIG_INI.get('local', 'local_data_path')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define directories\n",
+    "dir_standard = '2020-07-25T17-51-31_luvoir-small'\n",
+    "dir_multi = '2020-07-27T15-29-09_luvoir-small'\n",
+    "\n",
+    "# Define matrix name\n",
+    "matrix_name = 'PASTISmatrix_num_piston_Noll1.fits'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The multiprocessed case saves individual fits images, while the standard way saves out a PSF cube. It can also save out individual PSF fits images by setting the according parameter, by that's not really necessary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read PSF from cube in standard dir\n",
+    "cube_standard = fits.getdata(os.path.join(datadir, dir_standard, 'matrix_numerical', 'psfs', 'psf_cube.fits'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define a segment pair you want to compare the DH image for and read both PSFs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pick segment pair\n",
+    "seg1 = 1\n",
+    "seg2 = 10\n",
+    "\n",
+    "# Read PSFs\n",
+    "psf_name_multi = f'psf_piston_Noll1_segs_{seg1}-{seg2}.fits'\n",
+    "psf_mult = fits.getdata(os.path.join(datadir, dir_multi, 'matrix_numerical', 'psfs', psf_name_multi))\n",
+    "\n",
+    "standard_index = (seg1-1)*120+(seg2-1)\n",
+    "psf_stand = cube_standard[standard_index]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot both PSFs side by side to compare them. In the following cell, plot their difference - it should be zero."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot both\n",
+    "plt.figure(figsize=(18, 9))\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.title('standard')\n",
+    "plt.imshow(psf_stand, norm=LogNorm())\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.title('multi')\n",
+    "plt.imshow(psf_mult, norm=LogNorm())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot difference\n",
+    "print(np.sum(psf_stand - psf_mult))\n",
+    "plt.imshow(np.log10(psf_stand - psf_mult))\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Prepare to measure their DH mean contrast by making DH mask."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create Luvoir and DH mask\n",
+    "optics_input = CONFIG_INI.get('LUVOIR', 'optics_path')\n",
+    "sampling = 4\n",
+    "design = 'small'\n",
+    "luvoir = LuvoirAPLC(optics_input, design, sampling)   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dh_outer = hc.circular_aperture(2 * luvoir.apod_dict[design]['owa'] * luvoir.lam_over_d)(luvoir.focal_det)\n",
+    "dh_inner = hc.circular_aperture(2 * luvoir.apod_dict[design]['iwa'] * luvoir.lam_over_d)(luvoir.focal_det)\n",
+    "dh_mask = (dh_outer - dh_inner).astype('bool')\n",
+    "\n",
+    "hc.imshow_field(dh_mask)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compare the mean contrast in both images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Measure contrast in both images\n",
+    "dh_int_stand = (psf_stand) * dh_mask.shaped\n",
+    "c_stand = np.mean(dh_int_stand[np.where(dh_mask.shaped != 0)])\n",
+    "print('contrast floor: {}'.format(c_stand))\n",
+    "\n",
+    "dh_int_multi = (psf_mult) * dh_mask.shaped\n",
+    "c_multi = np.mean(dh_int_multi[np.where(dh_mask.shaped != 0)])\n",
+    "print('contrast floor: {}'.format(c_multi))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's do the same on the PASTIS matrices directly. Load them, plot them side by side and then their difference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load both matrices\n",
+    "mat_stand = fits.getdata(os.path.join(dir_standard, 'matrix_numerical', matrix_name))\n",
+    "mat_multi = fits.getdata(os.path.join(dir_multi, 'matrix_numerical', matrix_name))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot both matrices\n",
+    "plt.figure(figsize=(18, 9))\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.imshow(mat_stand)#, norm=LogNorm())\n",
+    "plt.colorbar()\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.imshow(mat_multi)#, norm=LogNorm())\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot their difference\n",
+    "print(np.sum(mat_stand - mat_multi))\n",
+    "plt.imshow(mat_stand - mat_multi, norm=LogNorm())\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Jupyter Notebooks/LUVOIR/18_comparison_matrices_multiprocessed.ipynb
+++ b/Jupyter Notebooks/LUVOIR/18_comparison_matrices_multiprocessed.ipynb
@@ -37,7 +37,7 @@
    "source": [
     "# Define directories\n",
     "dir_standard = '2020-07-25T17-51-31_luvoir-small'\n",
-    "dir_multi = '2020-07-27T15-29-09_luvoir-small'\n",
+    "dir_multi = '2020-07-27T20-00-29_luvoir-small'\n",
     "\n",
     "# Define matrix name\n",
     "matrix_name = 'PASTISmatrix_num_piston_Noll1.fits'"
@@ -74,8 +74,8 @@
    "outputs": [],
    "source": [
     "# Pick segment pair\n",
-    "seg1 = 1\n",
-    "seg2 = 10\n",
+    "seg1 = 46\n",
+    "seg2 = 78\n",
     "\n",
     "# Read PSFs\n",
     "psf_name_multi = f'psf_piston_Noll1_segs_{seg1}-{seg2}.fits'\n",
@@ -190,8 +190,8 @@
    "outputs": [],
    "source": [
     "# Load both matrices\n",
-    "mat_stand = fits.getdata(os.path.join(dir_standard, 'matrix_numerical', matrix_name))\n",
-    "mat_multi = fits.getdata(os.path.join(dir_multi, 'matrix_numerical', matrix_name))"
+    "mat_stand = fits.getdata(os.path.join(datadir, dir_standard, 'matrix_numerical', matrix_name))\n",
+    "mat_multi = fits.getdata(os.path.join(datadir, dir_multi, 'matrix_numerical', matrix_name))"
    ]
   },
   {
@@ -218,7 +218,7 @@
    "source": [
     "# Plot their difference\n",
     "print(np.sum(mat_stand - mat_multi))\n",
-    "plt.imshow(mat_stand - mat_multi, norm=LogNorm())\n",
+    "plt.imshow(np.log10(mat_stand - mat_multi))\n",
     "plt.colorbar()"
    ]
   },

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ local_data_path = /Users/<user-name>/<path-to-data>
 $ python run_cases.py
 ```
 **This will run for a couple of hours** as the first thing that is generated is the PASTIS matrix. On a 13-in MacBook 
-Pro 2020, the matrix gets calculated in about 160min, and the analysis runs in about 15 minutes.
+Pro 2020, the matrix gets calculated in about 80min, and the analysis runs in about 15 minutes.
 When it is done, you can inspect your results and log files in the path you specified under `local_data_path` in the section `[local]`
 of your `config_local.ini`!
 

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -543,7 +543,5 @@ if __name__ == '__main__':
         #num_matrix_jwst()
 
         coro_design = CONFIG_INI.get('LUVOIR', 'coronagraph_size')
-        num_matrix_luvoir(design=coro_design)
-
-        num_matrix_luvoir(design='small')
-        # num_matrix_luvoir_multiprocess(design='small')
+        #num_matrix_luvoir(design=coro_design)
+        num_matrix_luvoir_multiprocess(design=coro_design)

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -510,7 +510,7 @@ def num_matrix_luvoir_multiprocess(design, savepsfs=False, saveopds=True):
     results = mypool.map(luvoir_matrix_pair, product(np.arange(nb_seg), np.arange(nb_seg)))
     t_stop = time.time()
 
-    log.info("\nMultiprocess calculation complete in {:.1f} s".format(t_stop-t_start))
+    log.info(f"Multiprocess calculation complete in {t_stop-t_start}sec = {(t_stop-t_start)/60}min")
 
     # Unscramble results
     all_contrasts = np.zeros_like(matrix_direct)

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -11,11 +11,13 @@ This module contains functions that construct the matrix M for PASTIS *NUMERICAL
 import os
 import time
 import functools
+from itertools import product
 from shutil import copy
 from astropy.io import fits
 import astropy.units as u
 import logging
 import matplotlib.pyplot as plt
+import multiprocessing
 import numpy as np
 import hcipy as hc
 
@@ -392,8 +394,6 @@ def num_matrix_luvoir_multiprocess(design):
     Multiprocessed version of num_matrix_luvoir(). Implementation adapted from
     hicat.scripts.stroke_minimization.calculate_jacobian
     """
-    import multiprocessing
-    from itertools import product
 
     # Keep track of time
     start_time = time.time()   # runtime is currently around 150 minutes

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -260,17 +260,12 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
     optics_input = CONFIG_INI.get('LUVOIR', 'optics_path')
     luvoir = LuvoirAPLC(optics_input, design, sampling)
 
-    ### Dark hole mask
-    dh_outer = hc.circular_aperture(2 * luvoir.apod_dict[design]['owa'] * luvoir.lam_over_d)(luvoir.focal_det)
-    dh_inner = hc.circular_aperture(2 * luvoir.apod_dict[design]['iwa'] * luvoir.lam_over_d)(luvoir.focal_det)
-    dh_mask = (dh_outer - dh_inner).astype('bool')
-
     ### Reference images for contrast normalization and coronagraph floor
     unaberrated_coro_psf, ref = luvoir.calc_psf(ref=True, display_intermediate=False, return_intermediate=False)
     norm = np.max(ref)
 
-    dh_intensity = (unaberrated_coro_psf / norm) * dh_mask
-    contrast_floor = np.mean(dh_intensity[np.where(dh_mask != 0)])
+    dh_intensity = (unaberrated_coro_psf / norm) * luvoir.dh_mask
+    contrast_floor = np.mean(dh_intensity[np.where(luvoir.dh_mask != 0)])
     log.info(f'contrast floor: {contrast_floor}')
 
     ### Generating the PASTIS matrix and a list for all contrasts
@@ -311,8 +306,8 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
                 plt.savefig(os.path.join(resDir, 'OTE_images', opd_name + '.pdf'))
 
             log.info('Calculating mean contrast in dark hole')
-            dh_intensity = psf * dh_mask
-            contrast = np.mean(dh_intensity[np.where(dh_mask != 0)])
+            dh_intensity = psf * luvoir.dh_mask
+            contrast = np.mean(dh_intensity[np.where(luvoir.dh_mask != 0)])
             log.info(f'contrast: {float(contrast)}')    # contrast is a Field, here casting to normal float
             all_contrasts.append(contrast)
 

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -297,7 +297,7 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
                 filename_psf = 'psf_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(i+1) + '-' + str(j+1)
                 hc.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'))
 
-            # Save OPD images for testing (are these actually surface images, not OPD?)
+            # Save OPD images for testing
             if saveopds:
                 opd_name = 'opd_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(
                     i + 1) + '-' + str(j + 1)
@@ -352,7 +352,23 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
     return overall_dir
 
 
-def _luvoir_matrix_one_pair(optics_input, design, sampling, norm, dh_mask, wfe_aber, zern_mode, resDir, segment_pair):
+def _luvoir_matrix_one_pair(optics_input, design, sampling, norm, dh_mask, wfe_aber, zern_mode, resDir, savepsfs, saveopds, segment_pair):
+    """
+    Function to calculate LVUOIR-A mean contrast of one aberrated segment pair; for num_matrix_luvoir_multiprocess().
+    :param optics_input: str, path to LUVOIR-A optics input files
+    :param design: str, what coronagraph LUVOIR-A design to use - 'small', 'medium' or 'large'
+    :param sampling: float, PSF sampling factor in pixels per lambda/D
+    :param norm: float, direct PSF normalization factor (peak pixel of direct PSF)
+    :param dh_mask: hcipy.Field, DH mask (usually luvoir.dh_mask)
+    :param wfe_aber: calibration aberration per segment in nm
+    :param zern_mode: Zernike mode object, local Zernike aberration
+    :param resDir: str, directory for matrix calculations
+    :param savepsfs: bool, if True, all PSFs will be saved to disk individually, as fits files
+    :param saveopds: bool, if True, all pupil surface maps of aberrated segment pairs will be saved to disk as PDF
+    :param segment_pair: tuple, pair of segments to aberrate. If same segment gets passed in both tuple entries, the
+                         segment will be aberrated only once.
+    :return: contrast as float, and segment pair as tuple
+    """
 
     # Instantiate LUVOIR object
     luv = LuvoirAPLC(optics_input, design, sampling)

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -544,3 +544,6 @@ if __name__ == '__main__':
 
         coro_design = CONFIG_INI.get('LUVOIR', 'coronagraph_size')
         num_matrix_luvoir(design=coro_design)
+
+        num_matrix_luvoir(design='small')
+        # num_matrix_luvoir_multiprocess(design='small')

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -486,13 +486,15 @@ def num_matrix_luvoir_multiprocess(design, savepsfs=False, saveopds=True):
     # to account for hyperthreading, however empirical testing on telserv3 shows that
     # it is slightly more performant on telserv3 to use all logical cores
     num_cpu = multiprocessing.cpu_count()
-    try:
-        import mkl
-        num_core_per_process = mkl.get_max_threads()
-    except ImportError:
-        # typically this is 4, so use that as default
-        log.info("Couldn't import MKL; guessing default value of 4 cores per process")
-        num_core_per_process = 4
+    # try:
+    #     import mkl
+    #     num_core_per_process = mkl.get_max_threads()
+    # except ImportError:
+    #     # typically this is 4, so use that as default
+    #     log.info("Couldn't import MKL; guessing default value of 4 cores per process")
+    #     num_core_per_process = 4
+
+    num_core_per_process = 1   # NOTE: this was changed by Scott Will in HiCAT and makes more sense, somehow
     num_processes = int(num_cpu // num_core_per_process)
     log.info("Multiprocess PASTIS matrix for LUVOIR will use {} processes (with {} threads per process)".format(num_processes, num_core_per_process))
 

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -408,7 +408,7 @@ def _luvoir_matrix_one_pair(optics_input, design, sampling, norm, dh_mask, wfe_a
     return float(contrast), segment_pair
 
 
-def num_matrix_luvoir_multiprocess(design, savepsfs=False, saveopds=True):
+def num_matrix_luvoir_multiprocess(design, savepsfs=True, saveopds=True):
     """
     Generate a numerical PASTIS matrix for a LUVOIR A coronagraph.
 

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -354,6 +354,189 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
     return overall_dir
 
 
+def _luvoir_matrix_one_pair(optics_input, design, sampling, norm, dh_mask, nm_aber, zern_mode, resDir, segment_pair):
+
+    # Instantiate LUVOIR object
+    luv = LuvoirAPLC(optics_input, design, sampling)
+
+    print('\nPAIR: {}-{}'.format(segment_pair[0]+1, segment_pair[1]+1))
+
+    # Put aberration on correct segments. If i=j, apply only once!
+    luv.flatten()
+    luv.set_segment(segment_pair[0]+1, nm_aber / 2, 0, 0)
+    if segment_pair[0] != segment_pair[1]:
+        luv.set_segment(segment_pair[1]+1, nm_aber / 2, 0, 0)
+
+    print('Calculating coro image...')
+    image, inter = luv.calc_psf(ref=False, display_intermediate=False, return_intermediate='intensity')
+    # Normalize PSF by reference image
+    psf = image / norm
+
+    # Save PSF image to disk
+    filename_psf = 'psf_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(
+        segment_pair[0]+1) + '-' + str(segment_pair[1]+1)
+    hc.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'))
+
+    print('Calculating mean contrast in dark hole')
+    dh_intensity = psf * dh_mask
+    contrast = np.mean(dh_intensity[np.where(dh_mask != 0)])
+    print('contrast: {}'.format(float(contrast)))    # contrast is a Field, here casting to normal float
+
+    return float(contrast), segment_pair, inter['seg_mirror'], psf
+
+
+def num_matrix_luvoir_multiprocess(design):
+    """
+    Generate a numerical PASTIS matrix for a LUVOIR A coronagraph.
+
+    Multiprocessed version of num_matrix_luvoir(). Implementation adapted from
+    hicat.scripts.stroke_minimization.calculate_jacobian
+    """
+    import multiprocessing
+    from itertools import product
+
+    # Keep track of time
+    start_time = time.time()   # runtime is currently around 150 minutes
+    print('Building numerical matrix for LUVOIR with multiprocessing\n')
+
+    # Figure out how many processes is optimal and create a Pool.
+    # Assume we're the only one on the machine so we can hog all the resources.
+    # We expect numpy to use multithreaded math via the Intel MKL library, so
+    # we check how many threads MKL will use, and create enough processes so
+    # as to use 100% of the CPU cores.
+    # You might think we should divide number of cores by 2 to get physical cores
+    # to account for hyperthreading, however empirical testing on telserv3 shows that
+    # it is slightly more performant on telserv3 to use all logical cores
+    num_cpu = multiprocessing.cpu_count()
+    try:
+        import mkl
+        num_core_per_process = mkl.get_max_threads()
+    except ImportError:
+        # typically this is 4, so use that as default
+        print("Couldn't import MKL; guessing default value of 4 cores per process")
+        num_core_per_process = 4
+    num_processes = int(num_cpu // num_core_per_process)
+    print("Multiprocess PASTIS matrix for LUVOIR will use {} processes (with {} threads per process)".format(num_processes, num_core_per_process))
+
+    ### Parameters
+
+    # System parameters
+    os.makedirs(os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'active'), exist_ok=True)
+    resDir = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'active', 'matrix_numerical')
+    zern_number = CONFIG_INI.getint('calibration', 'zernike')
+    zern_mode = util.ZernikeMode(zern_number)                       # Create Zernike mode object for easier handling
+
+    # General telescope parameters
+    nb_seg = CONFIG_INI.getint('LUVOIR', 'nb_subapertures')
+    wvln = CONFIG_INI.getfloat('LUVOIR', 'lambda') * 1e-9  # m
+    diam = CONFIG_INI.getfloat('LUVOIR', 'diameter')  # m
+    nm_aber = CONFIG_INI.getfloat('calibration', 'single_aberration') * 1e-9   # m
+
+    # Image system parameters
+    im_lamD = CONFIG_INI.getfloat('numerical', 'im_size_lamD_hcipy')  # image size in lambda/D
+    sampling = CONFIG_INI.getfloat('numerical', 'sampling')
+
+    # Print some of the defined parameters
+    print('LUVOIR apodizer design: {}'.format(design))
+    print()
+    print('Wavelength: {} m'.format(wvln))
+    print('Telescope diameter: {} m'.format(diam))
+    print('Number of segments: {}'.format(nb_seg))
+    print()
+    print('Image size: {} lambda/D'.format(im_lamD))
+    print('Sampling: {} px per lambda/D'.format(sampling))
+
+    # Create necessary directories if they don't exist yet
+    os.makedirs(resDir, exist_ok=True)
+    os.makedirs(os.path.join(resDir, 'OTE_images'), exist_ok=True)
+    os.makedirs(os.path.join(resDir, 'psfs'), exist_ok=True)
+
+    # Instantiate Luvoir telescope with chosen apodizer design
+    optics_input = CONFIG_INI.get('LUVOIR', 'optics_path')
+    luvoir = LuvoirAPLC(optics_input, design, sampling)
+
+    # Create dark hole mask
+    dh_outer = hc.circular_aperture(2 * luvoir.apod_dict[design]['owa'] * luvoir.lam_over_d)(luvoir.focal_det)
+    dh_inner = hc.circular_aperture(2 * luvoir.apod_dict[design]['iwa'] * luvoir.lam_over_d)(luvoir.focal_det)
+    dh_mask = (dh_outer - dh_inner).astype('bool')
+
+    # Calculate reference images for contrast normalization and coronagraph floor
+    unaberrated_coro_psf, ref = luvoir.calc_psf(ref=True, display_intermediate=False, return_intermediate=False)
+    norm = np.max(ref)
+
+    dh_intensity = (unaberrated_coro_psf / norm) * dh_mask
+    contrast_floor = np.mean(dh_intensity[np.where(dh_mask != 0)])
+    print('contrast floor: {}'.format(contrast_floor))
+
+    print('nm_aber: {} m'.format(nm_aber))
+    matrix_direct = np.zeros([nb_seg, nb_seg])  # Generate empty matrix
+
+    # Set up a function with all arguments fixed except for the last one, which is the segment pair tuple
+    luvoir_matrix_pair = functools.partial(_luvoir_matrix_one_pair, optics_input, design, sampling, norm, dh_mask,
+                                           nm_aber, zern_mode, resDir)
+
+    # Iterate over all segment pairs via a multiprocess pool
+    mypool = multiprocessing.Pool(num_processes)
+    t_start = time.time()
+    results = mypool.map(luvoir_matrix_pair, product(np.arange(nb_seg), np.arange(nb_seg)))
+    t_stop = time.time()
+
+    print("\nMultiprocess calculation complete in {:.1f} s".format(t_stop-t_start))
+
+    # Unscramble results
+    #all_psfs = np.zeros(nb_seg, nb_seg, pixels?)
+    all_contrasts = np.zeros_like(matrix_direct)
+    for i, res in enumerate(results):
+
+        # Fill according entry in the matrix and subtract baseline contrast
+        all_contrasts[results[i][1][0], results[i][1][1]] = results[i][0]
+        matrix_direct = all_contrasts - contrast_floor
+
+        # Plot all OPDs (or are these surfaces?)
+        opd_name = 'opd_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(
+            results[i][1][0]+1) + '-' + str(results[i][1][1]+1)
+        plt.clf()
+        hc.imshow_field(results[i][2], grid=luvoir.aperture.grid, mask=luvoir.aperture, cmap='RdBu')
+        plt.savefig(os.path.join(resDir, 'OTE_images', opd_name + '.pdf'))
+
+        # Collect all PSFs   #TODO: make this actually work, so we can save them as a cube later outside this loop
+        #all_psfs[results[i][1][0], results[i][1][1]] = results[i][3]
+
+    mypool.close()
+
+    # Save the PSF image *cube* as well (as opposed to each one individually)
+    #hc.write_fits(all_psfs, os.path.join(resDir, 'psfs', 'psf_cube' + '.fits'),)
+    all_contrasts = all_contrasts.ravel()
+    np.savetxt(os.path.join(resDir, 'contrasts.txt'), all_contrasts, fmt='%e')
+
+    # Filling the off-axis elements
+    print('\nCalculating off-axis matrix elements...')
+    matrix_two_N = np.copy(matrix_direct)      # This is just an intermediary copy so that I don't mix things up.
+    matrix_pastis = np.copy(matrix_direct)     # This will be the final PASTIS matrix.
+
+    for i in range(nb_seg):
+        for j in range(nb_seg):
+            if i != j:
+                matrix_off_val = (matrix_two_N[i,j] - matrix_two_N[i,i] - matrix_two_N[j,j]) / 2.
+                matrix_pastis[i,j] = matrix_off_val
+                #print('Off-axis for i{}-j{}: {}'.format(i+1, j+1, matrix_off_val))
+
+    # Normalize matrix for the input aberration - the whole code is set up to be normalized to 1 nm, and even if
+    # the units entered are in m for the sake of HCIPy, everything else is assuming the baseline is 1nm, so the
+    # normalization can be taken out if we're working with exactly 1 nm for the aberration, even if entered in meters.
+    #matrix_pastis /= np.square(nm_aber)
+
+    # Save matrix to file
+    filename_matrix = 'PASTISmatrix_num_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index)
+    hc.write_fits(matrix_pastis, os.path.join(resDir, filename_matrix + '.fits'))
+    print('\nMatrix saved to:', os.path.join(resDir, filename_matrix + '.fits'))
+
+    # Tell us how long it took to finish.
+    end_time = time.time()
+    print('Runtime for matrix_building_numerical.py:', end_time - start_time, 'sec =', (end_time - start_time) / 60, 'min')
+    print('Data saved to {}'.format(resDir))
+
+
 if __name__ == '__main__':
 
         # Pick the function of the telescope you want to run


### PR DESCRIPTION
Cleaner copy of #22, see there for comments and notes.

Back at this after dusting it off:
- rebased on most recend dev (the version that's (almost) ready for a new release)
- adjusted the multiprocessed function to reflect the changes done in the main matrix function in the past 7 months:
  - implemented logging
  - saving out of configfile with data
  - updated output file names
  - renamed `wfe_aber`
  - convert all `print()`/`log.info()` parameters to either f strings or formatted strings
- save PSFs and WFE maps within the function across processes, so that they don't have to be held in memory
- add notebook that allows me to check matrices against each other
- call the intermediate result it the more obvious name `contrast_matrix`

I will hold off on merging into dev since I don't want to include this in the v2.0.0 release that goes with the paper, since I didn't have this when doing the analyses for the paper.
