### PR TITLE
Implement logging

### DIFF
--- a/pastis/aperture_definition.py
+++ b/pastis/aperture_definition.py
@@ -35,9 +35,12 @@ import os
 import time
 import numpy as np
 import astropy.units as u
+import logging
 
 import util_pastis as util
 from config import CONFIG_INI
+
+log = logging.getLogger()
 
 
 def make_aperture_nrp():
@@ -54,7 +57,7 @@ def make_aperture_nrp():
     im_size_pupil = CONFIG_INI.getint('numerical', 'tel_size_px')
     m_to_px = im_size_pupil/flat_diam      # for conversion from meters to pixels: 3 [m] = 3 * m_to_px [px]
 
-    print('Running aperture generation for {}\n'.format(telescope))
+    log.info('Running aperture generation for {}\n'.format(telescope))
 
     # If main subfolder "active" doesn't exist yet, create it.
     if not os.path.isdir(localDir):
@@ -65,7 +68,7 @@ def make_aperture_nrp():
         os.mkdir(outDir)
 
     #-# Get the coordinates of the central pixel of each segment and save aperture to disk
-    print('Getting segment centers')
+    log.info('Getting segment centers')
     seg_position = np.zeros((nb_seg, 2))
 
     if telescope == 'JWST':
@@ -108,7 +111,7 @@ def make_aperture_nrp():
     ap = 0
     rp = 0
 
-    print('Nulling redundant segment pairs')
+    log.info('Nulling redundant segment pairs')
     for i in range(longshape):
         for j in range(i):   # Since i starts at 0, the case with i=0 & j=0 never happens, we start at i=1 & j=0
                              # With this loop setup, in all cases we have i != k, which is the baseline between a
@@ -154,7 +157,7 @@ def make_aperture_nrp():
     NR_pairs_nb = np.count_nonzero(distance_list)   # Counting how many non-redundant (NR) pairs we have
     # Save for testing
     np.savetxt(os.path.join(outDir, 'NR_distance_list.txt'), NR_distance_list, fmt='%2.2f')
-    print('Number of non-redundant pairs: ' + str(NR_pairs_nb))
+    log.info(f'Number of non-redundant pairs: {NR_pairs_nb}')
 
     #-# Select non redundant vectors
     # NR_pairs_list is a [NRP number, seg1, seg2] vector to hold non-redundant vector information.
@@ -200,7 +203,7 @@ def make_aperture_nrp():
     matrix_long = Projection_Matrix_int.shape[0] * Projection_Matrix_int.shape[1]
     matrix_flat = np.reshape(Projection_Matrix_int, (matrix_long, 3))
 
-    print('Creating projection matrix')
+    log.info('Creating projection matrix')
     for i in range(np.square(nb_seg)):
         # Compare segment pair in i against all available NRPs.
         # Where it matches, record the NRP number in the matrix entry that corresponds to segments in i.
@@ -232,11 +235,11 @@ def make_aperture_nrp():
     util.write_fits(NR_pairs_list, os.path.join(outDir, 'NR_pairs_list_int.fits'), header=None, metadata=None)
     util.write_fits(Projection_Matrix, os.path.join(outDir, 'Projection_Matrix.fits'), header=None, metadata=None)
 
-    print('All outputs saved to {}'.format(outDir))
+    log.info('All outputs saved to {}'.format(outDir))
 
     # Tell us how long it took to finish.
     end_time = time.time()
-    print('Runtime for aperture_definition.py:', end_time - start_time, 'sec =', (end_time - start_time)/60, 'min')
+    log.info(f'Runtime for aperture_definition.py: {end_time - start_time}sec = {(end_time - start_time)/60}min')
 
 
 if __name__ == '__main__':

--- a/pastis/contrast_calculation_simple.py
+++ b/pastis/contrast_calculation_simple.py
@@ -13,6 +13,7 @@ import time
 import numpy as np
 from astropy.io import fits
 import astropy.units as u
+import logging
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 import hcipy as hc
@@ -21,6 +22,8 @@ from config import CONFIG_INI
 import util_pastis as util
 import image_pastis as impastis
 from e2e_simulators.luvoir_imaging import LuvoirAPLC
+
+log = logging.getLogger()
 
 
 @u.quantity_input(rms=u.nm)
@@ -36,7 +39,7 @@ def contrast_jwst_ana_num(matdir, matrix_mode="analytical", rms=1. * u.nm, im_pa
     """
     from e2e_simulators import webbpsf_imaging as webbim
 
-    print("THIS ONLY WORKS FOR PISTON FOR NOW")
+    log.warning("THIS ONLY WORKS FOR PISTON FOR NOW")
 
     # Keep track of time
     start_time = time.time()   # runtime currently is around 12 min
@@ -68,14 +71,14 @@ def contrast_jwst_ana_num(matdir, matrix_mode="analytical", rms=1. * u.nm, im_pa
 
     # Create random aberration coefficients
     aber = np.random.random([nb_seg])   # piston values in input units
-    #print('PISTON ABERRATIONS:', aber)
+    #log.info(f'PISTON ABERRATIONS: {aber}')
 
     # Normalize to the RMS value I want
     rms_init = util.rms(aber)
     aber *= rms.value / rms_init
     calc_rms = util.rms(aber) * u.nm
     aber *= u.nm    # making sure the aberration has the correct units
-    print("Calculated RMS:", calc_rms)
+    log.info(f"Calculated RMS: {calc_rms}")
 
     # Remove global piston
     aber -= np.mean(aber)
@@ -85,13 +88,13 @@ def contrast_jwst_ana_num(matdir, matrix_mode="analytical", rms=1. * u.nm, im_pa
     Aber_WSS[:,0] = aber.to(u.m).value   # index "0" works because we're using piston currently; convert to meters
 
     ### BASELINE PSF - NO ABERRATIONS, NO CORONAGRAPH
-    print('Generating baseline PSF from E2E - no coronagraph, no aberrations')
+    log.info('Generating baseline PSF from E2E - no coronagraph, no aberrations')
     psf_perfect = webbim.nircam_nocoro(filter, np.zeros_like(Aber_WSS))
     normp = np.max(psf_perfect)
     psf_perfect = psf_perfect / normp
 
     ### WEBBPSF
-    print('Generating E2E coro contrast')
+    log.info('Generating E2E coro contrast')
     start_webb = time.time()
     # Set up NIRCam and coronagraph, get PSF
     psf_webbpsf = webbim.nircam_coro(filter, fpm, lyot_stop, Aber_WSS)
@@ -112,7 +115,7 @@ def contrast_jwst_ana_num(matdir, matrix_mode="analytical", rms=1. * u.nm, im_pa
     ### IMAGE PASTIS
     contrast_am = np.nan
     if im_pastis:
-        print('Generating contrast from image-PASTIS')
+        log.info('Generating contrast from image-PASTIS')
         start_impastis = time.time()
         # Create calibrated image from analytical model
         psf_am, full_psf = impastis.analytical_model(zern_number, aber, cali=True)
@@ -121,7 +124,7 @@ def contrast_jwst_ana_num(matdir, matrix_mode="analytical", rms=1. * u.nm, im_pa
         end_impastis = time.time()
 
     ### MATRIX PASTIS
-    print('Generating contrast from matrix-PASTIS')
+    log.info('Generating contrast from matrix-PASTIS')
     start_matrixpastis = time.time()
     # Get mean contrast from matrix PASTIS
     contrast_matrix = util.pastis_contrast(aber, matrix_pastis) + coro_floor   # calculating contrast with PASTIS matrix model
@@ -132,21 +135,21 @@ def contrast_jwst_ana_num(matdir, matrix_mode="analytical", rms=1. * u.nm, im_pa
         ratio = contrast_am / contrast_matrix
 
     # Outputs
-    print('\n--- CONTRASTS: ---')
-    print('Mean contrast from E2E:', contrast_webbpsf)
-    print('Mean contrast with image PASTIS:', contrast_am)
-    print('Contrast from matrix PASTIS:', contrast_matrix)
-    print('Ratio image PASTIS / matrix PASTIS:', ratio)
+    log.info('\n--- CONTRASTS: ---')
+    log.info(f'Mean contrast from E2E: {contrast_webbpsf}')
+    log.info(f'Mean contrast with image PASTIS: {contrast_am}')
+    log.info(f'Contrast from matrix PASTIS: {contrast_matrix}')
+    log.info(f'Ratio image PASTIS / matrix PASTIS: {ratio}')
 
-    print('\n--- RUNTIMES: ---')
-    print('E2E: ', end_webb-start_webb, 'sec =', (end_webb-start_webb)/60, 'min')
+    log.info('\n--- RUNTIMES: ---')
+    log.info(f'E2E: {end_webb-start_webb}sec = {(end_webb-start_webb)/60}min')
     if im_pastis:
-        print('Image PASTIS: ', end_impastis-start_impastis, 'sec =', (end_impastis-start_impastis)/60, 'min')
-    print('Matrix PASTIS: ', end_matrixpastis-start_matrixpastis, 'sec =', (end_matrixpastis-start_matrixpastis)/60, 'min')
+        log.info(f'Image PASTIS: {end_impastis-start_impastis}sec = {(end_impastis-start_impastis)/60}min')
+    log.info(f'Matrix PASTIS: {end_matrixpastis-start_matrixpastis}sec = {(end_matrixpastis-start_matrixpastis)/60}min')
 
     end_time = time.time()
     runtime = end_time - start_time
-    print(f'Runtime for contrast_calculation_simple.py: {runtime} sec = {runtime/60} min')
+    log.info(f'Runtime for contrast_calculation_simple.py: {runtime} sec = {runtime/60} min')
 
     # Save the PSFs
     if im_pastis:
@@ -201,20 +204,20 @@ def contrast_hicat_num(matrix_dir, matrix_mode='hicat', rms=1*u.nm):
 
     # Create random aberration coefficients
     aber = np.random.random([nb_seg])   # piston values in input units
-    print('PISTON ABERRATIONS:', aber)
+    log.info(f'PISTON ABERRATIONS: {aber}')
 
     # Normalize to the RMS value I want
     rms_init = util.rms(aber)
     aber *= rms.value / rms_init
     calc_rms = util.rms(aber) * u.nm
     aber *= u.nm    # making sure the aberration has the correct units
-    print("Calculated RMS:", calc_rms)
+    log.info(f"Calculated RMS: {calc_rms}")
 
     # Remove global piston
     aber -= np.mean(aber)
 
     ### BASELINE PSF - NO ABERRATIONS, NO CORONAGRAPH
-    print('Generating baseline PSF from E2E - no coronagraph, no aberrations')
+    log.info('Generating baseline PSF from E2E - no coronagraph, no aberrations')
     hc = hicat.simulators.hicat_sim.HICAT_Sim()
     hc.iris_ao = 'iris_ao'
     hc.apodizer = 'cnt1_apodizer'
@@ -237,7 +240,7 @@ def contrast_hicat_num(matrix_dir, matrix_mode='hicat', rms=1*u.nm):
     psf_coro = psf_coro[0].data / normp
 
 
-    print('Calculating E2E contrast...')
+    log.info('Calculating E2E contrast...')
     # Put aberration on Iris AO
     for nseg in range(nb_seg):
         hc.iris_dm.set_actuator(nseg+1, aber[nseg], 0, 0)
@@ -258,24 +261,24 @@ def contrast_hicat_num(matrix_dir, matrix_mode='hicat', rms=1*u.nm):
     coro_floor = np.mean(baseline_dh[np.where(baseline_dh != 0)])
 
     ## MATRIX PASTIS
-    print('Generating contrast from matrix-PASTIS')
+    log.info('Generating contrast from matrix-PASTIS')
     start_matrixpastis = time.time()
     # Get mean contrast from matrix PASTIS
     contrast_matrix = util.pastis_contrast(aber, matrix_pastis) + coro_floor   # calculating contrast with PASTIS matrix model
     end_matrixpastis = time.time()
 
     ## Outputs
-    print('\n--- CONTRASTS: ---')
-    print('Mean contrast from E2E:', contrast_hicat)
-    print('Contrast from matrix PASTIS:', contrast_matrix)
+    log.info('\n--- CONTRASTS: ---')
+    log.info(f'Mean contrast from E2E: {contrast_hicat}')
+    log.info(f'Contrast from matrix PASTIS: {contrast_matrix}')
 
-    print('\n--- RUNTIMES: ---')
-    print('E2E: ', end_e2e-start_e2e, 'sec =', (end_e2e-start_e2e)/60, 'min')
-    print('Matrix PASTIS: ', end_matrixpastis-start_matrixpastis, 'sec =', (end_matrixpastis-start_matrixpastis)/60, 'min')
+    log.info('\n--- RUNTIMES: ---')
+    log.info(f'E2E: {end_e2e-start_e2e}sec = {(end_e2e-start_e2e)/60}min')
+    log.info(f'Matrix PASTIS: {end_matrixpastis-start_matrixpastis}sec = {(end_matrixpastis-start_matrixpastis)/60}min')
 
     end_time = time.time()
     runtime = end_time - start_time
-    print(f'Runtime for contrast_calculation_simple.py: {runtime} sec = {runtime/60} min')
+    log.info(f'Runtime for contrast_calculation_simple.py: {runtime} sec = {runtime/60} min')
 
     return contrast_hicat, contrast_matrix
 
@@ -301,14 +304,14 @@ def contrast_luvoir_num(apodizer_choice, matrix_dir, rms=1*u.nm):
 
     # Create random aberration coefficients
     aber = np.random.random([nb_seg])   # piston values in input units
-    print('PISTON ABERRATIONS:', aber)
+    log.info(f'PISTON ABERRATIONS: {aber}')
 
     # Normalize to the WFE RMS value I want
     rms_init = util.rms(aber)
     aber *= rms.value / rms_init
     calc_rms = util.rms(aber) * u.nm
     aber *= u.nm    # making sure the aberration has the correct units
-    print("Calculated WFE RMS:", calc_rms)
+    log.info(f"Calculated WFE RMS: {calc_rms}")
 
     # Remove global piston
     aber -= np.mean(aber)
@@ -325,13 +328,13 @@ def contrast_luvoir_num(apodizer_choice, matrix_dir, rms=1*u.nm):
     ### BASELINE PSF - NO ABERRATIONS, NO CORONAGRAPH
     # and coro PSF without aberrations
     start_e2e = time.time()
-    print('Generating baseline PSF from E2E - no coronagraph, no aberrations')
-    print('Also generating coro PSF without aberrations')
+    log.info('Generating baseline PSF from E2E - no coronagraph, no aberrations')
+    log.info('Also generating coro PSF without aberrations')
     psf_perfect, ref = luvoir.calc_psf(ref=True)
     normp = np.max(ref)
     psf_coro = psf_perfect / normp
 
-    print('Calculating E2E contrast...')
+    log.info('Calculating E2E contrast...')
     # Put aberrations on segmented mirror
     for nseg in range(nb_seg):
         luvoir.set_segment(nseg+1, aber[nseg].to(u.m).value/2, 0, 0)
@@ -353,27 +356,27 @@ def contrast_luvoir_num(apodizer_choice, matrix_dir, rms=1*u.nm):
     # Calculate coronagraph contrast floor
     baseline_dh = psf_coro * dh_mask
     coro_floor = np.mean(baseline_dh[np.where(baseline_dh != 0)])
-    print(f'Baseline contrast: {coro_floor}')
+    log.info(f'Baseline contrast: {coro_floor}')
 
     ## MATRIX PASTIS
-    print('Generating contrast from matrix-PASTIS')
+    log.info('Generating contrast from matrix-PASTIS')
     start_matrixpastis = time.time()
     # Get mean contrast from matrix PASTIS
     contrast_matrix = util.pastis_contrast(aber, matrix_pastis) + coro_floor   # calculating contrast with PASTIS matrix model
     end_matrixpastis = time.time()
 
     ## Outputs
-    print('\n--- CONTRASTS: ---')
-    print('Mean contrast from E2E:', contrast_luvoir)
-    print('Contrast from matrix PASTIS:', contrast_matrix)
+    log.info('\n--- CONTRASTS: ---')
+    log.info(f'Mean contrast from E2E: {contrast_luvoir}')
+    log.info(f'Contrast from matrix PASTIS: {contrast_matrix}')
 
-    print('\n--- RUNTIMES: ---')
-    print('E2E: ', end_e2e-start_e2e, 'sec =', (end_e2e-start_e2e)/60, 'min')
-    print('Matrix PASTIS: ', end_matrixpastis-start_matrixpastis, 'sec =', (end_matrixpastis-start_matrixpastis)/60, 'min')
+    log.info('\n--- RUNTIMES: ---')
+    log.info(f'E2E: {end_e2e-start_e2e}sec = {(end_e2e-start_e2e)/60}min')
+    log.info(f'Matrix PASTIS: {end_matrixpastis-start_matrixpastis}sec = {(end_matrixpastis-start_matrixpastis)/60}min')
 
     end_time = time.time()
     runtime = end_time - start_time
-    print(f'Runtime for contrast_calculation_simple.py: {runtime} sec = {runtime/60} min')
+    log.info(f'Runtime for contrast_calculation_simple.py: {runtime} sec = {runtime/60} min')
 
     return contrast_luvoir, contrast_matrix
 

--- a/pastis/e2e_simulators/atlast_imaging.py
+++ b/pastis/e2e_simulators/atlast_imaging.py
@@ -5,12 +5,14 @@ import os
 import numpy as np
 import matplotlib.pyplot as plt
 import astropy.units as u
+import logging
 import hcipy
 import poppy
 
 from config import CONFIG_INI
 import util_pastis as util
 
+log = logging.getLogger()
 
 # Configfile imports
 which_tel = CONFIG_INI.get('telescope', 'name')
@@ -268,8 +270,8 @@ def seg_mirror_test():
     # --------------------------------- #
     #aber_rad = 6.2
     aber_array = np.linspace(0, 2*np.pi, 50, True)
-    print('Aber in rad: \n{}'.format(aber_array))
-    print('Aber in m: \n{}'.format(util.aber_to_opd(aber_array, wvln)))
+    log.info('Aber in rad: \n{}'.format(aber_array))
+    log.info('Aber in m: \n{}'.format(util.aber_to_opd(aber_array, wvln)))
     # --------------------------------- #
 
     ### HCIPy SM

--- a/pastis/e2e_simulators/webbpsf_imaging.py
+++ b/pastis/e2e_simulators/webbpsf_imaging.py
@@ -6,11 +6,14 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 import astropy.units as u
+import logging
 import poppy
 import webbpsf
 
 from config import CONFIG_INI
 import util_pastis as util
+
+log = logging.getLogger()
 
 # Setting to ensure that PyCharm finds the webbpsf-data folder. If you don't know where it is, find it with:
 # webbpsf.utils.get_webbpsf_data_path()
@@ -36,7 +39,7 @@ def get_jwst_coords(outDir):
     #-# Generate the pupil with segments and spiders
 
     # Use poppy to create JWST aperture without spiders
-    print('Creating and saving aperture')
+    log.info('Creating and saving aperture')
     jwst_pup = poppy.MultiHexagonAperture(rings=2, flattoflat=flat_to_flat)   # Create JWST pupil without spiders
     jwst_pup.display(colorbar=False)   # Show pupil (will be saved to file)
     plt.title('JWST telescope pupil')

--- a/pastis/hockeystick_contrast_curve.py
+++ b/pastis/hockeystick_contrast_curve.py
@@ -12,14 +12,17 @@ HiCAT and LUVOIR only have an E2E vs numerical PASTIS comparison (1 + 3).
 
 import os
 import time
+import astropy.units as u
+import logging
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import astropy.units as u
-import matplotlib.pyplot as plt
 
 from config import CONFIG_INI
 import contrast_calculation_simple as consim
 import plotting as ppl
+
+log = logging.getLogger()
 
 
 def hockeystick_jwst(range_points=3, no_realizations=3, matrix_mode='analytical'):
@@ -58,8 +61,8 @@ def hockeystick_jwst(range_points=3, no_realizations=3, matrix_mode='analytical'
     am_contrasts = []         # contrasts from image PASTIS
     matrix_contrasts = []     # contrasts from matrix PASTIS
 
-    print("RMS range: {}".format(rms_range, fmt="%e"))
-    print(f"Random realizations: {realiz}")
+    log.info("RMS range: {}".format(rms_range, fmt="%e"))
+    log.info(f"Random realizations: {realiz}")
 
     for i, rms in enumerate(rms_range):
 
@@ -70,11 +73,11 @@ def hockeystick_jwst(range_points=3, no_realizations=3, matrix_mode='analytical'
         matrix_rand = []
 
         for j in range(realiz):
-            print("\n#####################################")
-            print("CALCULATING CONTRAST FOR {:.4f}".format(rms))
-            print(f"RMS {i + 1}/{len(rms_range)}")
-            print(f"Random realization: {j+1}/{realiz}")
-            print(f"Total: {(i*realiz)+(j+1)}/{len(rms_range)*realiz}\n")
+            log.info("\n#####################################")
+            log.info("CALCULATING CONTRAST FOR {:.4f}".format(rms))
+            log.info(f"RMS {i + 1}/{len(rms_range)}")
+            log.info(f"Random realization: {j+1}/{realiz}")
+            log.info(f"Total: {(i*realiz)+(j+1)}/{len(rms_range)*realiz}\n")
 
             c_e2e, c_am, c_matrix = consim.contrast_jwst_ana_num(matdir=WORKDIRECTORY, matrix_mode=matrix_mode, rms=rms,
                                                                  im_pastis=True, plotting=True)
@@ -111,7 +114,7 @@ def hockeystick_jwst(range_points=3, no_realizations=3, matrix_mode='analytical'
 
     end_time = time.time()
     runtime = end_time - start_time
-    print(f'Runtime for pastis_vs_e2e_contrast_calc.py: {runtime} sec = {runtime/60} min')
+    log.info(f'Runtime for pastis_vs_e2e_contrast_calc.py: {runtime} sec = {runtime/60} min')
 
 
 def hockeystick_hicat(matrixdir, resultdir='', range_points=3, no_realizations=3):
@@ -143,8 +146,8 @@ def hockeystick_hicat(matrixdir, resultdir='', range_points=3, no_realizations=3
     e2e_contrasts = []        # contrasts from E2E sim
     matrix_contrasts = []     # contrasts from matrix PASTIS
 
-    print("RMS range: {}".format(rms_range, fmt="%e"))
-    print(f"Random realizations: {realiz}")
+    log.info("RMS range: {}".format(rms_range, fmt="%e"))
+    log.info(f"Random realizations: {realiz}")
 
     for i, rms in enumerate(rms_range):
 
@@ -154,11 +157,11 @@ def hockeystick_hicat(matrixdir, resultdir='', range_points=3, no_realizations=3
         matrix_rand = []
 
         for j in range(realiz):
-            print("\n#####################################")
-            print("CALCULATING CONTRAST FOR {:.4f}".format(rms))
-            print(f"RMS {i + 1}/{len(rms_range)}")
-            print(f"Random realization: {j+1}/{realiz}")
-            print(f"Total: {(i*realiz)+(j+1)}/{len(rms_range)*realiz}\n")
+            log.info("\n#####################################")
+            log.info("CALCULATING CONTRAST FOR {:.4f}".format(rms))
+            log.info(f"RMS {i + 1}/{len(rms_range)}")
+            log.info(f"Random realization: {j+1}/{realiz}")
+            log.info(f"Total: {(i*realiz)+(j+1)}/{len(rms_range)*realiz}\n")
 
             c_e2e, c_matrix = consim.contrast_hicat_num(matrix_dir=matrixdir, rms=rms,)
 
@@ -187,7 +190,7 @@ def hockeystick_hicat(matrixdir, resultdir='', range_points=3, no_realizations=3
 
     end_time = time.time()
     runtime = end_time - start_time
-    print(f'\nTotal runtime for pastis_vs_e2e_contrast_calc.py: {runtime} sec = {runtime/60} min')
+    log.info(f'\nTotal runtime for pastis_vs_e2e_contrast_calc.py: {runtime} sec = {runtime/60} min')
 
 
 def hockeystick_luvoir(apodizer_choice, matrixdir, resultdir='', range_points=3, no_realizations=3):
@@ -222,8 +225,8 @@ def hockeystick_luvoir(apodizer_choice, matrixdir, resultdir='', range_points=3,
     e2e_contrasts = []        # contrasts from E2E sim
     matrix_contrasts = []     # contrasts from matrix PASTIS
 
-    print("RMS range: {} nm".format(rms_range, fmt="%e"))
-    print(f"Random realizations: {no_realizations}")
+    log.info("RMS range: {} nm".format(rms_range, fmt="%e"))
+    log.info(f"Random realizations: {no_realizations}")
 
     for i, rms in enumerate(rms_range):
 
@@ -233,11 +236,11 @@ def hockeystick_luvoir(apodizer_choice, matrixdir, resultdir='', range_points=3,
         matrix_rand = []
 
         for j in range(no_realizations):
-            print("\n#####################################")
-            print("CALCULATING CONTRAST FOR {:.4f}".format(rms))
-            print(f"WFE RMS number {i + 1}/{len(rms_range)}")
-            print(f"Random realization: {j+1}/{no_realizations}")
-            print(f"Total: {(i*no_realizations)+(j+1)}/{len(rms_range)*no_realizations}\n")
+            log.info("\n#####################################")
+            log.info("CALCULATING CONTRAST FOR {:.4f}".format(rms))
+            log.info(f"WFE RMS number {i + 1}/{len(rms_range)}")
+            log.info(f"Random realization: {j+1}/{no_realizations}")
+            log.info(f"Total: {(i*no_realizations)+(j+1)}/{len(rms_range)*no_realizations}\n")
 
             c_e2e, c_matrix = consim.contrast_luvoir_num(apodizer_choice, matrix_dir=matrixdir, rms=rms)
 
@@ -262,7 +265,7 @@ def hockeystick_luvoir(apodizer_choice, matrixdir, resultdir='', range_points=3,
 
     end_time = time.time()
     runtime = end_time - start_time
-    print(f'\nTotal runtime for pastis_vs_e2e_contrast_calc.py: {runtime} sec = {runtime/60} min')
+    log.info(f'\nTotal runtime for pastis_vs_e2e_contrast_calc.py: {runtime} sec = {runtime/60} min')
 
 
 if __name__ == '__main__':

--- a/pastis/image_pastis.py
+++ b/pastis/image_pastis.py
@@ -11,6 +11,7 @@ from astropy.io import fits
 import astropy.units as u
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
+import logging
 import poppy.zernike as zern
 import poppy.matrixDFT as mft
 import poppy
@@ -18,6 +19,8 @@ import hcipy
 
 from config import CONFIG_INI
 import util_pastis as util
+
+log = logging.getLogger()
 
 
 @u.quantity_input(coef=u.nm)
@@ -262,12 +265,12 @@ if __name__ == '__main__':
     # Define the (Noll) zernike number
     zernike_pol = zern_number
 
-    print('coef: {}'.format(coef))
-    print('Aberration: {}'.format(nm_aber))
-    print('On segment: {}'.format(i+1))
-    print('Zernike (Noll): {}'.format(util.zernike_name(zern_number, framework='Noll')))
-    print('Zernike (WSS): {}'.format(util.zernike_name(wss_zern_nb, framework='WSS')))
-    print('Zernike number (Noll): {}'.format(zernike_pol))
+    log.info('coef: {}'.format(coef))
+    log.info('Aberration: {}'.format(nm_aber))
+    log.info('On segment: {}'.format(i+1))
+    log.info('Zernike (Noll): {}'.format(util.zernike_name(zern_number, framework='Noll')))
+    log.info('Zernike (WSS): {}'.format(util.zernike_name(wss_zern_nb, framework='WSS')))
+    log.info('Zernike number (Noll): {}'.format(zernike_pol))
 
     ### Run the analytical model without calibration
     dh_psf, int = analytical_model(zernike_pol, coef, cali=cali)

--- a/pastis/matrix_building_analytical.py
+++ b/pastis/matrix_building_analytical.py
@@ -9,17 +9,20 @@ import os
 import time
 import numpy as np
 import astropy.units as u
+import logging
 
 from config import CONFIG_INI
 import util_pastis as util
 import image_pastis as impastis
+
+log = logging.getLogger()
 
 
 def ana_matrix_jwst():
 
     # Keep track of time
     start_time = time.time()   # runtime is currently around 11 minutes
-    print('Building analytical matrix for JWST\n')
+    log.info('Building analytical matrix for JWST\n')
 
     # Parameters
     datadir = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'active')
@@ -43,7 +46,7 @@ def ana_matrix_jwst():
     for i in range(nb_seg):
         for j in range(nb_seg):
 
-            print('STEP: {}-{} / {}-{}'.format(i+1, j+1, nb_seg, nb_seg))
+            log.info('STEP: {}-{} / {}-{}'.format(i+1, j+1, nb_seg, nb_seg))
 
             # Putting aberration only on segments i and j
             tempA = np.zeros([nb_seg])
@@ -64,7 +67,7 @@ def ana_matrix_jwst():
 
             contrast = np.mean(temp_im_am[np.where(temp_im_am != 0)])
             matrix_direct[i,j] = contrast
-            print('contrast =', contrast)
+            log.info(f'contrast = {contrast}')
             all_contrasts.append(contrast)
 
     all_ims = np.array(all_ims)
@@ -80,7 +83,7 @@ def ana_matrix_jwst():
             if i != j:
                 matrix_off_val = (matrix_two_N[i, j] - matrix_two_N[i, i] - matrix_two_N[j, j]) / 2.
                 matrix_pastis[i,j] = matrix_off_val
-                print('Off-axis for i{}-j{}: {}'.format(i+1, j+1, matrix_off_val))
+                log.info('Off-axis for i{}-j{}: {}'.format(i+1, j+1, matrix_off_val))
 
     # Normalize matrix for the input aberration
     matrix_pastis /= np.square(nm_aber.value)
@@ -88,7 +91,7 @@ def ana_matrix_jwst():
     # Save matrix to file
     filename = 'PASTISmatrix_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index)
     util.write_fits(matrix_pastis, os.path.join(resDir, filename + '.fits'), header=None, metadata=None)
-    print('Matrix saved to:', os.path.join(resDir, filename + '.fits'))
+    log.info(f'Matrix saved to: {os.path.join(resDir, filename + ".fits")}')
 
     # Save the PSF and DH image *cubes* as well (as opposed to each one individually)
     util.write_fits(all_ims, os.path.join(resDir, 'psfs', 'psf_cube' + '.fits'), header=None, metadata=None)
@@ -97,8 +100,8 @@ def ana_matrix_jwst():
 
     # Tell us how long it took to finish.
     end_time = time.time()
-    print('Runtime for matrix_building.py:', end_time - start_time, 'sec =', (end_time - start_time) / 60, 'min')
-    print('Data saved to {}'.format(resDir))
+    log.info(f'Runtime for matrix_building.py: {end_time - start_time}sec = {(end_time - start_time) / 60}min')
+    log.info('Data saved to {}'.format(resDir))
 
 
 if __name__ == '__main__':

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -212,7 +212,6 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
 
     # Keep track of time
     start_time = time.time()
-    log.info('Building numerical matrix for LUVOIR\n')
 
     ### Parameters
 
@@ -220,6 +219,17 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
     overall_dir = util.create_data_path(CONFIG_INI.get('local', 'local_data_path'), telescope='luvoir-'+design)
     os.makedirs(overall_dir, exist_ok=True)
     resDir = os.path.join(overall_dir, 'matrix_numerical')
+
+    # Create necessary directories if they don't exist yet
+    os.makedirs(resDir, exist_ok=True)
+    os.makedirs(os.path.join(resDir, 'OTE_images'), exist_ok=True)
+    os.makedirs(os.path.join(resDir, 'psfs'), exist_ok=True)
+
+    # Set up logger
+    util.setup_pastis_logging(resDir, f'pastis_matrix_{design}')
+    log.info('Building numerical matrix for LUVOIR\n')
+
+    # Read calibration aberration
     zern_number = CONFIG_INI.getint('calibration', 'local_zernike')
     zern_mode = util.ZernikeMode(zern_number)                       # Create Zernike mode object for easier handling
 
@@ -240,11 +250,6 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
     log.info(f'Number of segments: {nb_seg}')
     log.info(f'Image size: {im_lamD} lambda/D')
     log.info(f'Sampling: {sampling} px per lambda/D')
-
-    # Create necessary directories if they don't exist yet
-    os.makedirs(resDir, exist_ok=True)
-    os.makedirs(os.path.join(resDir, 'OTE_images'), exist_ok=True)
-    os.makedirs(os.path.join(resDir, 'psfs'), exist_ok=True)
 
     #  Copy configfile to resulting matrix directory
     util.copy_config(resDir)

--- a/pastis/run_cases.py
+++ b/pastis/run_cases.py
@@ -7,25 +7,28 @@ from matrix_building_numerical import num_matrix_luvoir
 from pastis_analysis import run_full_pastis_analysis_luvoir
 from config import CONFIG_INI
 
+
 if __name__ == '__main__':
     
     # First generate a couple of matrices
     dir_small = num_matrix_luvoir(design='small')
     #dir_medium = num_matrix_luvoir(design='medium')
     #dir_large = num_matrix_luvoir(design='large')
+
+    # Alternativley, pick data locations to run PASTIS analysis on
+    #dir_small = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory_small')
+    #dir_medium = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory_medium')
+    #dir_large = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory_medium')
     
     # Then generate all hockeystick curves
-    #dir_small = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory_small')
     result_dir_small = os.path.join(dir_small, 'results')
     matrix_dir_small = os.path.join(dir_small, 'matrix_numerical')
     hockeystick_luvoir(apodizer_choice='small', matrixdir=matrix_dir_small, resultdir=result_dir_small, range_points=50, no_realizations=20)
 
-    #dir_medium = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory_medium')
     #result_dir_medium = os.path.join(dir_medium, 'results')
     #matrix_dir_medium = os.path.join(dir_medium, 'matrix_numerical')
     #hockeystick_luvoir(apodizer_choice='medium', matrixdir=matrix_dir_medium, resultdir=result_dir_medium, range_points=50, no_realizations=20)
 
-    #dir_large = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory_medium')
     #result_dir_large = os.path.join(dir_large, 'results')
     #matrix_dir_large = os.path.join(dir_large, 'matrix_numerical')
     #hockeystick_luvoir(apodizer_choice='large', matrixdir=matrix_dir_large, resultdir=result_dir_large, range_points=50, no_realizations=20)

--- a/pastis/run_cases.py
+++ b/pastis/run_cases.py
@@ -10,7 +10,7 @@ import util_pastis as util
 
 
 if __name__ == '__main__':
-    
+
     # First generate a couple of matrices
     dir_small = num_matrix_luvoir(design='small')
     #dir_medium = num_matrix_luvoir(design='medium')
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     #dir_medium = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory_medium')
     #dir_large = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory_medium')
 
-    # Set up loggers for all cases
+    # Set up loggers for data analysis in all cases
     util.setup_pastis_logging(dir_small, 'pastis_analysis')
     #util.setup_pastis_logging(dir_medium, 'pastis_analysis')
     #util.setup_pastis_logging(dir_large, 'pastis_analysis')

--- a/pastis/run_cases.py
+++ b/pastis/run_cases.py
@@ -6,6 +6,7 @@ from hockeystick_contrast_curve import hockeystick_luvoir
 from matrix_building_numerical import num_matrix_luvoir
 from pastis_analysis import run_full_pastis_analysis_luvoir
 from config import CONFIG_INI
+import util_pastis as util
 
 
 if __name__ == '__main__':
@@ -15,10 +16,15 @@ if __name__ == '__main__':
     #dir_medium = num_matrix_luvoir(design='medium')
     #dir_large = num_matrix_luvoir(design='large')
 
-    # Alternativley, pick data locations to run PASTIS analysis on
+    # Alternatively, pick data locations to run PASTIS analysis on
     #dir_small = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory_small')
     #dir_medium = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory_medium')
     #dir_large = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory_medium')
+
+    # Set up loggers for all cases
+    util.setup_pastis_logging(dir_small, 'pastis_analysis')
+    #util.setup_pastis_logging(dir_medium, 'pastis_analysis')
+    #util.setup_pastis_logging(dir_large, 'pastis_analysis')
     
     # Then generate all hockeystick curves
     result_dir_small = os.path.join(dir_small, 'results')

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -3,12 +3,17 @@ Helper functions for PASTIS.
 """
 
 import os
-import time
 import datetime
-from shutil  import copy
-import numpy as np
+import time
+from shutil import copy
+import sys
 from astropy.io import fits
 import astropy.units as u
+import logging
+import logging.handlers
+import numpy as np
+
+log = logging.getLogger()
 
 
 def write_fits(data, filepath, header=None, metadata=None):
@@ -313,3 +318,36 @@ def copy_config(outdir):
         copy('config_local.ini', outdir)
     except IOError:
         copy('config.ini', outdir)
+
+
+def setup_pastis_logging(experiment_path, name):
+    ### General logger
+    log = logging.getLogger()
+
+    log.setLevel(logging.NOTSET)    # set logger to pass all messages, then filter in handlers
+    suffix = ".log"
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    ### Set up the console log to stdout (not stderr since some messages are info)
+    consoleHandler = logging.StreamHandler(sys.stdout)
+
+    # add formatter, set logging level and add the handler
+    consoleHandler.setFormatter(formatter)
+    console_level = logging.INFO
+    consoleHandler.setLevel(console_level)
+
+    log.addHandler(consoleHandler)
+    log.info("LOG SETUP: Console will display messages of {} or higher".format(logging.getLevelName(consoleHandler.level)))
+
+    ### Set up the experiment log
+    experiment_logfile_path = os.path.join(experiment_path, name + suffix)
+    experiment_hander = logging.handlers.WatchedFileHandler(experiment_logfile_path)
+
+    # add formatter, set logging level and add the handler
+    experiment_hander.setFormatter(formatter)
+    experiment_level = logging.INFO
+    experiment_hander.setLevel(experiment_level)
+
+    log.addHandler(experiment_hander)
+    log.info("LOG SETUP: Experiment log will save messages of {} or higher to {}".format(logging.getLevelName(experiment_hander.level),
+                                                                                         experiment_logfile_path))


### PR DESCRIPTION
Using the `logging` module to create logs of the PASTIS matrix generation and analysis runs. This will be particularly useful since one of the next things I want to do is speed up the matrix generation.

One handler will write everything to `stdout` and another handler will write everything to a log file. I set up one log file for the matrix generation, and one log file for the pastis analysis. Any new analysis run will have logs that will be appended to this log.

Currently the matrix log will also include the log messages that then get written to the analysis log also, but this is not a problem so I will leave it like this for now.

This means I also changed all `print()` statements in the code to `log.info()`,  including the old codes for analytical PASTIS, or JWST and HiCAT that are currently not usable (only one of them I made a `log.warning()`). For this purpose I had to change all arguments of the print functions into formatted strings. Some are still using the `.format()` way of doing this, but any new one I made uses `f` strings.