### PR TITLE
Create PASTIS matrix with HiCAT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .ipynb_checkpoints/
 config_local.ini
 .idea/
+.DS_Store

--- a/Jupyter Notebooks/HiCAT/3_Get images from HiCAT simulator with IrisAO.ipynb
+++ b/Jupyter Notebooks/HiCAT/3_Get images from HiCAT simulator with IrisAO.ipynb
@@ -13,10 +13,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LogNorm\n",
     "import numpy as np\n",
     "import hicat.simulators"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
    ]
   },
   {
@@ -86,9 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Get an image from the simulator with flat IrisAO, unnormalized\n",
-    "\n",
-    "The initial simulator just read the info from the configfile. Here, we're just trying to make a PSF and we will deal with the setup later."
+    "## Get an image from the simulator with flat IrisAO, unnormalized"
    ]
   },
   {
@@ -99,8 +106,7 @@
    "source": [
     "# All the images\n",
     "plt.figure(figsize=(14,14))\n",
-    "psf, waves = hc.calc_psf(display=True, return_intermediates=True)\n",
-    "plt.show()"
+    "psf, waves = hc.calc_psf(display=True, return_intermediates=True)"
    ]
   },
   {
@@ -121,8 +127,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(10,10))\n",
-    "plt.imshow(np.log10(hicat_psf))\n",
-    "plt.show()"
+    "plt.imshow(np.log10(hicat_psf))"
    ]
   },
   {
@@ -140,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hc.inculde_fpm = False\n",
+    "hc.include_fpm = False\n",
     "psf_direct_data = hc.calc_psf()"
    ]
   },
@@ -172,8 +177,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hc.inculde_fpm = True\n",
-    "psf_coro_data = hc.calc_psf(display=False, return_intermediates=False)"
+    "hc.include_fpm = True\n",
+    "psf_coro_data = hc.calc_psf()"
    ]
   },
   {
@@ -188,6 +193,135 @@
     "plt.title('Coro PSF')\n",
     "plt.imshow(np.log10(psf_coro), cmap='inferno')\n",
     "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Aberrate a segment on the IrisAO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hc.iris_dm.flatten()\n",
+    "hc.iris_dm.set_actuator(0, 50e-9, 0, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(14,14))\n",
+    "one_seg_data, inter = hc.calc_psf(display=True, return_intermediates=True)\n",
+    "one_seg = one_seg_data[0].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display PSF and IrisAo OPD\n",
+    "plt.figure(figsize=(7, 7))\n",
+    "plt.imshow(one_seg, norm=LogNorm(), cmap='inferno')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(7, 7))\n",
+    "inter[1].display(what='phase')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Aberrate pair of segments\n",
+    "\n",
+    "0 is the center segment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hc.iris_dm.flatten()\n",
+    "\n",
+    "seg1 = 4\n",
+    "seg2 = 23\n",
+    "ampl = 50e-9    # nm\n",
+    "\n",
+    "hc.iris_dm.set_actuator(seg1, ampl, 0, 0)\n",
+    "hc.iris_dm.set_actuator(seg2, ampl, 0, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pair_psf_data, inter = hc.calc_psf(return_intermediates=True)\n",
+    "pair_psf = pair_psf_data[0].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(7, 7))\n",
+    "plt.imshow(pair_psf, norm=LogNorm(), cmap='inferno')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(7, 7))\n",
+    "inter[1].display(what='phase')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hc.display_pupil_overlaps()"
    ]
   },
   {
@@ -214,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/Jupyter Notebooks/HiCAT/3_Get images from HiCAT simulator with IrisAO.ipynb
+++ b/Jupyter Notebooks/HiCAT/3_Get images from HiCAT simulator with IrisAO.ipynb
@@ -231,7 +231,7 @@
    "source": [
     "# Display PSF and IrisAo OPD\n",
     "plt.figure(figsize=(7, 7))\n",
-    "plt.imshow(one_seg, norm=LogNorm(), cmap='inferno')\n",
+    "plt.imshow(one_seg/norm, norm=LogNorm(), cmap='inferno')\n",
     "plt.colorbar()"
    ]
   },
@@ -287,7 +287,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(7, 7))\n",
-    "plt.imshow(pair_psf, norm=LogNorm(), cmap='inferno')\n",
+    "plt.imshow(pair_psf/norm, norm=LogNorm(), cmap='inferno')\n",
     "plt.colorbar()"
    ]
   },
@@ -302,11 +302,105 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create DH mask and measure mean contrast"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# lifted from util_pastis\n",
+    "def create_dark_hole(pup_im, iwa, owa, samp):\n",
+    "    \"\"\"\n",
+    "    Create a dark hole on pupil image pup_im.\n",
+    "    :param pup_im: np.array of pupil image\n",
+    "    :param iwa: inner working angle in lambda/D\n",
+    "    :param owa: outer working angle in lambda/D\n",
+    "    :param samp: sampling factor\n",
+    "    :return: dh_area: np.array\n",
+    "    \"\"\"\n",
+    "    circ_inner = circle_mask(pup_im, pup_im.shape[0]/2., pup_im.shape[1]/2., iwa * samp) * 1   # *1 converts from booleans to integers\n",
+    "    circ_outer = circle_mask(pup_im, pup_im.shape[0]/2., pup_im.shape[1]/2., owa * samp) * 1\n",
+    "    dh_area = circ_outer - circ_inner\n",
+    "\n",
+    "    return dh_area\n",
+    "\n",
+    "def circle_mask(im, xc, yc, rcirc):\n",
+    "    \"\"\" Create a circle on array im centered on xc, yc with radius rcirc; inside circle equals 1.\"\"\"\n",
+    "    x, y = np.shape(im)\n",
+    "    newy, newx = np.mgrid[0:y,0:x]\n",
+    "    circ = (newx-xc)**2 + (newy-yc)**2 < rcirc**2\n",
+    "    return circ\n",
+    "\n",
+    "def dh_mean(im, dh):\n",
+    "    \"\"\"\n",
+    "    Return the dark hole contrast.\n",
+    "\n",
+    "    Calculate the mean intensity in the dark hole area dh of the image im.\n",
+    "    im and dh have to have the same array size and shape.\n",
+    "    :param im: array, normalized (by direct PSF peak pixel) image\n",
+    "    :param dh: array, dark hole mask\n",
+    "    \"\"\"\n",
+    "    darkh = im * dh\n",
+    "    con = np.mean(darkh[np.where(dh != 0)])\n",
+    "    return con"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iwa = 6\n",
+    "owa = 11\n",
+    "sampling = 3.1364"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dh_mask = create_dark_hole(pair_psf, iwa, owa, sampling)\n",
+    "\n",
+    "plt.figure(figsize=(10, 5))\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.imshow(dh_mask)\n",
+    "plt.title('dh_mask')\n",
+    "\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.imshow(pair_psf/norm, norm=LogNorm())\n",
+    "plt.imshow(dh_mask, alpha=0.5)\n",
+    "plt.title('Dark hole')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(7, 7))\n",
+    "plt.imshow(pair_psf/norm*dh_mask, norm=LogNorm(), cmap='inferno')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "contrast = dh_mean(pair_psf/norm, dh_mask)\n",
+    "print(contrast)"
+   ]
   },
   {
    "cell_type": "code",

--- a/Jupyter Notebooks/HiCAT/3_Get images from HiCAT simulator with IrisAO.ipynb
+++ b/Jupyter Notebooks/HiCAT/3_Get images from HiCAT simulator with IrisAO.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting images from HiCAT simulator and controlling the IrisAO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import hicat.simulators"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instantiate hicat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hc = hicat.simulators.hicat_sim.HICAT_Sim()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hc.testbed_state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(hc.describe())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set the testbed into the correct hardware state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hc.pupil_maskmask = 'circular'    # I will likely have to implement a new pupil mask\n",
+    "hc.iris_ao = 'iris_ao'\n",
+    "hc.apodizer = 'no_apodizer'\n",
+    "hc.lyot_stop = 'circular'\n",
+    "hc.detector = 'imager'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hc.testbed_state"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get an image from the simulator with flat IrisAO, unnormalized\n",
+    "\n",
+    "The initial simulator just read the info from the configfile. Here, we're just trying to make a PSF and we will deal with the setup later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# All the images\n",
+    "plt.figure(figsize=(14,14))\n",
+    "psf, waves = hc.calc_psf(display=True, return_intermediates=True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hicat_psf = psf[0].data\n",
+    "print(type(hicat_psf))\n",
+    "print(hicat_psf.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "plt.imshow(np.log10(hicat_psf))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get normalized coro PSF\n",
+    "\n",
+    "### Calculate direct image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hc.inculde_fpm = False\n",
+    "psf_direct_data = hc.calc_psf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psf_direct = psf_direct_data[0].data\n",
+    "norm = psf_direct.max()\n",
+    "\n",
+    "plt.figure(figsize=(10,10))\n",
+    "plt.title('Direct PSF')\n",
+    "plt.imshow(np.log10(psf_direct), cmap='inferno')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate normalized coro image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hc.inculde_fpm = True\n",
+    "psf_coro_data = hc.calc_psf(display=False, return_intermediates=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psf_coro = psf_coro_data[0].data/norm\n",
+    "\n",
+    "plt.figure(figsize=(10,10))\n",
+    "plt.title('Coro PSF')\n",
+    "plt.imshow(np.log10(psf_coro), cmap='inferno')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pastis/config.ini
+++ b/pastis/config.ini
@@ -65,9 +65,19 @@ diameter = 0.019725
 gaps = 90e-6
 
 ; coronagraph
-IWA = 5
-OWA = 12
+include_apodizer = false
+; Since sampling is given wrt LS, IWA/OWA will also be given wrt D_LS
+; 4-11.7 when apod=false, 3.125-11.7 when apod=true
+; needs to agree with strokemin DH though
+IWA = 6
+OWA = 11
+; in nm
 lambda = 638
+
+; sampling_with_lyot_stop = 12.5456 for: no apodizer, no iris-ao April 17, 2020
+; "CLC2" mode with pupil and LS that match the sizes in APLC mode
+; BINNED BY 4!!!!!
+sampling = 3.1364
 
 [LUVOIR]
 ; aberration for matrix calculation, in NANOMETERS

--- a/pastis/config.ini
+++ b/pastis/config.ini
@@ -72,9 +72,9 @@ include_apodizer = false
 IWA = 6
 OWA = 11
 ; in nm
-lambda = 638
+lambda = 640
 ; for coronagraph solution with active control
-dm_maps_path = /Users/ilaginja/hicat_data/simulations/2020-07-28T18-15-01_broadband_stroke_minimization/iter0006/coron_640/dm_command
+dm_maps_path = /Users/ilaginja/hicat_data/simulations/2020-07-28T18-15-01_broadband_stroke_minimization/iter0007/coron_640/dm_command
 
 ; sampling_with_lyot_stop = 12.5456 for: no apodizer, no iris-ao April 17, 2020
 ; "CLC2" mode with pupil and LS that match the sizes in APLC mode

--- a/pastis/config.ini
+++ b/pastis/config.ini
@@ -60,7 +60,7 @@ im_size_lamD_hcipy = 30
 calibration_aberration = 10.
 
 ; telescope
-nb_subapertures = 36
+nb_subapertures = 37
 diameter = 0.019725
 gaps = 90e-6
 

--- a/pastis/config.ini
+++ b/pastis/config.ini
@@ -73,6 +73,8 @@ IWA = 6
 OWA = 11
 ; in nm
 lambda = 638
+; for coronagraph solution with active control
+dm_maps_path = /Users/ilaginja/hicat_data/simulations/2020-07-28T18-15-01_broadband_stroke_minimization/iter0006/coron_640/dm_command
 
 ; sampling_with_lyot_stop = 12.5456 for: no apodizer, no iris-ao April 17, 2020
 ; "CLC2" mode with pupil and LS that match the sizes in APLC mode

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -661,7 +661,6 @@ if __name__ == '__main__':
         # Pick the function of the telescope you want to run
         #num_matrix_jwst()
 
-        tel = CONFIG_INI.get('telescope', 'name')
-        coro_design = CONFIG_INI.get('LUVOIR', 'coronagraph_design')
-        #num_matrix_luvoir(design=coro_design)
-        num_matrix_multiprocess(instrument=tel, design=coro_design)
+        #num_matrix_luvoir(design='small')
+        #num_matrix_multiprocess(instrument='LUVOIR', design='small')
+        num_matrix_multiprocess(instrument='HiCAT')

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -130,7 +130,7 @@ def num_matrix_jwst():
             # plt.show()
 
             # Save OPD images for testing
-            opd_name = 'opd_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(i+1) + '-' + str(j+1)
+            opd_name = f'opd_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}_segs_{i+1}-{j+1}'
             plt.clf()
             ote_coro.display_opd()
             plt.savefig(os.path.join(resDir, 'OTE_images', opd_name + '.pdf'))
@@ -140,7 +140,7 @@ def num_matrix_jwst():
             psf = image[0].data / normp
 
             # Save WebbPSF image to disk
-            filename_psf = 'psf_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(i+1) + '-' + str(j+1)
+            filename_psf = f'psf_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}_segs_{i+1}-{j+1}'
             util.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'), header=None, metadata=None)
             all_psfs.append(psf)
 
@@ -150,7 +150,7 @@ def num_matrix_jwst():
             log.info(f'contrast: {contrast}')
 
             # Save DH image to disk and put current contrast in list
-            filename_dh = 'dh_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(i+1) + '-' + str(j+1)
+            filename_dh = f'dh_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}_segs_{i+1}-{j+1}'
             util.write_fits(dh_intensity, os.path.join(resDir, 'darkholes', filename_dh + '.fits'), header=None, metadata=None)
             all_dhs.append(dh_intensity)
             all_contrasts.append(contrast)
@@ -178,13 +178,13 @@ def num_matrix_jwst():
     matrix_pastis /= np.square(wfe_aber.value)
 
     # Save matrix to file
-    filename_matrix = 'PASTISmatrix_num_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index)
+    filename_matrix = f'PASTISmatrix_num_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}'
     util.write_fits(matrix_pastis, os.path.join(resDir, filename_matrix + '.fits'), header=None, metadata=None)
     log.info(f'Matrix saved to: {os.path.join(resDir, filename_matrix + ".fits")}')
 
     # Save the PSF and DH image *cubes* as well (as opposed to each one individually)
-    util.write_fits(all_psfs, os.path.join(resDir, 'psfs', 'psf_cube' + '.fits'), header=None, metadata=None)
-    util.write_fits(all_dhs, os.path.join(resDir, 'darkholes', 'dh_cube' + '.fits'), header=None, metadata=None)
+    util.write_fits(all_psfs, os.path.join(resDir, 'psfs', 'psf_cube.fits'), header=None, metadata=None)
+    util.write_fits(all_dhs, os.path.join(resDir, 'darkholes', 'dh_cube.fits'), header=None, metadata=None)
     np.savetxt(os.path.join(resDir, 'pair-wise_contrasts.txt'), all_contrasts, fmt='%e')
 
     # Tell us how long it took to finish.
@@ -293,13 +293,12 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
 
             # Save image to disk
             if savepsfs:   # TODO: I might want to change this to matplotlib images since I save the PSF cube anyway.
-                filename_psf = 'psf_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(i+1) + '-' + str(j+1)
+                filename_psf = f'psf_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}_segs_{i+1}-{j+1}'
                 hcipy.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'))
 
             # Save OPD images for testing
             if saveopds:
-                opd_name = 'opd_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(
-                    i + 1) + '-' + str(j + 1)
+                opd_name = f'opd_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}_segs_{i+1}-{j+1}'
                 plt.clf()
                 hcipy.imshow_field(inter['seg_mirror'], mask=luvoir.aperture, cmap='RdBu')
                 plt.savefig(os.path.join(resDir, 'OTE_images', opd_name + '.pdf'))
@@ -318,7 +317,7 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
     all_contrasts = np.array(all_contrasts)
 
     # Save the PSF image *cube* as well (as opposed to each one individually)
-    hcipy.write_fits(all_psfs, os.path.join(resDir, 'psfs', 'psf_cube' + '.fits'),)
+    hcipy.write_fits(all_psfs, os.path.join(resDir, 'psfs', 'psf_cube.fits'),)
     np.savetxt(os.path.join(resDir, 'pair-wise_contrasts.txt'), all_contrasts, fmt='%e')
 
     # Filling the off-axis elements
@@ -428,7 +427,7 @@ def _luvoir_matrix_one_pair(design, norm, wfe_aber, zern_mode, resDir, savepsfs,
     optics_input = CONFIG_INI.get('LUVOIR', 'optics_path')
     luv = LuvoirAPLC(optics_input, design, sampling)
 
-    log.info('PAIR: {}-{}'.format(segment_pair[0]+1, segment_pair[1]+1))
+    log.info(f'PAIR: {segment_pair[0]+1}-{segment_pair[1]+1}')
 
     # Put aberration on correct segments. If i=j, apply only once!
     luv.flatten()
@@ -443,14 +442,12 @@ def _luvoir_matrix_one_pair(design, norm, wfe_aber, zern_mode, resDir, savepsfs,
 
     # Save PSF image to disk
     if savepsfs:
-        filename_psf = 'psf_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(
-            segment_pair[0]+1) + '-' + str(segment_pair[1]+1)
+        filename_psf = f'psf_{zern_mode.name}_{zern_mode.convention}_segs_{segment_pair[0]+1}-{segment_pair[1]+1}'
         hcipy.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'))
 
     # Plot segmented mirror WFE and save to disk
     if saveopds:
-        opd_name = 'opd_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(
-            segment_pair[0]+1) + '-' + str(segment_pair[1]+1)
+        opd_name = f'opd_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}_segs_{segment_pair[0]+1}-{segment_pair[1]+1}'
         plt.clf()
         hcipy.imshow_field(inter['seg_mirror'], grid=luv.aperture.grid, mask=luv.aperture, cmap='RdBu')
         plt.savefig(os.path.join(resDir, 'OTE_images', opd_name + '.pdf'))
@@ -458,7 +455,7 @@ def _luvoir_matrix_one_pair(design, norm, wfe_aber, zern_mode, resDir, savepsfs,
     log.info('Calculating mean contrast in dark hole')
     dh_intensity = psf * luv.dh_mask
     contrast = np.mean(dh_intensity[np.where(luv.dh_mask != 0)])
-    log.info('contrast: {}'.format(float(contrast)))    # contrast is a Field, here casting to normal float
+    log.info(f'contrast: {float(contrast)}')    # contrast is a Field, here casting to normal float
 
     return float(contrast), segment_pair
 
@@ -488,7 +485,7 @@ def _hicat_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_p
 
     # TODO: load DM map (optionally?)
 
-    log.info('PAIR: {}-{}'.format(segment_pair[0], segment_pair[1]))
+    log.info(f'PAIR: {segment_pair[0]}-{segment_pair[1]}')
 
     # Put aberration on correct segments. If i=j, apply only once!
     hc.iris_dm.flatten()
@@ -575,7 +572,7 @@ def num_matrix_multiprocess(instrument, design=None, savepsfs=True, saveopds=Tru
     log.info(f'Wavelength: {wvln} m')
     log.info(f'Number of segments: {nb_seg}')
     log.info(f'Segment list: {seglist}')
-    log.info('wfe_aber: {} m'.format(wfe_aber))
+    log.info(f'wfe_aber: {wfe_aber} m')
 
     #  Copy configfile to resulting matrix directory
     util.copy_config(resDir)

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -384,7 +384,11 @@ def calculate_unaberrated_contrast_and_normalization(instrument, design=None):
         hc.lyot_stop = 'circular'
         hc.detector = 'imager'
 
-        # TODO: load DM map (optionally?)
+        # Load Boston DM maps into HiCAT simulator
+        path_to_dh_solution = CONFIG_INI.get('HiCAT', 'dm_maps_path')
+        dm1_surface, dm2_surface = util.read_continuous_dm_maps_hicat(path_to_dh_solution)
+        hc.dm1.set_surface(dm1_surface)
+        hc.dm2.set_surface(dm2_surface)
 
         # Calculate direct reference images for contrast normalization
         hc.include_fpm = False
@@ -483,7 +487,11 @@ def _hicat_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_p
     hc.lyot_stop = 'circular'
     hc.detector = 'imager'
 
-    # TODO: load DM map (optionally?)
+    # Load Boston DM maps into HiCAT simulator
+    path_to_dh_solution = CONFIG_INI.get('HiCAT', 'dm_maps_path')
+    dm1_surface, dm2_surface = util.read_continuous_dm_maps_hicat(path_to_dh_solution)
+    hc.dm1.set_surface(dm1_surface)
+    hc.dm2.set_surface(dm2_surface)
 
     log.info(f'PAIR: {segment_pair[0]}-{segment_pair[1]}')
 

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -19,7 +19,7 @@ import logging
 import matplotlib.pyplot as plt
 import multiprocessing
 import numpy as np
-import hcipy as hc
+import hcipy
 import hicat.simulators
 
 from config import CONFIG_INI
@@ -294,14 +294,14 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
             # Save image to disk
             if savepsfs:   # TODO: I might want to change this to matplotlib images since I save the PSF cube anyway.
                 filename_psf = 'psf_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(i+1) + '-' + str(j+1)
-                hc.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'))
+                hcipy.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'))
 
             # Save OPD images for testing
             if saveopds:
                 opd_name = 'opd_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(
                     i + 1) + '-' + str(j + 1)
                 plt.clf()
-                hc.imshow_field(inter['seg_mirror'], mask=luvoir.aperture, cmap='RdBu')
+                hcipy.imshow_field(inter['seg_mirror'], mask=luvoir.aperture, cmap='RdBu')
                 plt.savefig(os.path.join(resDir, 'OTE_images', opd_name + '.pdf'))
 
             log.info('Calculating mean contrast in dark hole')
@@ -318,7 +318,7 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
     all_contrasts = np.array(all_contrasts)
 
     # Save the PSF image *cube* as well (as opposed to each one individually)
-    hc.write_fits(all_psfs, os.path.join(resDir, 'psfs', 'psf_cube' + '.fits'),)
+    hcipy.write_fits(all_psfs, os.path.join(resDir, 'psfs', 'psf_cube' + '.fits'),)
     np.savetxt(os.path.join(resDir, 'pair-wise_contrasts.txt'), all_contrasts, fmt='%e')
 
     # Filling the off-axis elements
@@ -340,7 +340,7 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
 
     # Save matrix to file
     filename_matrix = f'PASTISmatrix_num_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}'
-    hc.write_fits(matrix_pastis, os.path.join(resDir, filename_matrix + '.fits'))
+    hcipy.write_fits(matrix_pastis, os.path.join(resDir, filename_matrix + '.fits'))
     log.info(f'Matrix saved to: {os.path.join(resDir, filename_matrix + ".fits")}')
 
     # Tell us how long it took to finish.
@@ -444,14 +444,14 @@ def _luvoir_matrix_one_pair(design, norm, wfe_aber, zern_mode, resDir, savepsfs,
     if savepsfs:
         filename_psf = 'psf_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(
             segment_pair[0]+1) + '-' + str(segment_pair[1]+1)
-        hc.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'))
+        hcipy.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'))
 
     # Plot segmented mirror WFE and save to disk
     if saveopds:
         opd_name = 'opd_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(
             segment_pair[0]+1) + '-' + str(segment_pair[1]+1)
         plt.clf()
-        hc.imshow_field(inter['seg_mirror'], grid=luv.aperture.grid, mask=luv.aperture, cmap='RdBu')
+        hcipy.imshow_field(inter['seg_mirror'], grid=luv.aperture.grid, mask=luv.aperture, cmap='RdBu')
         plt.savefig(os.path.join(resDir, 'OTE_images', opd_name + '.pdf'))
 
     log.info('Calculating mean contrast in dark hole')
@@ -502,7 +502,7 @@ def _hicat_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_p
     # Save PSF image to disk
     if savepsfs:
         filename_psf = f'psf_piston_Noll1_segs_{segment_pair[0]}-{segment_pair[1]}'
-        hc.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'))
+        hcipy.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'))
 
     # Plot segmented mirror WFE and save to disk
     if saveopds:
@@ -653,7 +653,7 @@ def num_matrix_multiprocess(instrument, design=None, savepsfs=True, saveopds=Tru
 
     # Save matrix to file
     filename_matrix = f'PASTISmatrix_num_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}'
-    hc.write_fits(matrix_pastis, os.path.join(resDir, filename_matrix + '.fits'))
+    hcipy.write_fits(matrix_pastis, os.path.join(resDir, filename_matrix + '.fits'))
     log.info(f'Matrix saved to: {os.path.join(resDir, filename_matrix + ".fits")}')
 
     # Tell us how long it took to finish.

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -609,7 +609,7 @@ def num_matrix_multiprocess(instrument, design=None, savepsfs=True, saveopds=Tru
                                                   savepsfs, saveopds)
 
     if instrument == 'HiCAT':
-        calculate_matrix_pair = functools.partial(_hicat_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds))
+        calculate_matrix_pair = functools.partial(_hicat_matrix_one_pair, norm, wfe_aber, resDir, savepsfs, saveopds)
 
     # Iterate over all segment pairs via a multiprocess pool
     mypool = multiprocessing.Pool(num_processes)

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -352,6 +352,14 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
 
 
 def calculate_unaberrated_contrast_and_normalization(instrument, design=None):
+    """
+    Calculate the direct PSF peak and unaberrated coronagraph floor of an instrument.
+    :param instrument: string, 'LUVOIR' or 'HiCAT'
+    :param design: str, optional, default=None, which means we read from the configfile: what coronagraph design
+                   to use - 'small', 'medium' or 'large'
+    :return: contrast floor and PSF normalization factor
+    """
+
     if instrument == 'LUVOIR':
         # Instantiate LuvoirAPLC class
         sampling = CONFIG_INI.getfloat(instrument, 'sampling')

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -409,7 +409,7 @@ def _luvoir_matrix_one_pair(design, norm, wfe_aber, zern_mode, resDir, savepsfs,
             segment_pair[0]+1) + '-' + str(segment_pair[1]+1)
         hc.write_fits(psf, os.path.join(resDir, 'psfs', filename_psf + '.fits'))
 
-    # Plot all OPDs
+    # Plot segmented mirror WFE and save to disk
     if saveopds:
         opd_name = 'opd_' + zern_mode.name + '_' + zern_mode.convention + str(zern_mode.index) + '_segs_' + str(
             segment_pair[0]+1) + '-' + str(segment_pair[1]+1)

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -184,6 +184,21 @@ def get_segment_list(instrument):
     return seglist
 
 
+def read_continuous_dm_maps_hicat(path_to_dm_maps):
+    """
+    Read Boston DM maps from disk and return as one list per DM.
+    :param path_to_dm_maps: string, absolute path to folder containing DM maps to load
+    :return: DM1 actuator map array, DM2 actuator map array; in m
+    """
+
+    surfaces = []
+    for dmnum in [1, 2]:
+        actuators_2d = fits.getdata(os.path.join(path_to_dm_maps, f'dm{dmnum}_command_2d_noflat.fits'))
+        surfaces.append(actuators_2d)
+
+    return surfaces[0], surfaces[1]
+
+
 def rms(ar):
     """
     Manual root-mean-square calculation, assuming a zero-mean

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -13,6 +13,8 @@ import logging
 import logging.handlers
 import numpy as np
 
+from config import CONFIG_INI
+
 log = logging.getLogger()
 
 
@@ -163,6 +165,23 @@ def calc_variance_of_mean_contrast(pastismatrix, cov_segments):
     """
     var = 2 * np.trace(np.matmul(pastismatrix, np.matmul(cov_segments, (np.matmul(pastismatrix, cov_segments)))))
     return var
+
+
+def get_segment_list(instrument):
+    """
+    Horribly hacky function to get correct segment numer list for an instrument.
+
+    We can assume that both implemented instruments start their numbering at 0, at the center segment. LUVOIR doesn't
+    use the center segment though, so we start at 1 and go until 120, for a total of 120 segments. HiCAT does use it,
+    so we start at 0 and go to 36 for a total of 37 segments.
+    :param instrument: string, "HiCAT" or "LUVOIR"
+    :return: seglist, array of segment numbers (names!)
+    """
+    seglist = np.arange(CONFIG_INI.getint(instrument, 'nb_subapertures'))
+    if instrument == 'LUVOIR':
+        seglist += 1
+
+    return seglist
 
 
 def rms(ar):

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -58,6 +58,24 @@ def write_fits(data, filepath, header=None, metadata=None):
     return filepath
 
 
+def write_all_fits_to_cube(path):
+    """
+    Write all fits files in a directory to an image cube.
+
+    Directory can *only* contain fits files, and only files that you want in the cube. Subdirectories will be ignored.
+    :param path: string, path to directory that contains all fits files that should be put into cube; cube gets saved
+                 into that same directory
+    """
+    # Collect all filenames
+    all_file_names = [fname for fname in os.listdir(path) if os.path.isfile(os.path.join(path, fname))]
+    # Read all files into list
+    allfiles = []
+    for fname in all_file_names:
+        allfiles.append(fits.getdata(os.path.join(path, fname)))
+    cube = np.array(allfiles)
+    write_fits(cube, os.path.join(path, 'psf_cube.fits'))
+
+
 def circle_mask(im, xc, yc, rcirc):
     """ Create a circle on array im centered on xc, yc with radius rcirc; inside circle equals 1."""
     x, y = np.shape(im)


### PR DESCRIPTION
Hooking up the HiCAT simulator to create a PASTIS matrix.
Requires a conda env that has all the pastis requirements, and installations of hicat and catkit in it.

Matrix generation for HiCAT lifted from the notebook `Jupyter Notebooks/HiCAT/4_...`

Includes:
- set up new notebook to go through segment aberration with IrisAO
- abstract multiprocessed matrix generation function to accomodate HiCAT, and general abstraction
- write a HiCAT function to calcualte the coronagraph floor and unaberrated coro PSF
- write a HiCAT function that aberrates a single pair of segments and measures the resulting DH mean contrast
- load Boston DM maps that are DH solutions
- add some clarification on segment numbering choice
- pick and create correct DH size
- scoop up some more strings and make them f strings

Note how at some point there was an issue between `import hcipy as hc` and `hc = hicat.simulators.HICAT_Sim()`. I decided to change to `import hcipy` and keep `hc` an instance of the HiCAT simulator, however, this is now inconsistent between the scripts in the repo, which is not great. I will clean this up at a later point. I tried calling the HICAT_Sim() instance just `hicat`, but that's already the package name so that doesn't work either.

**IMPORTANT**: The HiCAT simulator will read the **wavelength** as well as the **WFE** from the hicat configfile. The wavelength defaults to 640nm so that is fine, but I had to set all WFE to zero over in the hicat repo to make this work the way I wanted to. The DM maps that are read from `dm_maps_path` in the PASTIS configfile are from a run that used the same HiCAT configfile setup.

**ALSO IMPORTANT**: The **IWA** and **OWA** in the PASTIS configfile need to be that same that were used in the strokemin run that generated the DH and DM maps in `dm_maps_path` (also in PASTIS configfile). The probe file used in that strokemin run should have the IWA and OWA in its file name.