### PR TITLE
Implement simple symmetric matrix with non-repeating segment pairs

### DIFF
--- a/Jupyter Notebooks/HiCAT/19_comparison matrices less pairs.ipynb
+++ b/Jupyter Notebooks/HiCAT/19_comparison matrices less pairs.ipynb
@@ -37,7 +37,7 @@
    "source": [
     "# Define directories\n",
     "dir_standard = '2020-09-02T10-59-17_hicat'\n",
-    "dir_new = '2020-09-02T14-50-44_hicat'\n",
+    "dir_new = '2020-09-02T18-08-16_hicat'\n",
     "\n",
     "# Define matrix name\n",
     "matrix_name = 'PASTISmatrix_num_piston_Noll1.fits'\n",

--- a/Jupyter Notebooks/HiCAT/19_comparison matrices less pairs.ipynb
+++ b/Jupyter Notebooks/HiCAT/19_comparison matrices less pairs.ipynb
@@ -37,7 +37,7 @@
    "source": [
     "# Define directories\n",
     "dir_standard = '2020-09-02T10-59-17_hicat'\n",
-    "dir_new = '2020-09-02T11-31-56_hicat'\n",
+    "dir_new = '2020-09-02T14-50-44_hicat'\n",
     "\n",
     "# Define matrix name\n",
     "matrix_name = 'PASTISmatrix_num_piston_Noll1.fits'\n",
@@ -172,7 +172,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's noisy, but at a very low level and seems random. Let's see if I can just use the original contast matrix, use *its* upper triangle (lower right in these figures) and recreate itself."
+    "### Check the matrix transposes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(np.all(mat_stand) == np.all(mat_stand.T))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(np.all(mat_new) == np.all(mat_new.T))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(np.all(con_stand) == np.all(con_stand.T))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(np.all(con_new_symm) == np.all(con_new_symm.T))"
    ]
   },
   {
@@ -232,9 +268,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's also noisy, so this will just be from the different noise realizations in the HiCAT simulator from two different cases. This is fine. Moving on.\n",
-    "\n",
-    "Symmetrize this."
+    "### Symmetrize this"
    ]
   },
   {
@@ -278,8 +312,214 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Good! Moving on."
+    "## Compare the half original contrst matrix to new contrsat matrix\n",
+    "... which is only half anyway"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot both contrast matrices\n",
+    "plt.figure(figsize=(18, 9))\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.imshow(con_orig_half)#, norm=LogNorm())\n",
+    "plt.colorbar()\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.imshow(con_new)#, norm=LogNorm())\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot their difference\n",
+    "print(np.sum(con_orig_half - con_new))\n",
+    "plt.imshow(np.log10(con_orig_half - con_new))\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Good! We can confirm that both methods produce exactly the same contrast matrix that gets saved to disk, except that the new one is only half filled. Neither of them have had the coronagraph floor subtracted yet.\n",
+    "\n",
+    "Moving on."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare off-axis matrices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load both matrices\n",
+    "off_name = 'off_axis_matrix.fits'\n",
+    "off_dir_stand = '2020-09-02T16-44-03_hicat'\n",
+    "off_dir_new = '2020-09-02T17-48-47_hicat'\n",
+    "\n",
+    "off_stand = fits.getdata(os.path.join(datadir, off_dir_stand, 'matrix_numerical', off_name))\n",
+    "off_new = fits.getdata(os.path.join(datadir, off_dir_new, 'matrix_numerical', off_name))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot both contrast matrices\n",
+    "plt.figure(figsize=(18, 9))\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.imshow(off_stand)#, norm=LogNorm())\n",
+    "plt.colorbar()\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.imshow(off_new)#, norm=LogNorm())\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot their difference\n",
+    "print(np.sum(off_stand - off_new))\n",
+    "plt.imshow(np.log10(off_stand - off_new))\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Symmetrize the new one and try again"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "off_new_sym = util.symmetrize(off_new)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot both contrast matrices\n",
+    "plt.figure(figsize=(18, 9))\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.imshow(off_stand)#, norm=LogNorm())\n",
+    "plt.colorbar()\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.imshow(off_new_sym)#, norm=LogNorm())\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot their difference\n",
+    "print(np.sum(off_stand - off_new_sym))\n",
+    "plt.imshow(np.log10(off_stand - off_new_sym))\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WHOOOOO!!\n",
+    "\n",
+    "## It works!\n",
+    "\n",
+    "Rest below here was just other things I was playing around with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load coronagraph floor and subtract"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "floor_name = 'coronagraph_floor.txt'\n",
+    "floor_orig_path = os.path.join(datadir, dir_standard, floor_name)\n",
+    "floor_new_path = os.path.join(datadir, dir_new, floor_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_coro_floor_from_txt(filename):\n",
+    "    with open(filename, 'r') as file:\n",
+    "        full = file.read()\n",
+    "    return float(full[19:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "floor_orig = read_coro_floor_from_txt(floor_orig_path)\n",
+    "floor_new = read_coro_floor_from_txt(floor_new_path)\n",
+    "print(f'floor_orig: {floor_orig}')\n",
+    "print(f'floor_new: {floor_new}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ directory structure is as follows:
 |      |-- OTE_images
 |          |-- opd[...].pdf                      # PDF images of each segment pair aberration in the pupil
 |          |-- ...
-|      |-- pair-wise_contrasts.fits:             # contrast matrix - E2E DH average contrasts per aberrated segment pair (only half of it since it is symmetric), contrast floor is not subtracted yet
+|      |-- pair-wise_contrasts.fits:             # contrast matrix - E2E DH average contrasts per aberrated segment pair (only half of it since it is symmetric), contrast floor is already subtracted
 |      |-- pastis_matrix.log                     # logging output of matrix calculation
 |      |-- PASTISmatrix_num_piston_Noll1.fits    # the PASTIS matrix
 |      |-- psfs

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -550,6 +550,7 @@ def pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber):
     coronagraph floor already needs to be subtracted from it at this point though.
     This function calculates the off-axis elements of the PASTIS matrix and then normalizes it by the calibration
     aberration to get a matrix with units of contrast / nm^2.
+    Finally, it symmetrizes the matrix to output the full PASTIS matrix.
 
     :param contrast_matrix: nd.array, nseg x nseg matrix holding DH mean contast values of all aberrated segment pairs,
                             with the coro floor already subtracted, but only half of the matrix has non-zero values
@@ -559,7 +560,10 @@ def pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber):
     """
 
     # Calculate the off-axis elements in the PASTIS matrix
-    matrix_pastis = calculate_off_axis_elements(contrast_matrix, seglist)
+    matrix_pastis_half = calculate_off_axis_elements(contrast_matrix, seglist)
+
+    # Symmetrize the half-PASTIS matrix
+    matrix_pastis = util.symmetrize(matrix_pastis_half)
 
     # Normalize matrix for the input aberration - this defines what units the PASTIS matrix will be in. The PASTIS
     # matrix propagation function (util.pastis_contrast()) then needs to take in the aberration vector in these same

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -544,10 +544,10 @@ def pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber):
     """
     Calculate the final PASTIS matrix from the input contrast matrix (coro floor already subtracted, but only half filled).
 
-    The contrast matrix is a nseg x nseg matrix where only half of it is filled, it's lower half (np.tril(C)). It holds
-    the DH mean contrast values of each aberrated segment pair, with an WFE amplitude of the calibration
-    aberration wfe_aber, in m. Hence, the input contrast matrix is not normalized to the desired units yet. The
-    coronagraph floor already needs to be subtracted from it at this point though.
+    The contrast matrix is a nseg x nseg matrix where only half of it is filled, including the diagonal, and the other
+    half is filled with zeros. It holds the DH mean contrast values of each aberrated segment pair, with an WFE
+    amplitude of the calibration aberration wfe_aber, in m. Hence, the input contrast matrix is not normalized to the
+    desired units yet. The coronagraph floor already needs to be subtracted from it at this point though.
     This function calculates the off-axis elements of the PASTIS matrix and then normalizes it by the calibration
     aberration to get a matrix with units of contrast / nm^2.
     Finally, it symmetrizes the matrix to output the full PASTIS matrix.
@@ -583,7 +583,7 @@ def calculate_off_axis_elements(contrast_matrix, seglist):
     :param contrast_matrix: nd.array, nseg x nseg matrix holding DH mean contast values of all aberrated segment pairs,
                             with the coro floor already subtracted
     :param seglist: list of segment indices (e.g. 0, 1, 2, ...36 [HiCAT]; or 1, 2, ..., 120 [LUVOIR])
-    :return: unnormalized half PASTIS matrix, nd.array of nseg x nseg where its lower triangle (np.tril(M)) will be all zeros
+    :return: unnormalized half PASTIS matrix, nd.array of nseg x nseg where one of its matrix triangles will be all zeros
     """
 
     # Create future (half filled) PASTIS matrix

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -705,15 +705,14 @@ def num_matrix_multiprocess(instrument, design=None, savepsfs=True, saveopds=Tru
 
     # Unscramble results
     # results is a list of tuples that contain the return from the partial function, in this case: result[i] = (c, (seg1, seg2))
-    all_contrasts = np.zeros([nb_seg, nb_seg])  # Generate empty matrix
+    contrast_matrix = np.zeros([nb_seg, nb_seg])  # Generate empty matrix
     for i in range(len(results)):
         # Fill according entry in the matrix and subtract baseline contrast
-        all_contrasts[results[i][1][0], results[i][1][1]] = results[i][0]
-    contrast_matrix = all_contrasts - contrast_floor
+        contrast_matrix[results[i][1][0], results[i][1][1]] = results[i][0] - contrast_floor
     mypool.close()
 
-    # Save all contrasts to disk, WITHOUT subtraction of coronagraph floor
-    hcipy.write_fits(all_contrasts, os.path.join(resDir, 'pair-wise_contrasts.fits'))
+    # Save all contrasts to disk, WITH subtraction of coronagraph floor
+    hcipy.write_fits(contrast_matrix, os.path.join(resDir, 'pair-wise_contrasts.fits'))
 
     # Calculate the PASTIS matrix from the contrast matrix: off-axis elements and normalization
     matrix_pastis = pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber)

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -648,6 +648,8 @@ def num_matrix_multiprocess(instrument, design=None, savepsfs=True, saveopds=Tru
     log.info(f'Number of segments: {nb_seg}')
     log.info(f'Segment list: {seglist}')
     log.info(f'wfe_aber: {wfe_aber} m')
+    log.info(f'Total number of segment pairs in {instrument} pupil: {len(list(util.segment_pairs_all(nb_seg)))}')
+    log.info(f'Non-repeating pairs in {instrument} pupil calculated here: {len(list(util.segment_pairs_non_repeating(nb_seg)))}')
 
     #  Copy configfile to resulting matrix directory
     util.copy_config(resDir)

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -11,7 +11,6 @@ This module contains functions that construct the matrix M for PASTIS *NUMERICAL
 import os
 import time
 import functools
-from itertools import product
 import shutil
 import astropy.units as u
 import logging
@@ -692,7 +691,7 @@ def num_matrix_multiprocess(instrument, design=None, savepsfs=True, saveopds=Tru
     # Iterate over all segment pairs via a multiprocess pool
     mypool = multiprocessing.Pool(num_processes)
     t_start = time.time()
-    results = mypool.map(calculate_matrix_pair, product(np.arange(nb_seg), np.arange(nb_seg)))
+    results = mypool.map(calculate_matrix_pair, util.segment_pairs_non_repeating(nb_seg))    # this util function returns a generator
     t_stop = time.time()
 
     log.info(f"Multiprocess calculation complete in {t_stop-t_start}sec = {(t_stop-t_start)/60}min")

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -560,9 +560,11 @@ def pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber):
     """
 
     # Calculate the off-axis elements in the PASTIS matrix
+    log.info('Calculating off-axis elements of PASTIS matrix')
     matrix_pastis_half = calculate_off_axis_elements(contrast_matrix, seglist)
 
     # Symmetrize the half-PASTIS matrix
+    log.info('Symmetrizing PASTIS matrix')
     matrix_pastis = util.symmetrize(matrix_pastis_half)
 
     # Normalize matrix for the input aberration - this defines what units the PASTIS matrix will be in. The PASTIS

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -278,20 +278,12 @@ def segment_pairs_non_repeating(nseg):
 def symmetrize(array):
     """
     Return a symmetrized version of NumPy array a.
+    This assumes that the other half of the array only contains zeros.
 
-    Values x are replaced by the array value at the symmetric
-    position (with respect to the diagonal), i.e. if a_ij = x,
-    then the returned array a' is such that a'_ij = a_ji.
-
-    Diagonal values are left untouched.
-
-    a -- square NumPy array, such that a_ij = x or a_ji = x,
-    for i != j.
-
-    Srouce:
-    https://stackoverflow.com/a/2573982/10112569
+    :param array: nd.array with filled diagonal and upper triangle (np.triu(array)). Lower triangle is zero.
+    :return symemtric array
     """
-    return array + array.T - np.diag(array.diagonal())
+    return array.T + np.triu(array, 1)
 
 
 def rms(ar):

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -278,12 +278,18 @@ def segment_pairs_non_repeating(nseg):
 def symmetrize(array):
     """
     Return a symmetrized version of NumPy array a.
-    This assumes that the other half of the array only contains zeros.
 
-    :param array: nd.array with filled diagonal and upper triangle (np.triu(array)). Lower triangle is zero.
-    :return symemtric array
+    Values 0 are replaced by the array value at the symmetric
+    position (with respect to the diagonal), i.e. if a_ij = 0,
+    then the returned array a' is such that a'_ij = a_ji.
+    Diagonal values are left untouched.
+    :param array: square NumPy array, such that a_ij = 0 or a_ji = 0,
+    for i != j.
+
+    Source:
+    https://stackoverflow.com/a/2573982/10112569
     """
-    return array.T + np.triu(array, 1)
+    return array + array.T - np.diag(array.diagonal())
 
 
 def read_coro_floor_from_txt(datadir):

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -286,6 +286,17 @@ def symmetrize(array):
     return array.T + np.triu(array, 1)
 
 
+def read_coro_floor_from_txt(datadir):
+    """
+    Read the coro floor as float from the output file in the data directory.
+    :param datadir: str, path to data directory
+    :return: coronagraph floor as float
+    """
+    with open(os.path.join(datadir, 'coronagraph_floor.txt'), 'r') as file:
+        full = file.read()
+    return float(full[19:])
+
+
 def rms(ar):
     """
     Manual root-mean-square calculation, assuming a zero-mean

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -5,6 +5,7 @@ Helper functions for PASTIS.
 import glob
 import os
 import datetime
+import itertools
 import time
 from shutil import copy
 import sys
@@ -248,6 +249,49 @@ def read_continuous_dm_maps_hicat(path_to_dm_maps):
         surfaces.append(actuators_2d)
 
     return surfaces[0], surfaces[1]
+
+
+def segment_pairs_all(nseg):
+    """
+    Return a generator with all possible segment pairs, including repeating ones.
+
+    E.g. if segments are 0, 1, 2, then the returned pairs will be:
+    00, 01, 02, 10, 11, 12, 20, 21, 22
+    :param nseg: int, number of segments
+    :return:
+    """
+    return itertools.product(np.arange(nseg), np.arange(nseg))
+
+
+def segment_pairs_non_repeating(nseg):
+    """
+    Return a generator with all possible non-repeating segment pairs.
+
+    E.g. if segments are 0, 1, 2, then the returned pairs will be:
+    00, 01, 02, 11, 12, 22
+    :param nseg: int, number of segments
+    :return:
+    """
+    return itertools.combinations_with_replacement(np.arange(nseg), r=2)
+
+
+def symmetrize(array):
+    """
+    Return a symmetrized version of NumPy array a.
+
+    Values x are replaced by the array value at the symmetric
+    position (with respect to the diagonal), i.e. if a_ij = x,
+    then the returned array a' is such that a'_ij = a_ji.
+
+    Diagonal values are left untouched.
+
+    a -- square NumPy array, such that a_ij = x or a_ji = x,
+    for i != j.
+
+    Srouce:
+    https://stackoverflow.com/a/2573982/10112569
+    """
+    return array + array.T - np.diag(array.diagonal())
 
 
 def rms(ar):


### PR DESCRIPTION
Continues where I found a discrepancy in #43.

Rewrite the matrix calculation script to only calculate half of the matrix, including the diagonal, since it is symmetric. This should cut its calculation time by a factor of ~2.

Note that I am not doing any further optimization in the matrix calculation, I am still carrying the full matrix around in memory. This change just makes sure I don't do unnecessary coronagraph propagations.