### PR TITLE
Save HiCAT BostonDM maps during matrix generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ directory structure is as follows:
 |      |-- OTE_images
 |          |-- opd[...].pdf                      # PDF images of each segment pair aberration in the pupil
 |          |-- ...
-|      |-- pair-wise_contrasts.txt:              # list of E2E DH average contrasts per aberrated segment pair
+|      |-- pair-wise_contrasts.fits:             # contrast matrix - E2E DH average contrasts per aberrated segment pair (only half of it since it is symmetric)
 |      |-- pastis_matrix.log                     # logging output of matrix calculation
 |      |-- PASTISmatrix_num_piston_Noll1.fits    # the PASTIS matrix
 |      |-- psfs

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -628,8 +628,7 @@ def num_matrix_multiprocess(instrument, design=None, savepsfs=True, saveopds=Tru
     mypool.close()
 
     # Save all contrasts to disk
-    all_contrasts = all_contrasts.ravel()
-    np.savetxt(os.path.join(resDir, 'pair-wise_contrasts.txt'), all_contrasts, fmt='%e')
+    hcipy.write_fits(all_contrasts, os.path.join(resDir, 'pair-wise_contrasts.fits'))
 
     # Filling the off-axis elements
     log.info('\nCalculating off-axis matrix elements...')

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -12,15 +12,13 @@ import os
 import time
 import functools
 from itertools import product
-from shutil import copy
-from astropy.io import fits
+import shutil
 import astropy.units as u
 import logging
 import matplotlib.pyplot as plt
 import multiprocessing
 import numpy as np
 import hcipy
-import hicat.simulators
 
 from config import CONFIG_INI
 import util_pastis as util
@@ -605,6 +603,9 @@ def num_matrix_multiprocess(instrument, design=None, savepsfs=True, saveopds=Tru
                                                   savepsfs, saveopds)
 
     if instrument == 'HiCAT':
+        # Copy used BostonDM maps to matrix folder
+        shutil.copytree(CONFIG_INI.get('HiCAT', 'dm_maps_path'), os.path.join(resDir, 'hicat_boston_dm_commands'))
+
         calculate_matrix_pair = functools.partial(_hicat_matrix_one_pair, norm, wfe_aber, resDir, savepsfs, saveopds)
 
     # Iterate over all segment pairs via a multiprocess pool

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -397,9 +397,9 @@ def copy_config(outdir):
     """
     print('Saving the configfile to outputs folder.')
     try:
-        copy('config_local.ini', outdir)
+        copy(os.path.join(CONFIG_INI.get('local', 'local_repo_path'), 'pastis', 'config_local.ini'), outdir)
     except IOError:
-        copy('config.ini', outdir)
+        copy(os.path.join(CONFIG_INI.get('local', 'local_repo_path'), 'pastis', 'config.ini'), outdir)
 
 
 def setup_pastis_logging(experiment_path, name):


### PR DESCRIPTION
- make sure that the Boston DM maps used for the HiCAT coronagraph get saved together with the matrix output
- pass the full repo path to the function that copies the configfile