### PR TITLE
Implement HiCAT PASTIS analysis

### DIFF
--- a/pastis/config.ini
+++ b/pastis/config.ini
@@ -58,6 +58,9 @@ im_size_lamD_hcipy = 30
 [HiCAT]
 ; aberration for matrix calculation, in NANOMETERS
 calibration_aberration = 10.
+; log10 limits of PASTIS validity
+valid_range_lower = -1
+valid_range_upper = 3
 
 ; telescope
 nb_subapertures = 37
@@ -84,6 +87,9 @@ sampling = 3.1364
 [LUVOIR]
 ; aberration for matrix calculation, in NANOMETERS
 calibration_aberration = 1.
+; log10 limits of PASTIS validity
+valid_range_lower = -4
+valid_range_upper = 4
 
 ; telescope
 nb_subapertures = 120

--- a/pastis/config.ini
+++ b/pastis/config.ini
@@ -96,6 +96,9 @@ nb_subapertures = 120
 diameter = 15.
 gaps = 0.02
 optics_path = ${local:local_repo_path}/LUVOIR_delivery_May2019/
+aperture_path_in_optics = inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000.fits
+indexed_aperture_path_in_optics = inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000_indexed.fits
+lyot_stop_path_in_optics = inputs/LS_LUVOIR_ID0120_OD0982_no_struts_gy_ovsamp4_N1000.fits
 
 ; coronagraph
 ; iwa and owa from dictionaries within files. could move that to util.

--- a/pastis/config.ini
+++ b/pastis/config.ini
@@ -58,7 +58,7 @@ im_size_lamD_hcipy = 30
 [HiCAT]
 ; aberration for matrix calculation, in NANOMETERS
 calibration_aberration = 10.
-; log10 limits of PASTIS validity
+; log10 limits of PASTIS validity in nm WFE
 valid_range_lower = -1
 valid_range_upper = 3
 
@@ -87,7 +87,7 @@ sampling = 3.1364
 [LUVOIR]
 ; aberration for matrix calculation, in NANOMETERS
 calibration_aberration = 1.
-; log10 limits of PASTIS validity
+; log10 limits of PASTIS validity in nm WFE
 valid_range_lower = -4
 valid_range_upper = 4
 

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -217,11 +217,11 @@ class LuvoirAPLC(SegmentedTelescopeAPLC):
         self.imlamD = 1.2 * self.apod_dict[apod_design]['owa']
 
         # Pupil plane optics
-        aper_path = 'inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000.fits'
-        aper_ind_path = 'inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000_indexed.fits'
+        aper_path = CONFIG_INI.get('LUVOIR', 'aperture_path_in_optics')
+        aper_ind_path = CONFIG_INI.get('LUVOIR', 'indexed_aperture_path_in_optics')
         apod_path = os.path.join('luvoir_stdt_baseline_bw10', apod_design + '_fpm', 'solutions',
                                  self.apod_dict[apod_design]['fname'])
-        ls_fname = 'inputs/LS_LUVOIR_ID0120_OD0982_no_struts_gy_ovsamp4_N1000.fits'
+        ls_fname = CONFIG_INI.get('LUVOIR', 'lyot_stop_path_in_optics')
 
         pup_read = hcipy.read_fits(os.path.join(input_dir, aper_path))
         aper_ind_read = hcipy.read_fits(os.path.join(input_dir, aper_ind_path))

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -219,7 +219,7 @@ class LuvoirAPLC(SegmentedTelescopeAPLC):
         # Pupil plane optics
         aper_path = 'inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000.fits'
         aper_ind_path = 'inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000_indexed.fits'
-        apod_path = os.path.join(input_dir, 'luvoir_stdt_baseline_bw10', apod_design + '_fpm', 'solutions',
+        apod_path = os.path.join('luvoir_stdt_baseline_bw10', apod_design + '_fpm', 'solutions',
                                  self.apod_dict[apod_design]['fname'])
         ls_fname = 'inputs/LS_LUVOIR_ID0120_OD0982_no_struts_gy_ovsamp4_N1000.fits'
 

--- a/pastis/hockeystick_contrast_curve.py
+++ b/pastis/hockeystick_contrast_curve.py
@@ -158,7 +158,7 @@ def hockeystick_curve(instrument, apodizer_choice=None, matrixdir='', resultdir=
     e2e_contrasts = []        # contrasts from E2E sim
     matrix_contrasts = []     # contrasts from matrix PASTIS
 
-    log.info("RMS range: {} nm".format(rms_range, fmt="%e"))
+    log.info("WFE RMS range: {} nm".format(rms_range, fmt="%e"))
     log.info(f"Random realizations: {no_realizations}")
 
     for i, rms in enumerate(rms_range):

--- a/pastis/hockeystick_contrast_curve.py
+++ b/pastis/hockeystick_contrast_curve.py
@@ -143,13 +143,10 @@ def hockeystick_curve(instrument, apodizer_choice=None, matrixdir='', resultdir=
     # Keep track of time
     start_time = time.time()
 
-    ##########################
     # Create range of WFE RMS values to test
-    if instrument == 'LUVOIR':
-        rms_range = np.logspace(-4, 4, range_points)
-    if instrument == 'HiCAT':
-        rms_range = np.logspace(-1, 3, range_points)
-    ##########################
+    rms_range = np.logspace(CONFIG_INI.getfloat(instrument, 'valid_range_lower'),
+                            CONFIG_INI.getfloat(instrument, 'valid_range_upper'),
+                            range_points)
 
     # Create results directory if it doesn't exist yet
     os.makedirs(resultdir, exist_ok=True)

--- a/pastis/launchers/run_hicat.py
+++ b/pastis/launchers/run_hicat.py
@@ -27,4 +27,4 @@ if __name__ == '__main__':
     hockeystick_curve(instrument='HiCAT', matrixdir=matrix_dir, resultdir=result_dir, range_points=50, no_realizations=20)
 
     # Finally run the analysis
-    run_full_pastis_analysis(instrument='HiCAT', design='small', run_choice=dir_run)
+    run_full_pastis_analysis(instrument='HiCAT', run_choice=dir_run, c_target=1e-7)

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -283,7 +283,7 @@ def calculate_segment_constraints(pmodes, pastismatrix, c_target, coronagraph_fl
 
     # Calculate segment requirements
     mu_map = np.sqrt(
-        ((c_target - coronagraph_floor) / nmodes) / (np.dot(c_avg - coronagraph_floor, np.square(modestosegs))))
+        ((c_target - coronagraph_floor) / nmodes) / (np.dot(np.array(c_avg) - coronagraph_floor, np.square(modestosegs))))
 
     return mu_map
 
@@ -395,8 +395,8 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
     calculate_modes = False
     calculate_sigmas = False
     run_monte_carlo_modes = False
-    calc_cumulative_contrast = True
-    calculate_mus = False
+    calc_cumulative_contrast = False
+    calculate_mus = True
     run_monte_carlo_segments = False
     calculate_covariance_matrices = False
     analytical_statistics = False
@@ -555,11 +555,8 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
         mus = calculate_segment_constraints(pmodes, matrix, c_target, coro_floor)
         np.savetxt(os.path.join(workdir, 'results', f'segment_requirements_{c_target}.txt'), mus)
 
-        # Put mus on SM and plot
-        wf_constraints = util.apply_mode_to_luvoir(mus, luvoir)
-
         ppl.plot_segment_weights(mus, out_dir=os.path.join(workdir, 'results'), c_target=c_target, save=True)
-        ppl.plot_mu_map(mus, out_dir=os.path.join(workdir, 'results'), design=design, c_target=c_target, save=True)
+        ppl.plot_mu_map(instrument, mus, sim_instance, out_dir=os.path.join(workdir, 'results'), design=design, c_target=c_target, save=True)
     else:
         log.info(f'Reading mus from {workdir}')
         mus = np.loadtxt(os.path.join(workdir, 'results', f'segment_requirements_{c_target}.txt'))

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -97,13 +97,11 @@ def full_modes_from_themselves(instrument, pmodes, datadir, sim_instance, saving
 
         if instrument == "LUVOIR":
             log.info(f'Working on mode {thismode}/{nseg}.')
-
             wf_sm = util.apply_mode_to_luvoir(pmodes[:, i], sim_instance)
             all_modes.append((wf_sm.phase / wf_sm.wavenumber).shaped)   # wf_sm.phase is in rad, so this converts it to meters
 
         if instrument == 'HiCAT':
             log.info(f'Working on mode {thismode}/{nseg-1}.')
-
             for segnum in range(nseg):
                 sim_instance.iris_dm.set_actuator(segnum, pmodes[segnum, i] / 1e9, 0, 0)   # /1e9 converts to meters
             psf, inter = sim_instance.calc_psf(return_intermediates=True)
@@ -201,7 +199,7 @@ def cumulative_contrast_e2e(instrument, pmodes, sigmas, sim_instance, dh_mask, n
     :param sigmas: array, weights per PASTIS mode
     :param sim_instance: class instance of the simulator for "instrument"
     :param dh_mask: hcipy.Field, dh_mask that goes together with the instance of the LUVOIR simulator
-        :param norm_direct: float, normalization factor for PSF; peak of unaberrated direct PSF
+    :param norm_direct: float, normalization factor for PSF; peak of unaberrated direct PSF
     :param individual: bool, if False (default), calculates cumulative contrast, if True, calculates contrast per mode
     :return: cont_cum_e2e, list of cumulative or individual contrasts
     """

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -368,8 +368,8 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
     """
 
     # Which parts are we running?
-    calculate_modes = True
-    calculate_sigmas = False
+    calculate_modes = False
+    calculate_sigmas = True
     run_monte_carlo_modes = False
     calc_cumulative_contrast = False
     calculate_mus = False
@@ -467,7 +467,7 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
         np.savetxt(os.path.join(workdir, 'results', f'mode_requirements_{c_target}_uniform.txt'), sigmas)
 
         # Plot static mode constraints
-        ppl.plot_mode_weights_simple(sigmas, wvln=CONFIG_INI.getfloat('LUVOIR', 'lambda'),
+        ppl.plot_mode_weights_simple(sigmas, wvln=CONFIG_INI.getfloat(instrument, 'lambda'),
                                      out_dir=os.path.join(workdir, 'results'),
                                      c_target=c_target,
                                      fname_suffix='uniform',

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -659,6 +659,7 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
         log.info('Calculating segment-based error budget.')
 
         # Extract segment-based mode weights
+        log.info('Calculate segment-based mode weights')
         sigmas_opt = np.sqrt(np.diag(Cb))
         np.savetxt(os.path.join(workdir, 'results', f'mode_requirements_{c_target}_segment-based.txt'), sigmas_opt)
         ppl.plot_mode_weights_simple(sigmas_opt, wvln, out_dir=os.path.join(workdir, 'results'), c_target=c_target,
@@ -669,6 +670,7 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
                                           alphas=(0.5, 1.), linestyles=('--', '-'), colors=('k', 'r'), save=True)
 
         # Calculate contrast per mode
+        log.info('Calculating contrast per mode')
         per_mode_opt_e2e = cumulative_contrast_e2e(instrument, pmodes, sigmas_opt, sim_instance, dh_mask, norm, individual=True)
         np.savetxt(os.path.join(workdir, 'results', f'contrast_per_mode_{c_target}_e2e_segment-based.txt'),
                    per_mode_opt_e2e)
@@ -676,6 +678,7 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
                                    os.path.join(workdir, 'results'), save=True)
 
         # Calculate segment-based cumulative contrast
+        log.info('Calculating segment-based cumulative contrast')
         cumulative_opt_e2e = cumulative_contrast_e2e(instrument, pmodes, sigmas_opt, sim_instance, dh_mask, norm)
         np.savetxt(os.path.join(workdir, 'results', f'cumul_contrast_allocation_e2e_{c_target}_segment-based.txt'),
                    cumulative_opt_e2e)

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -619,8 +619,8 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
 
     else:
         log.info('Loading covariance matrices from disk.')
-        Ca = fits.getdata(os.path.join(workdir, 'results', f'cov_matrix_segments_Ca_{c_target}.fits'))
-        Cb = fits.getdata(os.path.join(workdir, 'results', f'cov_matrix_modes_Cb_{c_target}.fits'))
+        Ca = fits.getdata(os.path.join(workdir, 'results', f'cov_matrix_segments_Ca_{c_target}_segment-based.fits'))
+        Cb = fits.getdata(os.path.join(workdir, 'results', f'cov_matrix_modes_Cb_{c_target}_segment-based.fits'))
 
     ### Analytically calculate statistical mean contrast and its variance
     if analytical_statistics:

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -397,15 +397,15 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
     """
 
     # Which parts are we running?
-    calculate_modes = False
-    calculate_sigmas = False
-    run_monte_carlo_modes = False
-    calc_cumulative_contrast = False
-    calculate_mus = False
+    calculate_modes = True
+    calculate_sigmas = True
+    run_monte_carlo_modes = True
+    calc_cumulative_contrast = True
+    calculate_mus = True
     run_monte_carlo_segments = True
-    calculate_covariance_matrices = False
-    analytical_statistics = False
-    calculate_segment_based = False
+    calculate_covariance_matrices = True
+    analytical_statistics = True
+    calculate_segment_based = True
 
     # Data directory
     workdir = os.path.join(CONFIG_INI.get('local', 'local_data_path'), run_choice)

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -304,7 +304,6 @@ def calc_random_segment_configuration(instrument, sim_instance, mus, dh_mask, no
     segments_random_state = np.random.RandomState()
     rand = segments_random_state.normal(0, 1, mus.shape[0])
 
-    mus *= u.nm
     random_map = []
 
     # Multiply each segment mu by one of these random numbers,
@@ -585,6 +584,7 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
     else:
         log.info(f'Reading mus from {workdir}')
         mus = np.loadtxt(os.path.join(workdir, 'results', f'segment_requirements_{c_target}.txt'))
+        mus *= u.nm
 
     ### Calculate Monte Carlo confirmation for segments, with E2E
     if run_monte_carlo_segments:

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -127,7 +127,10 @@ def full_modes_from_themselves(instrument, pmodes, datadir, sim_instance, saving
         log.info('Saving all PASTIS modes...')
         plt.figure(figsize=(36, 30))
         for i, thismode in enumerate(seglist):
-            plt.subplot(12, 10, i + 1)
+            if instrument == 'LUVOIR':
+                plt.subplot(12, 10, i + 1)
+            if instrument == 'HiCAT':
+                plt.subplot(8, 5, i + 1)
             plt.imshow(all_modes[i], cmap='RdBu')
             plt.axis('off')
             plt.title(f'Mode {thismode}')

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -496,7 +496,7 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
         np.savetxt(os.path.join(workdir, 'results', f'mode_requirements_{c_target}_uniform.txt'), sigmas)
 
         # Plot static mode constraints
-        ppl.plot_mode_weights_simple(sigmas, wvln=CONFIG_INI.getfloat(instrument, 'lambda'),
+        ppl.plot_mode_weights_simple(sigmas, wvln,
                                      out_dir=os.path.join(workdir, 'results'),
                                      c_target=c_target,
                                      fname_suffix='uniform',

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -332,8 +332,9 @@ def calc_random_mode_configurations(instrument, pmodes, sim_instance, sigmas, dh
              rand_contrast: float, mean contrast of the calculated PSF
     """
 
-    # Create normal distribution
-    rand = np.random.normal(0, 1, sigmas.shape[0])
+    # Create a random number generator
+    this_rng = np.random.RandomState()
+    rand = this_rng.normal(0, 1, sigmas.shape[0])
     random_weights = sigmas * rand
 
     # Sum up all modes with randomly scaled sigmas to make total OPD

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -137,7 +137,7 @@ def full_modes_from_themselves(instrument, pmodes, datadir, sim_instance, saving
     for i, thismode in enumerate(seglist):
         # pdf
         plt.clf()
-        plt.imshow(all_modes[i], cmap='RdBu')
+        plt.imshow(all_modes[i], cmap='RdBu')    # TODO: this is now super slow for LUVOIR, using hcipy was way faster. Change back in LUVOIR case?
         plt.axis('off')
         plt.title(f'Mode {thismode}', size=30)
         if saving:

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -373,7 +373,7 @@ def calc_random_mode_configurations(instrument, pmodes, sim_instance, sigmas, dh
     return random_weights, rand_contrast
 
 
-def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_repeat=100):
+def run_full_pastis_analysis(instrument, run_choice, design=None, c_target=1e-10, n_repeat=100):
     """
     Run a full PASTIS analysis on a given PASTIS matrix.
 
@@ -389,8 +389,9 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
     9. calculting segment-based error budget
 
     :param instrument: str, "LUVOIR" or "HiCAT"
-    :param design: str, "small", "medium" or "large" LUVOIR-A APLC design
     :param run_choice: str, path to data and where outputs will be saved
+    :param design: str, optional, default=None, which means we read from the configfile: what coronagraph design
+               to use - 'small', 'medium' or 'large'
     :param c_target: float, target contrast
     :param n_repeat: number of realizations in both Monte Carlo simulations (modes and segments), default=100
     """
@@ -420,6 +421,10 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
     # TODO: replace this section with calculate_unaberrated_contrast_and_normalization(). This will require to save out
     # reference and unaberrated coronagraphic PSF already in matrix generation.
     if instrument == "LUVOIR":
+        if design is None:
+            design = CONFIG_INI.get('LUVOIR', 'coronagraph_design')
+            log.info(f'Coronagraph design: {design}')
+
         sampling = CONFIG_INI.getfloat('LUVOIR', 'sampling')
         optics_input = CONFIG_INI.get('LUVOIR', 'optics_path')
         luvoir = LuvoirAPLC(optics_input, design, sampling)
@@ -689,15 +694,14 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
 
     ### DONE
     log.info(f"All saved in {os.path.join(workdir, 'results')}")
-    log.info('\nGood job')
+    log.info('Good job')
 
 
 if __name__ == '__main__':
 
     instrument = CONFIG_INI.get('telescope', 'name')
-    coro_design = CONFIG_INI.get('LUVOIR', 'coronagraph_design')
     run = CONFIG_INI.get('numerical', 'current_analysis')
     c_target = 1e-10
     mc_repeat = 100
 
-    run_full_pastis_analysis(instrument, coro_design, run_choice=run, c_target=c_target, n_repeat=mc_repeat)
+    run_full_pastis_analysis(instrument, run_choice=run, c_target=c_target, n_repeat=mc_repeat)

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -627,6 +627,8 @@ def run_full_pastis_analysis(instrument, design, run_choice, c_target=1e-10, n_r
         log.info('Calculating analytical statistics.')
         mean_stat_c = util.calc_statistical_mean_contrast(matrix, Ca, coro_floor)
         var_c = util.calc_variance_of_mean_contrast(matrix, Ca)
+        log.info(f'Analytical statistical mean: {mean_stat_c}')
+        log.info(f'Analytical standard deviation: {var_c}')
 
         with open(os.path.join(workdir, 'results', f'statistical_contrast_analytical_{c_target}.txt'), 'w') as file:
             file.write(f'Analytical, statistical mean: {mean_stat_c}')

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -412,9 +412,11 @@ def plot_mu_map(instrument, mus, sim_instance, out_dir, design, c_target, limits
         fname += f'_{fname_suffix}'
 
     if instrument == 'LUVOIR':
+        sim_instance.flatten()
         wf_constraints = apply_mode_to_luvoir(mus, sim_instance)
         map_small = (wf_constraints.phase / wf_constraints.wavenumber * 1e12).shaped  # in picometers
     if instrument == 'HiCAT':
+        sim_instance.iris_dm.flatten()
         for segnum in range(CONFIG_INI.getint(instrument, 'nb_subapertures')):
             sim_instance.iris_dm.set_actuator(segnum, mus[segnum] / 1e9, 0, 0)  # /1e9 converts to meters
         psf, inter = sim_instance.calc_psf(return_intermediates=True)


### PR DESCRIPTION
Follow up to #40.

Rewrite the PASTIS analysis script such that it can do both HiCAT and LUVOIR.
Note: I am ignoring that the label positions in the plots will be wrong for the HiCAT results and hence won't show up. I will deal with this at a later point.

- [x] make the PASTIS analysis work for HiCAT
    - [x] create modes
    - [x] calculate mode constraints
    - [x] calculate cumulative contrast
    - [x] calculate segment constraints
    - [x] run Monte Carlo simulations
    - [x] plot results
    - [x] calculate covariance matrices
    - [x] calculate analytical analysis
    - [x] segment based error budget
- [x] implement instances of numpy's random number generator (`numpy.random.RandomState`) to avoid specified seed from HiCAT simulator
- [x] move hard-coded strings for LUVOIR optics from simulator script to configfile
- [x] move WFE RMS ranges in hockeystick for LUVOIR and HiCAT form hard-coded to configfile