### PR TITLE
Prep work for abstracttion of PASTIS analysis wrt instrument and including HiCAT case

### DIFF
--- a/Jupyter Notebooks/HiCAT/9_Contrast calculation E2E vs PASTIS.ipynb
+++ b/Jupyter Notebooks/HiCAT/9_Contrast calculation E2E vs PASTIS.ipynb
@@ -1,0 +1,240 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Comparing HiCAT E2E vs. matrix PASTIS contrast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.io import fits\n",
+    "import astropy.units as u\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from config import CONFIG_INI\n",
+    "from e2e_simulators.hicat_imaging import set_up_hicat\n",
+    "import util_pastis as util"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nb_seg = CONFIG_INI.getint('HiCAT', 'nb_subapertures')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HiCAT direct PSF and normalization\n",
+    "hicat = set_up_hicat(apply_continuous_dm_maps=True)\n",
+    "hicat.include_fpm = False\n",
+    "data = hicat.calc_psf()\n",
+    "psf = data[0].data\n",
+    "norm = psf.max()\n",
+    "print(norm)\n",
+    "\n",
+    "plt.imshow(np.log(psf))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HiCAT coronagraph floor\n",
+    "hicat = set_up_hicat(apply_continuous_dm_maps=True)\n",
+    "hicat.include_fpm = True\n",
+    "data = hicat.calc_psf()\n",
+    "coro = data[0].data / norm\n",
+    "\n",
+    "iwa = CONFIG_INI.getfloat('HiCAT', 'IWA')\n",
+    "owa = CONFIG_INI.getfloat('HiCAT', 'OWA')\n",
+    "sampling = CONFIG_INI.getfloat('HiCAT', 'sampling')\n",
+    "\n",
+    "dh_mask = util.create_dark_hole(coro, iwa=iwa, owa=owa, samp=sampling)\n",
+    "coro_floor = util.dh_mean(coro, dh_mask)\n",
+    "print(f'Coro floor: {coro_floor}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the matrix\n",
+    "matrix = fits.getdata('/Users/ilaginja/data_from_repos/pastis_data/2020-08-26T11-44-28_hicat/matrix_numerical/PASTISmatrix_num_piston_Noll1.fits')\n",
+    "print(matrix.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(matrix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create aberation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create random aberrations normalized to a certain WFE rms value\n",
+    "rms_norm = 2 *u.nm\n",
+    "print(rms_norm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aber = np.random.random([nb_seg]) \n",
+    "rms_init = util.rms(aber)\n",
+    "aber *= rms_norm.value / rms_init\n",
+    "aber *= u.nm\n",
+    "print(aber)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aber -= np.mean(aber)\n",
+    "print(aber)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## E2E contrast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Put aberration on Iris AO and calculate PSF\n",
+    "plt.figure(figsize=(12, 10))\n",
+    "for nseg in range(nb_seg):\n",
+    "    hicat.iris_dm.set_actuator(nseg, aber[nseg], 0, 0)\n",
+    "\n",
+    "psf_hicat = hicat.calc_psf(display=True, return_intermediates=False)\n",
+    "psf_hicat = psf_hicat[0].data / norm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "plt.imshow(np.log10(psf_hicat))\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "contrast_e2e = util.dh_mean(psf_hicat, dh_mask)\n",
+    "print(rms_norm)\n",
+    "print(contrast_e2e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PASTIS contrast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "contrast_pastis = util.pastis_contrast(aber, matrix) + coro_floor\n",
+    "print(contrast_pastis)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(matrix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Jupyter Notebooks/LUVOIR/3a_Full E2E LUVOIR simulator.ipynb
+++ b/Jupyter Notebooks/LUVOIR/3a_Full E2E LUVOIR simulator.ipynb
@@ -47,7 +47,7 @@
     "sampling = 4\n",
     "apodizer_design = 'large'\n",
     "# This path is specific to the paths used in the LuvoirAPLC class\n",
-    "optics_input = '/Users/ilaginja/Documents/LabWork/ultra/LUVOIR_delivery_May2019/'"
+    "optics_input = CONFIG_INI.get('LUVOIR', 'optics_path')"
    ]
   },
   {

--- a/pastis/contrast_calculation_simple.py
+++ b/pastis/contrast_calculation_simple.py
@@ -224,7 +224,7 @@ def contrast_hicat_num(coro_floor, norm, matrix_dir, rms=1*u.nm):
     start_e2e = time.time()
 
     # Set HiCAT simulator to coro mode
-    hicat_sim = set_up_hicat()
+    hicat_sim = set_up_hicat(apply_continuous_dm_maps=True)
     hicat_sim.include_fpm = True
 
     log.info('Calculating E2E contrast...')

--- a/pastis/contrast_calculation_simple.py
+++ b/pastis/contrast_calculation_simple.py
@@ -16,12 +16,14 @@ import astropy.units as u
 import logging
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
-import hcipy as hc
+import hcipy
 
 from config import CONFIG_INI
-import util_pastis as util
-import image_pastis as impastis
+from e2e_simulators.hicat_imaging import set_up_hicat
 from e2e_simulators.luvoir_imaging import LuvoirAPLC
+import hicat.simulators
+import image_pastis as impastis
+import util_pastis as util
 
 log = logging.getLogger()
 
@@ -180,7 +182,7 @@ def contrast_jwst_ana_num(matdir, matrix_mode="analytical", rms=1. * u.nm, im_pa
     return contrast_webbpsf, contrast_am, contrast_matrix
 
 
-def contrast_hicat_num(matrix_dir, matrix_mode='hicat', rms=1*u.nm):
+def contrast_hicat_num(matrix_dir, rms=1*u.nm):
     """
     Compute the contrast for a random IrisAO mislignment on the HiCAT simulator.
     :param matrix_dir: str, directory of saved matrix
@@ -188,7 +190,6 @@ def contrast_hicat_num(matrix_dir, matrix_mode='hicat', rms=1*u.nm):
     :param rms: astropy quantity, rms wfe to be put randomly on the SM
     :return: 2x float, E2E and matrix contrast
     """
-    import hicat.simulators
 
     # Keep track of time
     start_time = time.time()   # runtime currently is around 12 min
@@ -197,9 +198,10 @@ def contrast_hicat_num(matrix_dir, matrix_mode='hicat', rms=1*u.nm):
     nb_seg = CONFIG_INI.getint('HiCAT', 'nb_subapertures')
     iwa = CONFIG_INI.getfloat('HiCAT', 'IWA')
     owa = CONFIG_INI.getfloat('HiCAT', 'OWA')
+    sampling = CONFIG_INI.getfloat('HiCAT', 'sampling')
 
-    # Import numerical PASTIS matrix for HiCAT sim
-    filename = 'PASTISmatrix_num_HiCAT_piston_Noll1'
+    # Import numerical PASTIS matrix
+    filename = 'PASTISmatrix_num_piston_Noll1'
     matrix_pastis = fits.getdata(os.path.join(matrix_dir, filename + '.fits'))
 
     # Create random aberration coefficients
@@ -211,45 +213,41 @@ def contrast_hicat_num(matrix_dir, matrix_mode='hicat', rms=1*u.nm):
     aber *= rms.value / rms_init
     calc_rms = util.rms(aber) * u.nm
     aber *= u.nm    # making sure the aberration has the correct units
-    log.info(f"Calculated RMS: {calc_rms}")
+    log.info(f"Calculated WFE RMS: {calc_rms}")
 
     # Remove global piston
     aber -= np.mean(aber)
 
     ### BASELINE PSF - NO ABERRATIONS, NO CORONAGRAPH
     log.info('Generating baseline PSF from E2E - no coronagraph, no aberrations')
-    hc = hicat.simulators.hicat_sim.HICAT_Sim()
-    hc.iris_ao = 'iris_ao'
-    hc.apodizer = 'cnt1_apodizer'
-    hc.lyot_stop = 'cnt1_apodizer_lyot_stop'
-    hc.include_fpm = False
+    log.info('Also generating coro PSF without aberrations')
 
-    psf_perfect = hc.calc_psf(display=False, return_intermediates=False)
+    hicat_sim = set_up_hicat()
+    hicat_sim.include_fpm = False
+
+    psf_perfect = hicat_sim.calc_psf(display=False, return_intermediates=False)
     normp = np.max(psf_perfect[0].data)
-    #psf_perfect = psf_perfect[0].data / normp   don't actually need the perfect PSF
 
-    ### HiCAT sim
+    ### E2E HiCAT sim
     start_e2e = time.time()
-    # Set up the HiCAT simulator, get PSF
-    hc.apodizer = 'cnt1_apodizer'
-    hc.lyot_stop = 'cnt1_apodizer_lyot_stop'
-    hc.include_fpm = True
+
+    # Set HiCAT simulator to coro mode
+    hicat_sim.include_fpm = True
 
     # Calculate coro PSF without aberrations
-    psf_coro = hc.calc_psf(display=False, return_intermediates=False)
+    psf_coro = hicat_sim.calc_psf(display=False, return_intermediates=False)
     psf_coro = psf_coro[0].data / normp
-
 
     log.info('Calculating E2E contrast...')
     # Put aberration on Iris AO
     for nseg in range(nb_seg):
-        hc.iris_dm.set_actuator(nseg+1, aber[nseg], 0, 0)
+        hicat_sim.iris_dm.set_actuator(nseg, aber[nseg], 0, 0)
 
-    psf_hicat = hc.calc_psf(display=False, return_intermediates=False)
+    psf_hicat = hicat_sim.calc_psf(display=False, return_intermediates=False)
     psf_hicat = psf_hicat[0].data / normp
 
     # Create DH
-    dh_mask = util.create_dark_hole(psf_hicat, iwa=iwa, owa=owa, samp=13 / 4)
+    dh_mask = util.create_dark_hole(psf_hicat, iwa=iwa, owa=owa, samp=sampling)
     # Get the mean contrast
     hicat_dh_psf = psf_hicat * dh_mask
     contrast_hicat = np.mean(hicat_dh_psf[np.where(hicat_dh_psf != 0)])
@@ -283,7 +281,7 @@ def contrast_hicat_num(matrix_dir, matrix_mode='hicat', rms=1*u.nm):
     return contrast_hicat, contrast_matrix
 
 
-def contrast_luvoir_num(apodizer_choice, matrix_dir, rms=1*u.nm):
+def contrast_luvoir_num(design, matrix_dir, rms=1*u.nm):
     """
     Compute the contrast for a random segmented mirror misalignment on the LUVOIR simulator.
     :param matrix_dir: str, directory of saved matrix
@@ -298,7 +296,7 @@ def contrast_luvoir_num(apodizer_choice, matrix_dir, rms=1*u.nm):
     nb_seg = CONFIG_INI.getint('LUVOIR', 'nb_subapertures')
     sampling = 4
 
-    # Import numerical PASTIS matrix for HiCAT sim
+    # Import numerical PASTIS matrix
     filename = 'PASTISmatrix_num_piston_Noll1'
     matrix_pastis = fits.getdata(os.path.join(matrix_dir, filename + '.fits'))
 
@@ -319,7 +317,6 @@ def contrast_luvoir_num(apodizer_choice, matrix_dir, rms=1*u.nm):
     # Coronagraph parameters
     # The LUVOIR STDT delivery in May 2018 included three different apodizers
     # we can work with, so I will implement an easy way of making a choice between them.
-    design = apodizer_choice
     optics_input = CONFIG_INI.get('LUVOIR', 'optics_path')
 
     # Instantiate LUVOIR telescope with APLC
@@ -343,8 +340,8 @@ def contrast_luvoir_num(apodizer_choice, matrix_dir, rms=1*u.nm):
     psf_luvoir /= normp
 
     # Create DH
-    dh_outer = hc.circular_aperture(2 * luvoir.apod_dict[design]['owa'] * luvoir.lam_over_d)(luvoir.focal_det)
-    dh_inner = hc.circular_aperture(2 * luvoir.apod_dict[design]['iwa'] * luvoir.lam_over_d)(luvoir.focal_det)
+    dh_outer = hcipy.circular_aperture(2 * luvoir.apod_dict[design]['owa'] * luvoir.lam_over_d)(luvoir.focal_det)
+    dh_inner = hcipy.circular_aperture(2 * luvoir.apod_dict[design]['iwa'] * luvoir.lam_over_d)(luvoir.focal_det)
     dh_mask = (dh_outer - dh_inner).astype('bool')
 
     # Get the mean contrast

--- a/pastis/e2e_simulators/hicat_imaging.py
+++ b/pastis/e2e_simulators/hicat_imaging.py
@@ -2,12 +2,15 @@
 This module contains useful functions to interface with the HiCAT simulator.
 """
 
-import os
+import logging
 import hicat.simulators
 from config import CONFIG_INI
+import util_pastis as util
+
+log = logging.getLogger()
 
 
-def set_up_hicat():
+def set_up_hicat(apply_continuous_dm_maps=False):
 
     hicat_sim = hicat.simulators.hicat_sim.HICAT_Sim()
 
@@ -16,5 +19,16 @@ def set_up_hicat():
     hicat_sim.apodizer = 'no_apodizer'
     hicat_sim.lyot_stop = 'circular'
     hicat_sim.detector = 'imager'
+
+    log.info(hicat_sim.describe())
+
+    # Load Boston DM maps into HiCAT simulator
+    if apply_continuous_dm_maps:
+        path_to_dh_solution = CONFIG_INI.get('HiCAT', 'dm_maps_path')
+        dm1_surface, dm2_surface = util.read_continuous_dm_maps_hicat(path_to_dh_solution)
+        hicat_sim.dm1.set_surface(dm1_surface)
+        hicat_sim.dm2.set_surface(dm2_surface)
+
+        log.info(f'BostonDM maps applied from {path_to_dh_solution}.')
 
     return hicat_sim

--- a/pastis/e2e_simulators/hicat_imaging.py
+++ b/pastis/e2e_simulators/hicat_imaging.py
@@ -11,6 +11,14 @@ log = logging.getLogger()
 
 
 def set_up_hicat(apply_continuous_dm_maps=False):
+    """
+    Return a configured instance of the HiCAT simulator.
+
+    Sets the pupil mask, whether the IrisAO is in or out, apodizer, Lyot stop and detector. Optionally, loads DM maps
+    onto the two continuous face-sheet Boston DMs.
+    :param apply_continuous_dm_maps: bool, whether to load BostonDM maps from path specified in configfile, default False
+    :return: instance of HICAT_Sim()
+    """
 
     hicat_sim = hicat.simulators.hicat_sim.HICAT_Sim()
 

--- a/pastis/e2e_simulators/hicat_imaging.py
+++ b/pastis/e2e_simulators/hicat_imaging.py
@@ -1,0 +1,20 @@
+"""
+This module contains useful functions to interface with the HiCAT simulator.
+"""
+
+import os
+import hicat.simulators
+from config import CONFIG_INI
+
+
+def set_up_hicat():
+
+    hicat_sim = hicat.simulators.hicat_sim.HICAT_Sim()
+
+    hicat_sim.pupil_maskmask = 'circular'  # I will likely have to implement a new pupil mask
+    hicat_sim.iris_ao = 'iris_ao'
+    hicat_sim.apodizer = 'no_apodizer'
+    hicat_sim.lyot_stop = 'circular'
+    hicat_sim.detector = 'imager'
+
+    return hicat_sim

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -12,30 +12,6 @@ from hcipy.optics.segmented_mirror import SegmentedMirror
 from config import CONFIG_INI
 
 
-def set_up_luvoir(design):
-    sampling = CONFIG_INI.getfloat('LUVOIR', 'sampling')
-    wvln = CONFIG_INI.getfloat('LUVOIR', 'lambda') * 1e-9   # [m]
-
-    # Read pupil and indexed pupil
-    optics_input = CONFIG_INI.get('LUVOIR', 'optics_path')
-    aper_path = 'inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000.fits'
-    aper_ind_path = 'inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000_indexed.fits'
-    aper_read = hc.read_fits(os.path.join(optics_input, aper_path))
-    aper_ind_read = hc.read_fits(os.path.join(optics_input, aper_ind_path))
-
-    # Sample them on a pupil grid and make them hcipy.Fields
-    pupil_grid = hc.make_pupil_grid(dims=aper_ind_read.shape[0], diameter=15)
-    aper = hc.Field(aper_read.ravel(), pupil_grid)
-
-    # Create the wavefront on the aperture
-    wf_aper = hc.Wavefront(aper, wvln)
-
-    # Instantiate LUVOIR
-    luvoir = LuvoirAPLC(optics_input, design, sampling)
-
-    return luvoir, wf_aper
-
-
 class SegmentedTelescopeAPLC:
     """ A segmented telescope with an APLC and actuated segments.
 

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -6,7 +6,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 from astropy.io import fits
-import hcipy as hc
+import hcipy
 from hcipy.optics.segmented_mirror import SegmentedMirror
 
 from config import CONFIG_INI
@@ -47,10 +47,10 @@ class SegmentedTelescopeAPLC:
         self.imlamD = params['imlamD']
         self.fpm_rad = params['fpm_rad']
         self.lamDrad = self.wvln / self.diam
-        self.coro = hc.LyotCoronagraph(indexed_aperture.grid, fpm, lyotst)
-        self.prop = hc.FraunhoferPropagator(indexed_aperture.grid, focal_grid)
-        self.coro_no_ls = hc.LyotCoronagraph(indexed_aperture.grid, fpm)
-        self.wf_aper = hc.Wavefront(aper, wavelength=self.wvln)
+        self.coro = hcipy.LyotCoronagraph(indexed_aperture.grid, fpm, lyotst)
+        self.prop = hcipy.FraunhoferPropagator(indexed_aperture.grid, focal_grid)
+        self.coro_no_ls = hcipy.LyotCoronagraph(indexed_aperture.grid, fpm)
+        self.wf_aper = hcipy.Wavefront(aper, wavelength=self.wvln)
         self.focal_det = focal_grid
 
     def calc_psf(self, ref=False, display_intermediate=False,  return_intermediate=None):
@@ -83,10 +83,10 @@ class SegmentedTelescopeAPLC:
         """
 
         # Create fake FPM for plotting
-        fpm_plot = 1 - hc.circular_aperture(2 * self.fpm_rad * self.lamDrad)(self.focal_det)
+        fpm_plot = 1 - hcipy.circular_aperture(2 * self.fpm_rad * self.lamDrad)(self.focal_det)
 
-        # Create apodozer as hc.Apodizer() object to be able to propagate through it
-        apod_prop = hc.Apodizer(self.apodizer)
+        # Create apodozer as hcipy.Apodizer() object to be able to propagate through it
+        apod_prop = hcipy.Apodizer(self.apodizer)
 
         # Calculate all wavefronts of the full propagation
         wf_sm = self.sm(self.wf_aper)
@@ -100,7 +100,7 @@ class SegmentedTelescopeAPLC:
         wf_before_lyot = self.coro_no_ls(wf_apod)
 
         # Wavefronts of the reference propagation
-        wf_ref_pup = hc.Wavefront(self.aper * self.apodizer * self.lyotstop, wavelength=self.wvln)
+        wf_ref_pup = hcipy.Wavefront(self.aper * self.apodizer * self.lyotstop, wavelength=self.wvln)
         wf_im_ref = self.prop(wf_ref_pup)
 
         # Display intermediate planes
@@ -109,33 +109,33 @@ class SegmentedTelescopeAPLC:
             plt.figure(figsize=(15, 15))
 
             plt.subplot(331)
-            hc.imshow_field(wf_sm.phase, mask=self.aper, cmap='RdBu')
+            hcipy.imshow_field(wf_sm.phase, mask=self.aper, cmap='RdBu')
             plt.title('Seg aperture phase')
 
             plt.subplot(332)
-            hc.imshow_field(wf_apod.intensity, cmap='inferno')
+            hcipy.imshow_field(wf_apod.intensity, cmap='inferno')
             plt.title('Apodizer')
 
             plt.subplot(333)
-            hc.imshow_field(wf_before_fpm.intensity / wf_before_fpm.intensity.max(), norm=LogNorm(), cmap='inferno')
+            hcipy.imshow_field(wf_before_fpm.intensity / wf_before_fpm.intensity.max(), norm=LogNorm(), cmap='inferno')
             plt.title('Before FPM')
 
             plt.subplot(334)
-            hc.imshow_field(int_after_fpm / wf_before_fpm.intensity.max(), cmap='inferno')
+            hcipy.imshow_field(int_after_fpm / wf_before_fpm.intensity.max(), cmap='inferno')
             plt.title('After FPM')
 
             plt.subplot(335)
-            hc.imshow_field(wf_before_lyot.intensity / wf_before_lyot.intensity.max(), norm=LogNorm(vmin=1e-3, vmax=1),
+            hcipy.imshow_field(wf_before_lyot.intensity / wf_before_lyot.intensity.max(), norm=LogNorm(vmin=1e-3, vmax=1),
                             cmap='inferno')
             plt.title('Before Lyot stop')
 
             plt.subplot(336)
-            hc.imshow_field(wf_lyot.intensity / wf_lyot.intensity.max(), norm=LogNorm(vmin=1e-3, vmax=1),
+            hcipy.imshow_field(wf_lyot.intensity / wf_lyot.intensity.max(), norm=LogNorm(vmin=1e-3, vmax=1),
                             cmap='inferno', mask=self.lyotstop)
             plt.title('After Lyot stop')
 
             plt.subplot(337)
-            hc.imshow_field(wf_im_coro.intensity / wf_im_ref.intensity.max(), norm=LogNorm(vmin=1e-10, vmax=1e-3),
+            hcipy.imshow_field(wf_im_coro.intensity / wf_im_ref.intensity.max(), norm=LogNorm(vmin=1e-10, vmax=1e-3),
                             cmap='inferno')
             plt.title('Final image')
             plt.colorbar()
@@ -223,17 +223,17 @@ class LuvoirAPLC(SegmentedTelescopeAPLC):
                                  self.apod_dict[apod_design]['fname'])
         ls_fname = 'inputs/LS_LUVOIR_ID0120_OD0982_no_struts_gy_ovsamp4_N1000.fits'
 
-        pup_read = hc.read_fits(os.path.join(input_dir, aper_path))
-        aper_ind_read = hc.read_fits(os.path.join(input_dir, aper_ind_path))
-        apod_read = hc.read_fits(os.path.join(input_dir, apod_path))
-        ls_read = hc.read_fits(os.path.join(input_dir, ls_fname))
+        pup_read = hcipy.read_fits(os.path.join(input_dir, aper_path))
+        aper_ind_read = hcipy.read_fits(os.path.join(input_dir, aper_ind_path))
+        apod_read = hcipy.read_fits(os.path.join(input_dir, apod_path))
+        ls_read = hcipy.read_fits(os.path.join(input_dir, ls_fname))
 
-        pupil_grid = hc.make_pupil_grid(dims=self.apod_dict[apod_design]['pxsize'], diameter=self.diam)
+        pupil_grid = hcipy.make_pupil_grid(dims=self.apod_dict[apod_design]['pxsize'], diameter=self.diam)
 
-        self.aperture = hc.Field(pup_read.ravel(), pupil_grid)
-        self.aper_ind = hc.Field(aper_ind_read.ravel(), pupil_grid)
-        self.apod = hc.Field(apod_read.ravel(), pupil_grid)
-        self.ls = hc.Field(ls_read.ravel(), pupil_grid)
+        self.aperture = hcipy.Field(pup_read.ravel(), pupil_grid)
+        self.aper_ind = hcipy.Field(aper_ind_read.ravel(), pupil_grid)
+        self.apod = hcipy.Field(apod_read.ravel(), pupil_grid)
+        self.ls = hcipy.Field(ls_read.ravel(), pupil_grid)
 
         # Load segment positions from fits header
         hdr = fits.getheader(os.path.join(input_dir, aper_ind_path))
@@ -246,16 +246,16 @@ class LuvoirAPLC(SegmentedTelescopeAPLC):
             poslist.append((xin, yin))
 
         poslist = np.transpose(np.array(poslist))
-        self.seg_pos = hc.CartesianGrid(poslist)
+        self.seg_pos = hcipy.CartesianGrid(poslist)
 
         # Focal plane mask
         samp_foc = self.apod_dict[apod_design]['fpm_px'] / (self.apod_dict[apod_design]['fpm_rad'] * 2)
-        focal_grid_fpm = hc.make_focal_grid(pupil_grid=pupil_grid, q=samp_foc,
+        focal_grid_fpm = hcipy.make_focal_grid(pupil_grid=pupil_grid, q=samp_foc,
                                             num_airy=self.apod_dict[apod_design]['fpm_rad'], wavelength=self.wvln)
-        self.fpm = 1 - hc.circular_aperture(2*self.apod_dict[apod_design]['fpm_rad']*self.lam_over_d)(focal_grid_fpm)
+        self.fpm = 1 - hcipy.circular_aperture(2*self.apod_dict[apod_design]['fpm_rad']*self.lam_over_d)(focal_grid_fpm)
 
         # Final focal plane grid (detector)
-        self.focal_det = hc.make_focal_grid(pupil_grid=pupil_grid, q=self.sampling, num_airy=self.imlamD, wavelength=self.wvln)
+        self.focal_det = hcipy.make_focal_grid(pupil_grid=pupil_grid, q=self.sampling, num_airy=self.imlamD, wavelength=self.wvln)
 
         luvoir_params = {'wavelength': self.wvln, 'diameter': self.diam, 'imlamD': self.imlamD,
                          'fpm_rad': self.apod_dict[apod_design]['fpm_rad']}
@@ -265,15 +265,15 @@ class LuvoirAPLC(SegmentedTelescopeAPLC):
                          lyotst=self.ls, fpm=self.fpm, focal_grid=self.focal_det, params=luvoir_params)
 
         # Make dark hole mask
-        dh_outer = hc.circular_aperture(2 * self.apod_dict[apod_design]['owa'] * self.lam_over_d)(
+        dh_outer = hcipy.circular_aperture(2 * self.apod_dict[apod_design]['owa'] * self.lam_over_d)(
             self.focal_det)
-        dh_inner = hc.circular_aperture(2 * self.apod_dict[apod_design]['iwa'] * self.lam_over_d)(
+        dh_inner = hcipy.circular_aperture(2 * self.apod_dict[apod_design]['iwa'] * self.lam_over_d)(
             self.focal_det)
         self.dh_mask = (dh_outer - dh_inner).astype('bool')
 
         # Propagators
-        self.coro = hc.LyotCoronagraph(pupil_grid, self.fpm, self.ls)
-        self.prop = hc.FraunhoferPropagator(pupil_grid, self.focal_det)
-        self.coro_no_ls = hc.LyotCoronagraph(pupil_grid, self.fpm)
+        self.coro = hcipy.LyotCoronagraph(pupil_grid, self.fpm, self.ls)
+        self.prop = hcipy.FraunhoferPropagator(pupil_grid, self.focal_det)
+        self.coro_no_ls = hcipy.LyotCoronagraph(pupil_grid, self.fpm)
         #TODO: these three propagators should actually happen in the super init
         # -> how are self.aper_ind and pupil_grid connected?

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -14,7 +14,6 @@ from config import CONFIG_INI
 
 def set_up_luvoir(design):
     sampling = CONFIG_INI.getfloat('LUVOIR', 'sampling')
-    nseg = CONFIG_INI.getint('LUVOIR', 'nb_subapertures')
     wvln = CONFIG_INI.getfloat('LUVOIR', 'lambda') * 1e-9   # [m]
 
     # Read pupil and indexed pupil
@@ -27,29 +26,14 @@ def set_up_luvoir(design):
     # Sample them on a pupil grid and make them hcipy.Fields
     pupil_grid = hc.make_pupil_grid(dims=aper_ind_read.shape[0], diameter=15)
     aper = hc.Field(aper_read.ravel(), pupil_grid)
-    aper_ind = hc.Field(aper_ind_read.ravel(), pupil_grid)
 
     # Create the wavefront on the aperture
     wf_aper = hc.Wavefront(aper, wvln)
 
-    # Load segment positions from fits header
-    hdr = fits.getheader(os.path.join(optics_input, aper_ind_path))
-    poslist = []
-    for i in range(nseg):
-        segname = 'SEG' + str(i + 1)
-        xin = hdr[segname + '_X']
-        yin = hdr[segname + '_Y']
-        poslist.append((xin, yin))
-    poslist = np.transpose(np.array(poslist))
-    seg_pos = hc.CartesianGrid(poslist)
-
-    # Instantiate segmented mirror
-    sm = SegmentedMirror(aper_ind, seg_pos)
-
     # Instantiate LUVOIR
     luvoir = LuvoirAPLC(optics_input, design, sampling)
 
-    return luvoir, wf_aper, sm
+    return luvoir, wf_aper
 
 
 class SegmentedTelescopeAPLC:

--- a/pastis/hockeystick_contrast_curve.py
+++ b/pastis/hockeystick_contrast_curve.py
@@ -155,7 +155,7 @@ def hockeystick_curve(instrument, apodizer_choice=None, matrixdir='', resultdir=
     os.makedirs(resultdir, exist_ok=True)
 
     # Calculate coronagraph floor, and normalization factor from direct image
-    contrast_floor, norm = calculate_unaberrated_contrast_and_normalization(instrument, apodizer_choice)
+    contrast_floor, norm = calculate_unaberrated_contrast_and_normalization(instrument, apodizer_choice, return_coro_simulator=False)
 
     # Loop over different RMS values and calculate contrast with MATRIX PASTIS and E2E simulation
     e2e_contrasts = []        # contrasts from E2E sim

--- a/pastis/hockeystick_contrast_curve.py
+++ b/pastis/hockeystick_contrast_curve.py
@@ -20,6 +20,7 @@ import pandas as pd
 
 from config import CONFIG_INI
 import contrast_calculation_simple as consim
+from matrix_building_numerical import calculate_unaberrated_contrast_and_normalization
 import plotting as ppl
 
 log = logging.getLogger()
@@ -153,6 +154,9 @@ def hockeystick_curve(instrument, apodizer_choice=None, matrixdir='', resultdir=
     # Create results directory if it doesn't exist yet
     os.makedirs(resultdir, exist_ok=True)
 
+    # Calculate coronagraph floor, and normalization factor from direct image
+    contrast_floor, norm = calculate_unaberrated_contrast_and_normalization(instrument, apodizer_choice)
+
     # Loop over different RMS values and calculate contrast with MATRIX PASTIS and E2E simulation
     e2e_contrasts = []        # contrasts from E2E sim
     matrix_contrasts = []     # contrasts from matrix PASTIS
@@ -175,9 +179,9 @@ def hockeystick_curve(instrument, apodizer_choice=None, matrixdir='', resultdir=
 
             # Chose correct contrast propagation function for chose instrument
             if instrument == 'LUVOIR':
-                c_e2e, c_matrix = consim.contrast_luvoir_num(apodizer_choice, matrix_dir=matrixdir, rms=rms)
+                c_e2e, c_matrix = consim.contrast_luvoir_num(contrast_floor, norm, apodizer_choice, matrix_dir=matrixdir, rms=rms)
             if instrument == 'HiCAT':
-                c_e2e, c_matrix = consim.contrast_hicat_num(matrix_dir=matrixdir, rms=rms)
+                c_e2e, c_matrix = consim.contrast_hicat_num(contrast_floor, norm, matrix_dir=matrixdir, rms=rms)
 
             e2e_rand.append(c_e2e)
             matrix_rand.append(c_matrix)

--- a/pastis/hockeystick_contrast_curve.py
+++ b/pastis/hockeystick_contrast_curve.py
@@ -117,92 +117,17 @@ def hockeystick_jwst(range_points=3, no_realizations=3, matrix_mode='analytical'
     log.info(f'Runtime for pastis_vs_e2e_contrast_calc.py: {runtime} sec = {runtime/60} min')
 
 
-def hockeystick_hicat(matrixdir, resultdir='', range_points=3, no_realizations=3):
+def hockeystick_curve(instrument, apodizer_choice=None, matrixdir='', resultdir='', range_points=3, no_realizations=3):
     """
-    Construct a PASTIS hockeystick contrast curve for validation of the PASTIS matrix for HiCAT.
-
-    The aberration range is a fixed parameter in the function body since it depends on the coronagraph (and telescope)
-    used. We define how many realizations of a specific rms error we want to run through, and also how many points we
-    want to fill the aberration range with. At each point we calculate the contrast for all realizations and plot the
-    mean of this set of results in a figure that shows contrast vs. rms phase error.
-
-    :param matrixdir: string, Path to matrix that should be used.
-    :param resultsdir: string, Path to directory where results will be saved.
-    :param range_points: int, How many points of rms error to use in the predefined aberration range.
-    :param no_realizations: int, How many realizations per rms error should be calculated; the mean of the realizations
-                                is used in the plot.
-    :return:
-    """
-
-    # Keep track of time
-    start_time = time.time()
-
-    ##########################
-    rms_range = np.logspace(-1, 3, range_points)      # Create range of RMS values to test
-    realiz = no_realizations                             # how many random realizations per RMS values to do
-    ##########################
-
-    # Loop over different RMS values and calculate contrast with MATRIX PASTIS and E2E simulation
-    e2e_contrasts = []        # contrasts from E2E sim
-    matrix_contrasts = []     # contrasts from matrix PASTIS
-
-    log.info("RMS range: {}".format(rms_range, fmt="%e"))
-    log.info(f"Random realizations: {realiz}")
-
-    for i, rms in enumerate(rms_range):
-
-        rms *= u.nm  # Making sure this has the correct units
-
-        e2e_rand = []
-        matrix_rand = []
-
-        for j in range(realiz):
-            log.info("\n#####################################")
-            log.info("CALCULATING CONTRAST FOR {:.4f}".format(rms))
-            log.info(f"RMS {i + 1}/{len(rms_range)}")
-            log.info(f"Random realization: {j+1}/{realiz}")
-            log.info(f"Total: {(i*realiz)+(j+1)}/{len(rms_range)*realiz}\n")
-
-            c_e2e, c_matrix = consim.contrast_hicat_num(matrix_dir=matrixdir, rms=rms,)
-
-            e2e_rand.append(c_e2e)
-            matrix_rand.append(c_matrix)
-
-        e2e_contrasts.append(np.mean(e2e_rand))
-        matrix_contrasts.append(np.mean(matrix_rand))
-
-    # Save contrasts and rms range
-    np.savetxt(os.path.join(resultdir, 'hockey_rms_range.txt'), rms_range)
-    np.savetxt(os.path.join(resultdir, 'hockey_e2e_contrasts.txt'), e2e_contrasts)
-    np.savetxt(os.path.join(resultdir, 'hockey_matrix_contrasts.txt'), matrix_contrasts)
-
-    # Plot
-    plt.clf()
-    plt.title("Contrast calculation")
-    plt.plot(rms_range, e2e_contrasts, label="E2E")
-    plt.plot(rms_range, matrix_contrasts, label="Matrix PASTIS")
-    plt.semilogx()
-    plt.semilogy()
-    plt.xlabel("Surface RMS in " + str(u.nm))
-    plt.ylabel("Contrast")
-    plt.legend()
-    plt.savefig(os.path.join(resultdir, 'hockeystick_contrasts.pdf'))
-
-    end_time = time.time()
-    runtime = end_time - start_time
-    log.info(f'\nTotal runtime for pastis_vs_e2e_contrast_calc.py: {runtime} sec = {runtime/60} min')
-
-
-def hockeystick_luvoir(apodizer_choice, matrixdir, resultdir='', range_points=3, no_realizations=3):
-    """
-    Construct a PASTIS hockeystick contrast curve for validation of the PASTIS matrix for LUVOIR.
+    Construct a PASTIS hockeystick contrast curve for validation of the PASTIS matrix, for one particular instrument.
 
     The aberration range is a fixed parameter in the function body since it depends on the coronagraph (and telescope)
     used. We define how many realizations of a specific WFE rms error we want to run through, and also how many points we
     want to fill the aberration range with. At each point we calculate the contrast for all realizations and plot the
     mean of this set of results in a figure that shows contrast vs. WFE rms error.
 
-    :param apodizer_choice: string, use "small", "medium" or "large" FPM coronagraph
+    :param instrument: string, 'LUVOIR' or 'HiCAT'
+    :param apodizer_choice: string, needed if instrument='LUVOIR'; use "small", "medium" or "large" FPM coronagraph
     :param matrixdir: string, Path to matrix that should be used.
     :param resultdir: string, Path to directory where results will be saved.
     :param range_points: int, How many points of WFE rms error to use in the predefined aberration range.
@@ -211,11 +136,18 @@ def hockeystick_luvoir(apodizer_choice, matrixdir, resultdir='', range_points=3,
     :return:
     """
 
+    if instrument == 'LUVOIR' and apodizer_choice is None:
+        raise ValueError('Need to specify apodizer_choice when working with LUVOIR instrument.')
+
     # Keep track of time
     start_time = time.time()
 
     ##########################
-    rms_range = np.logspace(-4, 4, range_points)      # Create range of WFE RMS values to test
+    # Create range of WFE RMS values to test
+    if instrument == 'LUVOIR':
+        rms_range = np.logspace(-4, 4, range_points)
+    if instrument == 'HiCAT':
+        rms_range = np.logspace(-1, 3, range_points)
     ##########################
 
     # Create results directory if it doesn't exist yet
@@ -236,13 +168,16 @@ def hockeystick_luvoir(apodizer_choice, matrixdir, resultdir='', range_points=3,
         matrix_rand = []
 
         for j in range(no_realizations):
-            log.info("\n#####################################")
             log.info("CALCULATING CONTRAST FOR {:.4f}".format(rms))
             log.info(f"WFE RMS number {i + 1}/{len(rms_range)}")
             log.info(f"Random realization: {j+1}/{no_realizations}")
-            log.info(f"Total: {(i*no_realizations)+(j+1)}/{len(rms_range)*no_realizations}\n")
+            log.info(f"Total: {(i*no_realizations)+(j+1)}/{len(rms_range)*no_realizations}")
 
-            c_e2e, c_matrix = consim.contrast_luvoir_num(apodizer_choice, matrix_dir=matrixdir, rms=rms)
+            # Chose correct contrast propagation function for chose instrument
+            if instrument == 'LUVOIR':
+                c_e2e, c_matrix = consim.contrast_luvoir_num(apodizer_choice, matrix_dir=matrixdir, rms=rms)
+            if instrument == 'HiCAT':
+                c_e2e, c_matrix = consim.contrast_hicat_num(matrix_dir=matrixdir, rms=rms)
 
             e2e_rand.append(c_e2e)
             matrix_rand.append(c_matrix)
@@ -258,7 +193,7 @@ def hockeystick_luvoir(apodizer_choice, matrixdir, resultdir='', range_points=3,
     # Plot
     plt.clf()
     ppl.plot_hockey_stick_curve(rms_range, matrix_contrasts, e2e_contrasts,
-                                wvln=CONFIG_INI.getfloat('LUVOIR', 'lambda'),
+                                wvln=CONFIG_INI.getfloat(instrument, 'lambda'),
                                 out_dir=resultdir,
                                 fname_suffix=f'{no_realizations}_realizations_each',
                                 save=True)
@@ -272,11 +207,10 @@ if __name__ == '__main__':
 
     # Pick one to run
     #hockeystick_jwst()
-    #hockeystick_hicat(matrixdir='/Users/ilaginja/Documents/Git/PASTIS/Jupyter Notebooks/HiCAT')
 
-    # LUVOIR
+    instrument = CONFIG_INI.get('telescope', 'name')
     run_choice = CONFIG_INI.get('numerical', 'current_analysis')
     coro_design = CONFIG_INI.get('LUVOIR', 'coronagraph_design')
     result_dir = os.path.join(CONFIG_INI.get('local', 'local_data_path'), run_choice, 'results')
     matrix_dir = os.path.join(CONFIG_INI.get('local', 'local_data_path'), run_choice, 'matrix_numerical')
-    hockeystick_luvoir(apodizer_choice=coro_design, matrixdir=matrix_dir, resultdir=result_dir, range_points=30, no_realizations=10)
+    hockeystick_curve(instrument, apodizer_choice=coro_design, matrixdir=matrix_dir, resultdir=result_dir, range_points=30, no_realizations=10)

--- a/pastis/launchers/run_hicat.py
+++ b/pastis/launchers/run_hicat.py
@@ -6,7 +6,7 @@ import os
 from config import CONFIG_INI
 from hockeystick_contrast_curve import hockeystick_curve
 from matrix_building_numerical import num_matrix_multiprocess
-from pastis_analysis import run_full_pastis_analysis_luvoir
+from pastis_analysis import run_full_pastis_analysis
 import util_pastis as util
 
 
@@ -27,4 +27,4 @@ if __name__ == '__main__':
     hockeystick_curve(instrument='HiCAT', matrixdir=matrix_dir, resultdir=result_dir, range_points=50, no_realizations=20)
 
     # Finally run the analysis
-    run_full_pastis_analysis_luvoir(instrument='HiCAT', design='small', run_choice=dir_run)
+    run_full_pastis_analysis(instrument='HiCAT', design='small', run_choice=dir_run)

--- a/pastis/launchers/run_hicat.py
+++ b/pastis/launchers/run_hicat.py
@@ -1,0 +1,30 @@
+"""
+Launcher script to start a full HiCAT run: generate matrix and run full PASTIS analysis.
+"""
+import os
+
+from config import CONFIG_INI
+from hockeystick_contrast_curve import hockeystick_curve
+from matrix_building_numerical import num_matrix_multiprocess
+from pastis_analysis import run_full_pastis_analysis_luvoir
+import util_pastis as util
+
+
+if __name__ == '__main__':
+
+    # Generate the matrix
+    dir_matrix = num_matrix_multiprocess(instrument='HiCAT')
+
+    # Alternatively, pick data location to run PASTIS analysis on
+    #dir_matrix = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory')
+
+    # Set up loggers for data analysis
+    util.setup_pastis_logging(dir_matrix, 'pastis_analysis')
+
+    # Then generate hockeystick curve
+    result_dir_small = os.path.join(dir_matrix, 'results')
+    matrix_dir_small = os.path.join(dir_matrix, 'matrix_numerical')
+    hockeystick_curve(instrument='HiCAT', matrixdir=matrix_dir_small, resultdir=result_dir_small, range_points=10, no_realizations=2)
+
+    # Finally run the analysis
+    run_full_pastis_analysis_luvoir(instrument='HiCAT', design='small', run_choice=matrix_dir_small)

--- a/pastis/launchers/run_hicat.py
+++ b/pastis/launchers/run_hicat.py
@@ -13,18 +13,18 @@ import util_pastis as util
 if __name__ == '__main__':
 
     # Generate the matrix
-    dir_matrix = num_matrix_multiprocess(instrument='HiCAT')
+    dir_run = num_matrix_multiprocess(instrument='HiCAT')
 
     # Alternatively, pick data location to run PASTIS analysis on
-    #dir_matrix = os.path.join(CONFIG_INI.get('local', 'local_data_path'), 'your-data-directory')
+    #dir_run = os.path.join(CONFIG_INI.get('local', 'local_data_path'), '2020-08-26T11-44-28_hicat')
 
     # Set up loggers for data analysis
-    util.setup_pastis_logging(dir_matrix, 'pastis_analysis')
+    util.setup_pastis_logging(dir_run, 'pastis_analysis')
 
     # Then generate hockeystick curve
-    result_dir_small = os.path.join(dir_matrix, 'results')
-    matrix_dir_small = os.path.join(dir_matrix, 'matrix_numerical')
-    hockeystick_curve(instrument='HiCAT', matrixdir=matrix_dir_small, resultdir=result_dir_small, range_points=10, no_realizations=2)
+    result_dir = os.path.join(dir_run, 'results')
+    matrix_dir = os.path.join(dir_run, 'matrix_numerical')
+    hockeystick_curve(instrument='HiCAT', matrixdir=matrix_dir, resultdir=result_dir, range_points=50, no_realizations=20)
 
     # Finally run the analysis
-    run_full_pastis_analysis_luvoir(instrument='HiCAT', design='small', run_choice=matrix_dir_small)
+    run_full_pastis_analysis_luvoir(instrument='HiCAT', design='small', run_choice=dir_run)

--- a/pastis/launchers/run_luvoir.py
+++ b/pastis/launchers/run_luvoir.py
@@ -7,7 +7,7 @@ import os
 from config import CONFIG_INI
 from hockeystick_contrast_curve import hockeystick_curve
 from matrix_building_numerical import num_matrix_multiprocess
-from pastis_analysis import run_full_pastis_analysis_luvoir
+from pastis_analysis import run_full_pastis_analysis
 import util_pastis as util
 
 
@@ -42,6 +42,6 @@ if __name__ == '__main__':
     #hockeystick_curve(instrument='LUVOIR', apodizer_choice='large', matrixdir=matrix_dir_large, resultdir=result_dir_large, range_points=50, no_realizations=20)
     
     # Finally run full analysis on all three cases
-    run_full_pastis_analysis_luvoir(instrument='LUVOIR', design='small', run_choice=dir_small)
-    #run_full_pastis_analysis_luvoir(instrument='LUVOIR', design='medium', run_choice=dir_medium)
-    #run_full_pastis_analysis_luvoir(instrument='LUVOIR', design='large', run_choice=dir_large)
+    run_full_pastis_analysis(instrument='LUVOIR', design='small', run_choice=dir_small)
+    #run_full_pastis_analysis(instrument='LUVOIR', design='medium', run_choice=dir_medium)
+    #run_full_pastis_analysis(instrument='LUVOIR', design='large', run_choice=dir_large)

--- a/pastis/launchers/run_luvoir.py
+++ b/pastis/launchers/run_luvoir.py
@@ -2,10 +2,11 @@
 Run different cases, free combination of matrices and analysis scripts.
 """
 import os
+
+from config import CONFIG_INI
 from hockeystick_contrast_curve import hockeystick_curve
 from matrix_building_numerical import num_matrix_multiprocess
 from pastis_analysis import run_full_pastis_analysis_luvoir
-from config import CONFIG_INI
 import util_pastis as util
 
 

--- a/pastis/launchers/run_luvoir.py
+++ b/pastis/launchers/run_luvoir.py
@@ -1,5 +1,6 @@
 """
-Run different cases, free combination of matrices and analysis scripts.
+Launcher script to start a full LUVOIR run: combinations of matrix generation, hockey stick curve and PASTIS analysis,
+freely choosable between the small, medium and large coronagraph designs.
 """
 import os
 
@@ -30,17 +31,17 @@ if __name__ == '__main__':
     # Then generate all hockeystick curves
     result_dir_small = os.path.join(dir_small, 'results')
     matrix_dir_small = os.path.join(dir_small, 'matrix_numerical')
-    hockeystick_curve(instrument='LUVOIR', apodizer_choice='small', matrixdir=matrix_dir_small, resultdir=result_dir_small, range_points=10, no_realizations=2)
+    hockeystick_curve(instrument='LUVOIR', apodizer_choice='small', matrixdir=matrix_dir_small, resultdir=result_dir_small, range_points=50, no_realizations=20)
 
     #result_dir_medium = os.path.join(dir_medium, 'results')
     #matrix_dir_medium = os.path.join(dir_medium, 'matrix_numerical')
-    #hockeystick_luvoir(apodizer_choice='medium', matrixdir=matrix_dir_medium, resultdir=result_dir_medium, range_points=50, no_realizations=20)
+    #hockeystick_curve(instrument='LUVOIR', apodizer_choice='medium', matrixdir=matrix_dir_medium, resultdir=result_dir_medium, range_points=50, no_realizations=20)
 
     #result_dir_large = os.path.join(dir_large, 'results')
     #matrix_dir_large = os.path.join(dir_large, 'matrix_numerical')
-    #hockeystick_luvoir(apodizer_choice='large', matrixdir=matrix_dir_large, resultdir=result_dir_large, range_points=50, no_realizations=20)
+    #hockeystick_curve(instrument='LUVOIR', apodizer_choice='large', matrixdir=matrix_dir_large, resultdir=result_dir_large, range_points=50, no_realizations=20)
     
     # Finally run full analysis on all three cases
-    run_full_pastis_analysis_luvoir(design='small', run_choice=dir_small)
-    #run_full_pastis_analysis_luvoir(design='medium', run_choice=dir_medium)
-    #run_full_pastis_analysis_luvoir(design='large', run_choice=dir_large)
+    run_full_pastis_analysis_luvoir(instrument='LUVOIR', design='small', run_choice=dir_small)
+    #run_full_pastis_analysis_luvoir(instrument='LUVOIR', design='medium', run_choice=dir_medium)
+    #run_full_pastis_analysis_luvoir(instrument='LUVOIR', design='large', run_choice=dir_large)

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -351,13 +351,14 @@ def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
     return overall_dir
 
 
-def calculate_unaberrated_contrast_and_normalization(instrument, design=None):
+def calculate_unaberrated_contrast_and_normalization(instrument, design=None, return_coro_simulator=True):
     """
     Calculate the direct PSF peak and unaberrated coronagraph floor of an instrument.
     :param instrument: string, 'LUVOIR' or 'HiCAT'
     :param design: str, optional, default=None, which means we read from the configfile: what coronagraph design
                    to use - 'small', 'medium' or 'large'
-    :return: contrast floor and PSF normalization factor
+    :param return_coro_simulator: bool, whether to return the coronagraphic simulator as third return, default True
+    :return: contrast floor and PSF normalization factor, and optionally (by default) the simulator in coron mode
     """
 
     if instrument == 'LUVOIR':
@@ -374,6 +375,9 @@ def calculate_unaberrated_contrast_and_normalization(instrument, design=None):
 
         # Calculate coronagraph floor in dark hole
         contrast_floor = util.dh_mean(unaberrated_coro_psf/norm, luvoir.dh_mask)
+
+        # Return the coronagraphic simulator
+        coro_simulator = luvoir
 
     if instrument == 'HiCAT':
         # Set up HiCAT simulator in correct state
@@ -395,8 +399,15 @@ def calculate_unaberrated_contrast_and_normalization(instrument, design=None):
         dh_mask = util.create_dark_hole(coro_psf, iwa, owa, sampling)
         contrast_floor = util.dh_mean(coro_psf, dh_mask)
 
+        # Return the coronagraphic simulator
+        coro_simulator = hicat_sim
+
     log.info(f'contrast floor: {contrast_floor}')
-    return contrast_floor, norm
+
+    if return_coro_simulator:
+        return contrast_floor, norm, coro_simulator
+    else:
+        return contrast_floor, norm
 
 
 def _luvoir_matrix_one_pair(design, norm, wfe_aber, zern_mode, resDir, savepsfs, saveopds, segment_pair):
@@ -563,7 +574,7 @@ def num_matrix_multiprocess(instrument, design=None, savepsfs=True, saveopds=Tru
     util.copy_config(resDir)
 
     # Calculate coronagraph floor, and normalization factor from direct image
-    contrast_floor, norm = calculate_unaberrated_contrast_and_normalization(instrument, design)
+    contrast_floor, norm = calculate_unaberrated_contrast_and_normalization(instrument, design, return_coro_simulator=False)
 
     # Figure out how many processes is optimal and create a Pool.
     # Assume we're the only one on the machine so we can hog all the resources.

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -469,6 +469,7 @@ def _hicat_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_p
 
     # Set up HiCAT simulator in correct state
     hicat_sim = set_up_hicat(apply_continuous_dm_maps=True)
+    hicat_sim.include_fpm = True
 
     # Put aberration on correct segments. If i=j, apply only once!
     log.info(f'PAIR: {segment_pair[0]}-{segment_pair[1]}')

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -498,7 +498,7 @@ def _hicat_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_p
     owa = CONFIG_INI.getfloat('HiCAT', 'OWA')
     sampling = CONFIG_INI.getfloat('HiCAT', 'sampling')
     dh_mask = util.create_dark_hole(psf, iwa, owa, sampling)
-    contrast = util.dh_mean(psf/norm, dh_mask)
+    contrast = util.dh_mean(psf, dh_mask)
 
     return contrast, segment_pair
 

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -376,28 +376,28 @@ def calculate_unaberrated_contrast_and_normalization(instrument, design=None):
 
     if instrument == 'HiCAT':
         # Set up HiCAT simulator in correct state
-        hc = hicat.simulators.hicat_sim.HICAT_Sim()
+        hicat_sim = hicat.simulators.hicat_sim.HICAT_Sim()
 
-        hc.pupil_maskmask = 'circular'  # I will likely have to implement a new pupil mask
-        hc.iris_ao = 'iris_ao'
-        hc.apodizer = 'no_apodizer'
-        hc.lyot_stop = 'circular'
-        hc.detector = 'imager'
+        hicat_sim.pupil_maskmask = 'circular'  # I will likely have to implement a new pupil mask
+        hicat_sim.iris_ao = 'iris_ao'
+        hicat_sim.apodizer = 'no_apodizer'
+        hicat_sim.lyot_stop = 'circular'
+        hicat_sim.detector = 'imager'
 
         # Load Boston DM maps into HiCAT simulator
         path_to_dh_solution = CONFIG_INI.get('HiCAT', 'dm_maps_path')
         dm1_surface, dm2_surface = util.read_continuous_dm_maps_hicat(path_to_dh_solution)
-        hc.dm1.set_surface(dm1_surface)
-        hc.dm2.set_surface(dm2_surface)
+        hicat_sim.dm1.set_surface(dm1_surface)
+        hicat_sim.dm2.set_surface(dm2_surface)
 
         # Calculate direct reference images for contrast normalization
-        hc.include_fpm = False
-        direct = hc.calc_psf()
+        hicat_sim.include_fpm = False
+        direct = hicat_sim.calc_psf()
         norm = direct[0].data.max()
 
         # Calculate unaberrated coronagraph image for contrast floor
-        hc.include_fpm = True
-        coro_image = hc.calc_psf()
+        hicat_sim.include_fpm = True
+        coro_image = hicat_sim.calc_psf()
         coro_psf = coro_image[0].data / norm
 
         iwa = CONFIG_INI.getfloat('HiCAT', 'IWA')
@@ -479,30 +479,30 @@ def _hicat_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_p
     """
 
     # Set up HiCAT simulator in correct state
-    hc = hicat.simulators.hicat_sim.HICAT_Sim()
+    hicat_sim = hicat.simulators.hicat_sim.HICAT_Sim()
 
-    hc.pupil_maskmask = 'circular'  # I will likely have to implement a new pupil mask
-    hc.iris_ao = 'iris_ao'
-    hc.apodizer = 'no_apodizer'
-    hc.lyot_stop = 'circular'
-    hc.detector = 'imager'
+    hicat_sim.pupil_maskmask = 'circular'  # I will likely have to implement a new pupil mask
+    hicat_sim.iris_ao = 'iris_ao'
+    hicat_sim.apodizer = 'no_apodizer'
+    hicat_sim.lyot_stop = 'circular'
+    hicat_sim.detector = 'imager'
 
     # Load Boston DM maps into HiCAT simulator
     path_to_dh_solution = CONFIG_INI.get('HiCAT', 'dm_maps_path')
     dm1_surface, dm2_surface = util.read_continuous_dm_maps_hicat(path_to_dh_solution)
-    hc.dm1.set_surface(dm1_surface)
-    hc.dm2.set_surface(dm2_surface)
+    hicat_sim.dm1.set_surface(dm1_surface)
+    hicat_sim.dm2.set_surface(dm2_surface)
 
     log.info(f'PAIR: {segment_pair[0]}-{segment_pair[1]}')
 
     # Put aberration on correct segments. If i=j, apply only once!
-    hc.iris_dm.flatten()
-    hc.iris_dm.set_actuator(segment_pair[0], wfe_aber, 0, 0)
+    hicat_sim.iris_dm.flatten()
+    hicat_sim.iris_dm.set_actuator(segment_pair[0], wfe_aber, 0, 0)
     if segment_pair[0] != segment_pair[1]:
-        hc.iris_dm.set_actuator(segment_pair[1], wfe_aber, 0, 0)
+        hicat_sim.iris_dm.set_actuator(segment_pair[1], wfe_aber, 0, 0)
 
     log.info('Calculating coro image...')
-    image, inter = hc.calc_psf(display=False, return_intermediates=True)
+    image, inter = hicat_sim.calc_psf(display=False, return_intermediates=True)
     psf = image[0].data / norm
 
     # Save PSF image to disk

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -24,6 +24,7 @@ import hicat.simulators
 
 from config import CONFIG_INI
 import util_pastis as util
+from e2e_simulators.hicat_imaging import set_up_hicat
 from e2e_simulators.luvoir_imaging import LuvoirAPLC
 
 log = logging.getLogger()
@@ -376,19 +377,7 @@ def calculate_unaberrated_contrast_and_normalization(instrument, design=None):
 
     if instrument == 'HiCAT':
         # Set up HiCAT simulator in correct state
-        hicat_sim = hicat.simulators.hicat_sim.HICAT_Sim()
-
-        hicat_sim.pupil_maskmask = 'circular'  # I will likely have to implement a new pupil mask
-        hicat_sim.iris_ao = 'iris_ao'
-        hicat_sim.apodizer = 'no_apodizer'
-        hicat_sim.lyot_stop = 'circular'
-        hicat_sim.detector = 'imager'
-
-        # Load Boston DM maps into HiCAT simulator
-        path_to_dh_solution = CONFIG_INI.get('HiCAT', 'dm_maps_path')
-        dm1_surface, dm2_surface = util.read_continuous_dm_maps_hicat(path_to_dh_solution)
-        hicat_sim.dm1.set_surface(dm1_surface)
-        hicat_sim.dm2.set_surface(dm2_surface)
+        hicat_sim = set_up_hicat(apply_continuous_dm_maps=True)
 
         # Calculate direct reference images for contrast normalization
         hicat_sim.include_fpm = False
@@ -479,23 +468,10 @@ def _hicat_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_p
     """
 
     # Set up HiCAT simulator in correct state
-    hicat_sim = hicat.simulators.hicat_sim.HICAT_Sim()
-
-    hicat_sim.pupil_maskmask = 'circular'  # I will likely have to implement a new pupil mask
-    hicat_sim.iris_ao = 'iris_ao'
-    hicat_sim.apodizer = 'no_apodizer'
-    hicat_sim.lyot_stop = 'circular'
-    hicat_sim.detector = 'imager'
-
-    # Load Boston DM maps into HiCAT simulator
-    path_to_dh_solution = CONFIG_INI.get('HiCAT', 'dm_maps_path')
-    dm1_surface, dm2_surface = util.read_continuous_dm_maps_hicat(path_to_dh_solution)
-    hicat_sim.dm1.set_surface(dm1_surface)
-    hicat_sim.dm2.set_surface(dm2_surface)
-
-    log.info(f'PAIR: {segment_pair[0]}-{segment_pair[1]}')
+    hicat_sim = set_up_hicat(apply_continuous_dm_maps=True)
 
     # Put aberration on correct segments. If i=j, apply only once!
+    log.info(f'PAIR: {segment_pair[0]}-{segment_pair[1]}')
     hicat_sim.iris_dm.flatten()
     hicat_sim.iris_dm.set_actuator(segment_pair[0], wfe_aber, 0, 0)
     if segment_pair[0] != segment_pair[1]:

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -90,7 +90,7 @@ def full_modes_from_themselves(pmodes, datadir, luvoir, saving=False):
         log.info(f'Working on mode {thismode + 1}/{nseg}.')
 
         wf_sm = apply_mode_to_luvoir(pmodes[:, thismode], luvoir)
-        all_modes.append(wf_sm.phase / wf_sm.wavenumber)    # wf.phase is in rad, so this converts it to meters
+            wf_sm = util.apply_mode_to_luvoir(pmodes[:, thismode], sim_instance)
 
     ### Check for results directory structure and create if it doesn't exist
     if saving:
@@ -517,7 +517,7 @@ def run_full_pastis_analysis_luvoir(instrument, design, run_choice, c_target=1e-
         np.savetxt(os.path.join(workdir, 'results', f'segment_requirements_{c_target}.txt'), mus)
 
         # Put mus on SM and plot
-        wf_constraints = apply_mode_to_luvoir(mus, luvoir)
+        wf_constraints = util.apply_mode_to_luvoir(mus, luvoir)
 
         ppl.plot_segment_weights(mus, out_dir=os.path.join(workdir, 'results'), c_target=c_target, save=True)
         ppl.plot_mu_map(mus, out_dir=os.path.join(workdir, 'results'), design=design, c_target=c_target, save=True)

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -77,6 +77,8 @@ def full_modes_from_themselves(pmodes, datadir, sm, wf_aper, saving=False):
     Optionally, save a PDF displaying all modes, a fits cube and individual PDF images.
     :param pmodes: array of PASTIS modes [segnum, modenum]
     :param datadir: string, path to overall data directory containing matrix and results folder
+    :param sm: hcipy.SegmentedMirror, but usually LuvoirAPLC.sm
+    :param wf_aper: hcipy.Wavefront of the aperture
     :param saving: bool, whether to save figure to disk or not, default=False
     :return: all_modes as array of Fields, mode_cube as array of 2D arrays (hcipy vs matplotlib)
     """
@@ -142,7 +144,7 @@ def apply_mode_to_sm(pmode, sm, wf_aper):
     This function first flattens the segmented mirror and then applies all segment coefficients from the input mode
     one by one to the segmented mirror.
     :param pmode: array, a single PASTIS mode [nseg] or any other segment phase map in NANOMETERS
-    :param sm: hcipy.SegmentedMirror
+    :param sm: hcipy.SegmentedMirror, but usually LuvoirAPLC.sm
     :param wf_aper: hcipy.Wavefront of the aperture
     :return: wf_sm: hcipy.Wavefront of the segmented mirror propagation
     """
@@ -400,7 +402,7 @@ def run_full_pastis_analysis_luvoir(design, run_choice, c_target=1e-10, n_repeat
     # TODO: set up instrument
     # TODO: calculate coronagraph floor
 
-    luvoir, wf_aper, sm = set_up_luvoir(design)
+    luvoir, wf_aper = set_up_luvoir(design)
 
     # Generate reference PSF and coronagraph contrast floor
     luvoir.flatten()
@@ -434,7 +436,7 @@ def run_full_pastis_analysis_luvoir(design, run_choice, c_target=1e-10, n_repeat
         pmodes, svals = modes_from_matrix(workdir)
 
         ### Get full 2D modes and save them
-        all_modes, mode_cube = full_modes_from_themselves(pmodes, workdir, sm, wf_aper, saving=True)
+        all_modes, mode_cube = full_modes_from_themselves(pmodes, workdir, luvoir.sm, wf_aper, saving=True)
 
     else:
         log.info(f'Reading PASTIS modes from {workdir}')
@@ -512,7 +514,7 @@ def run_full_pastis_analysis_luvoir(design, run_choice, c_target=1e-10, n_repeat
         np.savetxt(os.path.join(workdir, 'results', f'segment_requirements_{c_target}.txt'), mus)
 
         # Put mus on SM and plot
-        wf_constraints = apply_mode_to_sm(mus, sm, wf_aper)
+        wf_constraints = apply_mode_to_sm(mus, luvoir.sm, wf_aper)
 
         ppl.plot_segment_weights(mus, out_dir=os.path.join(workdir, 'results'), c_target=c_target, save=True)
         ppl.plot_mu_map(mus, wvln=CONFIG_INI.getfloat('LUVOIR', 'lambda'), out_dir=os.path.join(workdir, 'results'),

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -11,7 +11,7 @@ import astropy.units as u
 import logging
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
-import hcipy as hc
+import hcipy
 from hcipy.optics.segmented_mirror import SegmentedMirror
 
 from config import CONFIG_INI
@@ -107,7 +107,7 @@ def full_modes_from_themselves(pmodes, datadir, sm, wf_aper, saving=False):
         plt.figure(figsize=(36, 30))
         for thismode in range(nseg):
             plt.subplot(12, 10, thismode + 1)
-            hc.imshow_field(all_modes[thismode], cmap='RdBu')
+            hcipy.imshow_field(all_modes[thismode], cmap='RdBu')
             plt.axis('off')
             plt.title(f'Mode {thismode + 1}')
         plt.savefig(os.path.join(datadir, 'results', 'modes', 'modes_piston.pdf'))
@@ -118,7 +118,7 @@ def full_modes_from_themselves(pmodes, datadir, sm, wf_aper, saving=False):
 
         # pdf
         plt.clf()
-        hc.imshow_field(all_modes[thismode], cmap='RdBu')
+        hcipy.imshow_field(all_modes[thismode], cmap='RdBu')
         plt.axis('off')
         plt.title(f'Mode {thismode + 1}', size=30)
         if saving:
@@ -130,7 +130,7 @@ def full_modes_from_themselves(pmodes, datadir, sm, wf_aper, saving=False):
     # fits cube
     mode_cube = np.array(mode_cube)
     if saving:
-        hc.write_fits(mode_cube, os.path.join(datadir, 'results', 'modes', 'fits', 'cube_modes.fits'))
+        hcipy.write_fits(mode_cube, os.path.join(datadir, 'results', 'modes', 'fits', 'cube_modes.fits'))
 
     return all_modes, mode_cube
 
@@ -168,8 +168,8 @@ def full_modes_from_file(datadir):
     :return: all_modes as array of Fields, mode_cube as array of 2D arrays (hcipy vs matplotlib)
     """
 
-    mode_cube = hc.read_fits(os.path.join(datadir, 'results', 'modes', 'fits', 'cube_modes.fits'))
-    all_modes = hc.Field(mode_cube.ravel())
+    mode_cube = hcipy.read_fits(os.path.join(datadir, 'results', 'modes', 'fits', 'cube_modes.fits'))
+    all_modes = hcipy.Field(mode_cube.ravel())
 
     return all_modes, mode_cube
 
@@ -314,11 +314,11 @@ def calc_random_segment_configuration(luvoir, mus, dh_mask):
 
     # plt.figure()
     # plt.subplot(1, 3, 1)
-    # hc.imshow_field(dh_mask)
+    # hcipy.imshow_field(dh_mask)
     # plt.subplot(1, 3, 2)
-    # hc.imshow_field(psf, norm=LogNorm(), mask=dh_mask)
+    # hcipy.imshow_field(psf, norm=LogNorm(), mask=dh_mask)
     # plt.subplot(1, 3, 3)
-    # hc.imshow_field(psf, norm=LogNorm())
+    # hcipy.imshow_field(psf, norm=LogNorm())
     # plt.show()
 
     rand_contrast = util.dh_mean(psf / ref.max(), dh_mask)
@@ -405,16 +405,16 @@ def run_full_pastis_analysis_luvoir(design, run_choice, c_target=1e-10, n_repeat
     inputdir = CONFIG_INI.get('LUVOIR', 'optics_path')
     aper_path = 'inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000.fits'
     aper_ind_path = 'inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000_indexed.fits'
-    aper_read = hc.read_fits(os.path.join(inputdir, aper_path))
-    aper_ind_read = hc.read_fits(os.path.join(inputdir, aper_ind_path))
+    aper_read = hcipy.read_fits(os.path.join(inputdir, aper_path))
+    aper_ind_read = hcipy.read_fits(os.path.join(inputdir, aper_ind_path))
 
-    # Sample them on a pupil grid and make them hc.Fields
-    pupil_grid = hc.make_pupil_grid(dims=aper_ind_read.shape[0], diameter=15)
-    aper = hc.Field(aper_read.ravel(), pupil_grid)
-    aper_ind = hc.Field(aper_ind_read.ravel(), pupil_grid)
+    # Sample them on a pupil grid and make them hcipy.Fields
+    pupil_grid = hcipy.make_pupil_grid(dims=aper_ind_read.shape[0], diameter=15)
+    aper = hcipy.Field(aper_read.ravel(), pupil_grid)
+    aper_ind = hcipy.Field(aper_ind_read.ravel(), pupil_grid)
 
     # Create the wavefront on the aperture
-    wf_aper = hc.Wavefront(aper, wvln)
+    wf_aper = hcipy.Wavefront(aper, wvln)
 
     # Load segment positions from fits header
     hdr = fits.getheader(os.path.join(inputdir, aper_ind_path))
@@ -425,7 +425,7 @@ def run_full_pastis_analysis_luvoir(design, run_choice, c_target=1e-10, n_repeat
         yin = hdr[segname + '_Y']
         poslist.append((xin, yin))
     poslist = np.transpose(np.array(poslist))
-    seg_pos = hc.CartesianGrid(poslist)
+    seg_pos = hcipy.CartesianGrid(poslist)
 
     # Instantiate segmented mirror
     sm = SegmentedMirror(aper_ind, seg_pos)
@@ -442,13 +442,13 @@ def run_full_pastis_analysis_luvoir(design, run_choice, c_target=1e-10, n_repeat
     plt.figure()
     plt.subplot(1, 3, 1)
     plt.title("Dark hole mask")
-    hc.imshow_field(luvoir.dh_mask)
+    hcipy.imshow_field(luvoir.dh_mask)
     plt.subplot(1, 3, 2)
     plt.title("Unaberrated PSF")
-    hc.imshow_field(psf_unaber, norm=LogNorm(), mask=luvoir.dh_mask)
+    hcipy.imshow_field(psf_unaber, norm=LogNorm(), mask=luvoir.dh_mask)
     plt.subplot(1, 3, 3)
     plt.title("Unaberrated PSF (masked)")
-    hc.imshow_field(psf_unaber, norm=LogNorm())
+    hcipy.imshow_field(psf_unaber, norm=LogNorm())
     plt.savefig(os.path.join(workdir, 'unaberrated_dh.pdf'))
 
     # Calculate coronagraph floor
@@ -594,10 +594,10 @@ def run_full_pastis_analysis_luvoir(design, run_choice, c_target=1e-10, n_repeat
     if calculate_covariance_matrices:
         log.info('Calculating covariance matrices')
         Ca = np.diag(np.square(mus))
-        hc.write_fits(Ca, os.path.join(workdir, 'results', f'cov_matrix_segments_Ca_{c_target}_segment-based.fits'))
+        hcipy.write_fits(Ca, os.path.join(workdir, 'results', f'cov_matrix_segments_Ca_{c_target}_segment-based.fits'))
 
         Cb = np.dot(np.transpose(pmodes), np.dot(Ca, pmodes))
-        hc.write_fits(Cb, os.path.join(workdir, 'results', f'cov_matrix_modes_Cb_{c_target}_segment-based.fits'))
+        hcipy.write_fits(Cb, os.path.join(workdir, 'results', f'cov_matrix_modes_Cb_{c_target}_segment-based.fits'))
 
         ppl.plot_covariance_matrix(Ca, os.path.join(workdir, 'results'), c_target, segment_space=True,
                                    fname_suffix='segment-based', save=True)

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -402,7 +402,6 @@ def run_full_pastis_analysis_luvoir(instrument, design, run_choice, c_target=1e-
         sampling = CONFIG_INI.getfloat('LUVOIR', 'sampling')
         optics_input = CONFIG_INI.get('LUVOIR', 'optics_path')
         luvoir = LuvoirAPLC(optics_input, design, sampling)
-        wf_aper = hcipy.Wavefront(luvoir.aper, wvln)
 
         # Generate reference PSF and coronagraph contrast floor
         luvoir.flatten()

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -414,6 +414,7 @@ def run_full_pastis_analysis_luvoir(instrument, design, run_choice, c_target=1e-
         psf_unaber = psf_unaber.shaped
         dh_mask = luvoir.dh_mask.shaped
 
+    # Plot unaberrated coronagraph PSF
     plt.figure()
     plt.subplot(1, 3, 1)
     plt.title("Dark hole mask")

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -333,7 +333,7 @@ def calc_random_mode_configurations(pmodes, luvoir, sigmas, dh_mask):
     return random_weights, rand_contrast
 
 
-def run_full_pastis_analysis_luvoir(instrument, design, run_choice, c_target=1e-10, n_repeat=100):
+def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_repeat=100):
     """
     Run a full PASTIS analysis on a given PASTIS matrix.
 
@@ -646,4 +646,4 @@ if __name__ == '__main__':
     c_target = 1e-10
     mc_repeat = 100
 
-    run_full_pastis_analysis_luvoir(instrument, coro_design, run_choice=run, c_target=c_target, n_repeat=mc_repeat)
+    run_full_pastis_analysis(instrument, coro_design, run_choice=run, c_target=c_target, n_repeat=mc_repeat)

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -440,7 +440,7 @@ def run_full_pastis_analysis_luvoir(instrument, design, run_choice, c_target=1e-
         pmodes, svals = modes_from_matrix(workdir)
 
         ### Get full 2D modes and save them
-        all_modes, mode_cube = full_modes_from_themselves(pmodes, workdir, luvoir.sm, wf_aper, saving=True)
+        all_modes, mode_cube = full_modes_from_themselves(pmodes, workdir, luvoir, saving=True)
 
     else:
         log.info(f'Reading PASTIS modes from {workdir}')

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -520,8 +520,7 @@ def run_full_pastis_analysis_luvoir(instrument, design, run_choice, c_target=1e-
         wf_constraints = apply_mode_to_luvoir(mus, luvoir)
 
         ppl.plot_segment_weights(mus, out_dir=os.path.join(workdir, 'results'), c_target=c_target, save=True)
-        ppl.plot_mu_map(mus, wvln=CONFIG_INI.getfloat('LUVOIR', 'lambda'), out_dir=os.path.join(workdir, 'results'),
-                        design=design, c_target=c_target, save=True)
+        ppl.plot_mu_map(mus, out_dir=os.path.join(workdir, 'results'), design=design, c_target=c_target, save=True)
     else:
         log.info(f'Reading mus from {workdir}')
         mus = np.loadtxt(os.path.join(workdir, 'results', f'segment_requirements_{c_target}.txt'))

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -89,7 +89,7 @@ def full_modes_from_themselves(pmodes, datadir, luvoir, saving=False):
     for thismode in range(nseg):
         log.info(f'Working on mode {thismode + 1}/{nseg}.')
 
-        wf_sm = apply_mode_to_sm(pmodes[:, thismode], luvoir)
+        wf_sm = apply_mode_to_luvoir(pmodes[:, thismode], luvoir)
         all_modes.append(wf_sm.phase / wf_sm.wavenumber)    # wf.phase is in rad, so this converts it to meters
 
     ### Check for results directory structure and create if it doesn't exist
@@ -136,7 +136,7 @@ def full_modes_from_themselves(pmodes, datadir, luvoir, saving=False):
     return all_modes, mode_cube
 
 
-def apply_mode_to_sm(pmode, luvoir):
+def apply_mode_to_luvoir(pmode, luvoir):
     """
     Apply a PASTIS mode to the segmented mirror (SM) and return the propagated wavefront "through" the SM.
 
@@ -518,7 +518,7 @@ def run_full_pastis_analysis_luvoir(instrument, design, run_choice, c_target=1e-
         np.savetxt(os.path.join(workdir, 'results', f'segment_requirements_{c_target}.txt'), mus)
 
         # Put mus on SM and plot
-        wf_constraints = apply_mode_to_sm(mus, luvoir)
+        wf_constraints = apply_mode_to_luvoir(mus, luvoir)
 
         ppl.plot_segment_weights(mus, out_dir=os.path.join(workdir, 'results'), c_target=c_target, save=True)
         ppl.plot_mu_map(mus, wvln=CONFIG_INI.getfloat('LUVOIR', 'lambda'), out_dir=os.path.join(workdir, 'results'),

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -15,7 +15,7 @@ import hcipy
 from hcipy.optics.segmented_mirror import SegmentedMirror
 
 from config import CONFIG_INI
-from e2e_simulators.luvoir_imaging import set_up_luvoir
+from e2e_simulators.luvoir_imaging import LuvoirAPLC
 import plotting as ppl
 import util_pastis as util
 
@@ -402,7 +402,10 @@ def run_full_pastis_analysis_luvoir(design, run_choice, c_target=1e-10, n_repeat
     # TODO: set up instrument
     # TODO: calculate coronagraph floor
 
-    luvoir, wf_aper = set_up_luvoir(design)
+    sampling = CONFIG_INI.getfloat('LUVOIR', 'sampling')
+    optics_input = CONFIG_INI.get('LUVOIR', 'optics_path')
+    luvoir = LuvoirAPLC(optics_input, design, sampling)
+    wf_aper = hcipy.Wavefront(luvoir.aper, wvln)
 
     # Generate reference PSF and coronagraph contrast floor
     luvoir.flatten()

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -393,11 +393,10 @@ def plot_segment_weights(mus, out_dir, c_target, labels=None, fname_suffix='', s
         plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))
 
 
-def plot_mu_map(mus, wvln, out_dir, design, c_target, limits=None, fname_suffix='', save=False):
+def plot_mu_map(mus, out_dir, design, c_target, limits=None, fname_suffix='', save=False):
     """
     Plot the segment requirement map for a specific target contrast.
     :param mus: array or list, segment requirements (standard deviations) in nm
-    :param wvln: float, operating wavelength in nm
     :param out_dir: str, output path to save the figure to if save=True
     :param design: str, "small", "medium", or "large" LUVOIR-A APLC design for which the mus have been calculated
     :param c_target: float, target contrast for which the segment requirements have been calculated
@@ -439,11 +438,10 @@ def plot_mu_map(mus, wvln, out_dir, design, c_target, limits=None, fname_suffix=
         plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))
 
 
-def calculate_mode_phases(pastis_modes, wvln, design):
+def calculate_mode_phases(pastis_modes, design):
     """
     Calculate the phase maps in radians of a set of PASTIS modes.
     :param pastis_modes: array, PASTIS modes [seg, mode] in nm
-    :param wvln: float, wavelength at which the PASTIS matrix was generated, in nm
     :param design: str, "small", "medium", or "large" LUVOIR-A APLC design
     :return: all_modes, array of phase pupil images
     """
@@ -460,11 +458,10 @@ def calculate_mode_phases(pastis_modes, wvln, design):
     return all_modes
 
 
-def plot_all_modes(pastis_modes, wvln, out_dir, design, fname_suffix='', save=False):
+def plot_all_modes(pastis_modes, out_dir, design, fname_suffix='', save=False):
     """
     Plot all PATIS modes onto a grid.
     :param pastis_modes: array, PASTIS modes [seg, mode] in nm
-    :param wvln: float, wavelength at which the PASTIS matrix was generated, in nm
     :param out_dir: str, output path to save the figure to if save=True
     :param design: str, "small", "medium", or "large" LUVOIR-A APLC design
     :param fname_suffix: str, optional, suffix to add to the saved file name
@@ -476,7 +473,7 @@ def plot_all_modes(pastis_modes, wvln, out_dir, design, fname_suffix='', save=Fa
         fname += f'_{fname_suffix}'
 
     # Calculate phases of all modes
-    all_modes = calculate_mode_phases(pastis_modes, wvln, design)
+    all_modes = calculate_mode_phases(pastis_modes, design)
 
     # Plot them
     fig, axs = plt.subplots(12, 10, figsize=(20, 24))
@@ -490,12 +487,11 @@ def plot_all_modes(pastis_modes, wvln, out_dir, design, fname_suffix='', save=Fa
         plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))
 
 
-def plot_single_mode(mode_nr, pastis_modes, wvln, out_dir, design, figsize=(8.5,8.5), vmin=None, vmax=None, fname_suffix='', save=False):
+def plot_single_mode(mode_nr, pastis_modes, out_dir, design, figsize=(8.5,8.5), vmin=None, vmax=None, fname_suffix='', save=False):
     """
     Plot a single PASTIS mode.
     :param mode_nr: int, mode index
     :param pastis_modes: array, PASTIS modes [seg, mode] in nm
-    :param wvln: float, wavelength at which the PASTIS matrix was generated, in nm
     :param out_dir: str, output path to save the figure to if save=True
     :param design: str, "small", "medium", or "large" LUVOIR-A APLC design
     :param figsize: tuple, size of figure, default=(8.5,8.5)

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from config import CONFIG_INI
 from e2e_simulators.luvoir_imaging import LuvoirAPLC
-from pastis_analysis import apply_mode_to_sm
+from pastis_analysis import apply_mode_to_luvoir
 
 cmap_brev = cm.get_cmap('Blues_r')
 
@@ -437,7 +437,7 @@ def plot_mu_map(mus, wvln, out_dir, design, c_target, limits=None, fname_suffix=
 
     # Create wavefront in aperture plane and luvoir instance
     luvoir, wf_aper = create_luvoir_and_wf_at_mirror(design, wvln)
-    wf_constraints = apply_mode_to_sm(mus, luvoir)
+    wf_constraints = apply_mode_to_luvoir(mus, luvoir)
 
     plt.figure(figsize=(10, 10))
 
@@ -475,7 +475,7 @@ def calculate_mode_phases(pastis_modes, wvln, design):
     # Calculate phases of all modes
     all_modes = []
     for mode in range(len(pastis_modes)):
-        all_modes.append(apply_mode_to_sm(pastis_modes[:, mode], luvoir).phase)
+        all_modes.append(apply_mode_to_luvoir(pastis_modes[:, mode], luvoir).phase)
 
     return all_modes
 
@@ -533,7 +533,7 @@ def plot_single_mode(mode_nr, pastis_modes, wvln, out_dir, design, figsize=(8.5,
     luvoir, wf_aper = create_luvoir_and_wf_at_mirror(design, wvln)
 
     plt.figure(figsize=figsize, constrained_layout=False)
-    one_mode = apply_mode_to_sm(pastis_modes[:, mode_nr - 1], luvoir)
+    one_mode = apply_mode_to_luvoir(pastis_modes[:, mode_nr - 1], luvoir)
     hc.imshow_field(one_mode.phase, cmap='RdBu', vmin=vmin, vmax=vmax)
     plt.axis('off')
     plt.annotate(f'{mode_nr}', xy=(-7.1, -6.9), fontweight='roman', fontsize=43)

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from config import CONFIG_INI
 from e2e_simulators.luvoir_imaging import LuvoirAPLC
-from pastis_analysis import apply_mode_to_luvoir
+from util_pastis import apply_mode_to_luvoir
 
 cmap_brev = cm.get_cmap('Blues_r')
 

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -437,7 +437,7 @@ def plot_mu_map(mus, wvln, out_dir, design, c_target, limits=None, fname_suffix=
 
     # Create wavefront in aperture plane and luvoir instance
     luvoir, wf_aper = create_luvoir_and_wf_at_mirror(design, wvln)
-    wf_constraints = apply_mode_to_sm(mus, luvoir.sm, wf_aper)
+    wf_constraints = apply_mode_to_sm(mus, luvoir)
 
     plt.figure(figsize=(10, 10))
 
@@ -475,7 +475,7 @@ def calculate_mode_phases(pastis_modes, wvln, design):
     # Calculate phases of all modes
     all_modes = []
     for mode in range(len(pastis_modes)):
-        all_modes.append(apply_mode_to_sm(pastis_modes[:, mode], luvoir.sm, wf_aper).phase)
+        all_modes.append(apply_mode_to_sm(pastis_modes[:, mode], luvoir).phase)
 
     return all_modes
 
@@ -533,7 +533,7 @@ def plot_single_mode(mode_nr, pastis_modes, wvln, out_dir, design, figsize=(8.5,
     luvoir, wf_aper = create_luvoir_and_wf_at_mirror(design, wvln)
 
     plt.figure(figsize=figsize, constrained_layout=False)
-    one_mode = apply_mode_to_sm(pastis_modes[:, mode_nr - 1], luvoir.sm, wf_aper)
+    one_mode = apply_mode_to_sm(pastis_modes[:, mode_nr - 1], luvoir)
     hc.imshow_field(one_mode.phase, cmap='RdBu', vmin=vmin, vmax=vmax)
     plt.axis('off')
     plt.annotate(f'{mode_nr}', xy=(-7.1, -6.9), fontweight='roman', fontsize=43)

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -2,7 +2,7 @@
 Plotting functions for the PASTIS code.
 """
 import os
-import hcipy as hc
+import hcipy
 import matplotlib
 from matplotlib import cm
 import matplotlib.pyplot as plt
@@ -478,7 +478,7 @@ def plot_all_modes(pastis_modes, out_dir, design, fname_suffix='', save=False):
     # Plot them
     fig, axs = plt.subplots(12, 10, figsize=(20, 24))
     for i, ax in enumerate(axs.flat):
-        im = hc.imshow_field(all_modes[i], cmap='RdBu', ax=ax, vmin=-0.0045, vmax=0.0045)
+        im = hcipy.imshow_field(all_modes[i], cmap='RdBu', ax=ax, vmin=-0.0045, vmax=0.0045)
         ax.axis('off')
         ax.annotate(f'{i + 1}', xy=(-6.8, -6.8), fontweight='roman', fontsize=13)
     fig.tight_layout()
@@ -512,7 +512,7 @@ def plot_single_mode(mode_nr, pastis_modes, out_dir, design, figsize=(8.5,8.5), 
 
     plt.figure(figsize=figsize, constrained_layout=False)
     one_mode = apply_mode_to_luvoir(pastis_modes[:, mode_nr - 1], luvoir)
-    hc.imshow_field(one_mode.phase, cmap='RdBu', vmin=vmin, vmax=vmax)
+    hcipy.imshow_field(one_mode.phase, cmap='RdBu', vmin=vmin, vmax=vmax)
     plt.axis('off')
     plt.annotate(f'{mode_nr}', xy=(-7.1, -6.9), fontweight='roman', fontsize=43)
     cbar = plt.colorbar(fraction=0.046,

--- a/pastis/run_cases.py
+++ b/pastis/run_cases.py
@@ -2,7 +2,7 @@
 Run different cases, free combination of matrices and analysis scripts.
 """
 import os
-from hockeystick_contrast_curve import hockeystick_luvoir
+from hockeystick_contrast_curve import hockeystick_curve
 from matrix_building_numerical import num_matrix_multiprocess
 from pastis_analysis import run_full_pastis_analysis_luvoir
 from config import CONFIG_INI
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     # Then generate all hockeystick curves
     result_dir_small = os.path.join(dir_small, 'results')
     matrix_dir_small = os.path.join(dir_small, 'matrix_numerical')
-    hockeystick_luvoir(apodizer_choice='small', matrixdir=matrix_dir_small, resultdir=result_dir_small, range_points=50, no_realizations=20)
+    hockeystick_curve(instrument='LUVOIR', apodizer_choice='small', matrixdir=matrix_dir_small, resultdir=result_dir_small, range_points=10, no_realizations=2)
 
     #result_dir_medium = os.path.join(dir_medium, 'results')
     #matrix_dir_medium = os.path.join(dir_medium, 'matrix_numerical')

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -202,6 +202,31 @@ def get_segment_list(instrument):
     return seglist
 
 
+def apply_mode_to_luvoir(pmode, luvoir):
+    """
+    Apply a PASTIS mode to the segmented mirror (SM) and return the propagated wavefront "through" the SM.
+
+    This function first flattens the segmented mirror and then applies all segment coefficients from the input mode
+    one by one to the segmented mirror.
+    :param pmode: array, a single PASTIS mode [nseg] or any other segment phase map in NANOMETERS
+    :param luvoir: LuvoirAPLC
+    :return: hcipy.Wavefront of the segmented mirror
+    """
+
+    # Flatten SM to be sure we have no residual aberrations
+    luvoir.flatten()
+
+    # Loop through all segments to put them on the segmented mirror one by one
+    for seg, val in enumerate(pmode):
+        val *= u.nm  # the LUVOIR modes come out in units of nanometers
+        luvoir.set_segment(seg + 1, val.to(u.m).value / 2, 0, 0)  # /2 because this SM works in surface, not OPD
+
+    # Propagate the aperture wavefront through the SM
+    psf, planes = luvoir.calc_psf(return_intermediate='efield')
+
+    return planes['seg_mirror']
+
+
 def read_continuous_dm_maps_hicat(path_to_dm_maps):
     """
     Read Boston DM maps from disk and return as one list per DM.

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -187,7 +187,7 @@ def calc_variance_of_mean_contrast(pastismatrix, cov_segments):
 
 def get_segment_list(instrument):
     """
-    Horribly hacky function to get correct segment numer list for an instrument.
+    Horribly hacky function to get correct segment number list for an instrument (LUVOIR or HiCAT).
 
     We can assume that both implemented instruments start their numbering at 0, at the center segment. LUVOIR doesn't
     use the center segment though, so we start at 1 and go until 120, for a total of 120 segments. HiCAT does use it,
@@ -195,7 +195,12 @@ def get_segment_list(instrument):
     :param instrument: string, "HiCAT" or "LUVOIR"
     :return: seglist, array of segment numbers (names!)
     """
+    if instrument not in ['LUVOIR', 'HiCAT']:
+        raise ValueError('The instrument you requested is not implemented. Try with "LUVOIR" or "HiCAT" instead.')
+
     seglist = np.arange(CONFIG_INI.getint(instrument, 'nb_subapertures'))
+
+    # Drop the center segment with label '0' when working with LUVOIR
     if instrument == 'LUVOIR':
         seglist += 1
 


### PR DESCRIPTION
In this PR I prepare the PASTIS analysis that works for both LUVOIR and HiCAT. Here, I focus on making the hockey stikc curve work, which includes fixing a normalization error in the HiCAT matrix generation, and the setup of the PASTIS analysis. And I get rid of quite a bit of duplicate code.

Follow-up PR will deal with the actual PASTIS analysis.

- [x] refactor hockeystick function to work for both LUVOIR and HiCAT
- [x] fix a normalization bug in the HiCAT matrix generation
- [x] include new module in e2e simulators for HiCAT, add setup function for HiCAT simulator instance
- [x] make PASTIS analysis setup (direct PSF, normalization factor, unaberrated coro PSF) work for both HiCAT and LUVOIR
- [x] eliminate the self-standing segmented mirror (sm) that is currently there additionally to the LUVOIR simulator in the analysis script
- [x] refactor repo to not alias `hcipy` with `hc` anymore (conflict with initial variable for the hicat sim instance)