### PR TITLE
Implement simple symmetric matrix and copy HiCAT BostonDM maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ directory structure is as follows:
 |      |-- OTE_images
 |          |-- opd[...].pdf                      # PDF images of each segment pair aberration in the pupil
 |          |-- ...
-|      |-- pair-wise_contrasts.txt:              # list of E2E DH average contrasts per aberrated segment pair
+|      |-- pair-wise_contrasts.fits:             # contrast matrix - E2E DH average contrasts per aberrated segment pair (only half of it since it is symmetric)
 |      |-- pastis_matrix.log                     # logging output of matrix calculation
 |      |-- PASTISmatrix_num_piston_Noll1.fits    # the PASTIS matrix
 |      |-- psfs

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -628,8 +628,7 @@ def num_matrix_multiprocess(instrument, design=None, savepsfs=True, saveopds=Tru
     mypool.close()
 
     # Save all contrasts to disk
-    all_contrasts = all_contrasts.ravel()
-    np.savetxt(os.path.join(resDir, 'pair-wise_contrasts.txt'), all_contrasts, fmt='%e')
+    hcipy.write_fits(all_contrasts, os.path.join(resDir, 'pair-wise_contrasts.fits'))
 
     # Filling the off-axis elements
     log.info('\nCalculating off-axis matrix elements...')

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -12,15 +12,13 @@ import os
 import time
 import functools
 from itertools import product
-from shutil import copy
-from astropy.io import fits
+import shutil
 import astropy.units as u
 import logging
 import matplotlib.pyplot as plt
 import multiprocessing
 import numpy as np
 import hcipy
-import hicat.simulators
 
 from config import CONFIG_INI
 import util_pastis as util
@@ -605,6 +603,9 @@ def num_matrix_multiprocess(instrument, design=None, savepsfs=True, saveopds=Tru
                                                   savepsfs, saveopds)
 
     if instrument == 'HiCAT':
+        # Copy used BostonDM maps to matrix folder
+        shutil.copytree(CONFIG_INI.get('HiCAT', 'dm_maps_path'), os.path.join(resDir, 'hicat_boston_dm_commands'))
+
         calculate_matrix_pair = functools.partial(_hicat_matrix_one_pair, norm, wfe_aber, resDir, savepsfs, saveopds)
 
     # Iterate over all segment pairs via a multiprocess pool

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -441,9 +441,9 @@ def copy_config(outdir):
     """
     print('Saving the configfile to outputs folder.')
     try:
-        copy('config_local.ini', outdir)
+        copy(os.path.join(CONFIG_INI.get('local', 'local_repo_path'), 'pastis', 'config_local.ini'), outdir)
     except IOError:
-        copy('config.ini', outdir)
+        copy(os.path.join(CONFIG_INI.get('local', 'local_repo_path'), 'pastis', 'config.ini'), outdir)
 
 
 def setup_pastis_logging(experiment_path, name):

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -4,6 +4,7 @@ Helper functions for PASTIS.
 
 import os
 import datetime
+import itertools
 import time
 from shutil import copy
 import sys
@@ -245,6 +246,49 @@ def read_continuous_dm_maps_hicat(path_to_dm_maps):
         surfaces.append(actuators_2d)
 
     return surfaces[0], surfaces[1]
+
+
+def segment_pairs_all(nseg):
+    """
+    Return a generator with all possible segment pairs, including repeating ones.
+
+    E.g. if segments are 0, 1, 2, then the returned pairs will be:
+    00, 01, 02, 10, 11, 12, 20, 21, 22
+    :param nseg: int, number of segments
+    :return:
+    """
+    return itertools.product(np.arange(nseg), np.arange(nseg))
+
+
+def segment_pairs_non_repeating(nseg):
+    """
+    Return a generator with all possible non-repeating segment pairs.
+
+    E.g. if segments are 0, 1, 2, then the returned pairs will be:
+    00, 01, 02, 11, 12, 22
+    :param nseg: int, number of segments
+    :return:
+    """
+    return itertools.combinations_with_replacement(np.arange(nseg), r=2)
+
+
+def symmetrize(array):
+    """
+    Return a symmetrized version of NumPy array a.
+
+    Values x are replaced by the array value at the symmetric
+    position (with respect to the diagonal), i.e. if a_ij = x,
+    then the returned array a' is such that a'_ij = a_ji.
+
+    Diagonal values are left untouched.
+
+    a -- square NumPy array, such that a_ij = x or a_ji = x,
+    for i != j.
+
+    Srouce:
+    https://stackoverflow.com/a/2573982/10112569
+    """
+    return array + array.T - np.diag(array.diagonal())
 
 
 def rms(ar):


### PR DESCRIPTION
In this small PR:
- [x] I make sure that the Boston DM maps used for the HiCAT coronagraph get saved together with the matrix output
- [ ] I rewrite the matrix calculation script to only calculate half of the matrix, including the diagonal, since it is symmetric. This should cut its calculation time by a factor of ~2
- [x] save the contrast matrix as `pair-wise_contrasts.fits` rather than ravelled in `pair-wise_contrasts.txt`

Note that I am not doing any further optimization in the matrix calculation, I am still carrying the full matrix around in memory. This change just makes sure I don't do unnecessary coronagraph propagations.