### PR TITLE
Add focal plane mode saving and move some other outputs

### DIFF
--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -395,7 +395,7 @@ def calculate_unaberrated_contrast_and_normalization(instrument, design=None, re
         iwa = CONFIG_INI.getfloat('HiCAT', 'IWA')
         owa = CONFIG_INI.getfloat('HiCAT', 'OWA')
         sampling = CONFIG_INI.getfloat('HiCAT', 'sampling')
-        dh_mask = util.create_dark_hole(coro_psf, iwa, owa, sampling)
+        dh_mask = util.create_dark_hole(coro_psf, iwa, owa, sampling).astype('bool')
 
         # Return the coronagraphic simulator
         coro_simulator = hicat_sim

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -10,9 +10,7 @@ from astropy.io import fits
 import astropy.units as u
 import logging
 import matplotlib.pyplot as plt
-from matplotlib.colors import LogNorm
 import hcipy
-from hcipy.optics.segmented_mirror import SegmentedMirror
 
 from config import CONFIG_INI
 from e2e_simulators.hicat_imaging import set_up_hicat
@@ -460,21 +458,6 @@ def run_full_pastis_analysis(instrument, run_choice, design=None, c_target=1e-10
     # Calculate coronagraph contrast floor
     coro_floor = util.dh_mean(psf_unaber, dh_mask)
     log.info(f'Coronagraph floor: {coro_floor}')
-    with open(os.path.join(workdir, 'coronagraph_floor.txt'), 'w') as file:
-        file.write(f'{coro_floor}')
-
-    # Plot unaberrated coronagraph PSF
-    plt.figure()
-    plt.subplot(1, 3, 1)
-    plt.title("Dark hole mask")
-    plt.imshow(dh_mask)
-    plt.subplot(1, 3, 2)
-    plt.title("Unaberrated coro PSF")
-    plt.imshow(psf_unaber, norm=LogNorm())
-    plt.subplot(1, 3, 3)
-    plt.title("Unaberrated coro PSF (masked)")
-    plt.imshow(np.ma.masked_where(~dh_mask, psf_unaber), norm=LogNorm())
-    plt.savefig(os.path.join(workdir, 'unaberrated_dh.pdf'))
 
     # Read the PASTIS matrix
     matrix = fits.getdata(os.path.join(workdir, 'matrix_numerical', 'PASTISmatrix_num_piston_Noll1.fits'))

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -413,7 +413,7 @@ def plot_mu_map(instrument, mus, sim_instance, out_dir, design, c_target, limits
 
     if instrument == 'LUVOIR':
         sim_instance.flatten()
-        wf_constraints = apply_mode_to_luvoir(mus, sim_instance)
+        wf_constraints = apply_mode_to_luvoir(mus, sim_instance)[0]
         map_small = (wf_constraints.phase / wf_constraints.wavenumber * 1e12).shaped  # in picometers
     if instrument == 'HiCAT':
         sim_instance.iris_dm.flatten()
@@ -460,7 +460,7 @@ def calculate_mode_phases(pastis_modes, design):
     # Calculate phases of all modes
     all_modes = []
     for mode in range(len(pastis_modes)):
-        all_modes.append(apply_mode_to_luvoir(pastis_modes[:, mode], luvoir).phase)
+        all_modes.append(apply_mode_to_luvoir(pastis_modes[:, mode], luvoir)[0].phase)
 
     return all_modes
 
@@ -518,7 +518,7 @@ def plot_single_mode(mode_nr, pastis_modes, out_dir, design, figsize=(8.5,8.5), 
     luvoir = LuvoirAPLC(optics_input, design, sampling)
 
     plt.figure(figsize=figsize, constrained_layout=False)
-    one_mode = apply_mode_to_luvoir(pastis_modes[:, mode_nr - 1], luvoir)
+    one_mode = apply_mode_to_luvoir(pastis_modes[:, mode_nr - 1], luvoir)[0]
     hcipy.imshow_field(one_mode.phase, cmap='RdBu', vmin=vmin, vmax=vmax)
     plt.axis('off')
     plt.annotate(f'{mode_nr}', xy=(-7.1, -6.9), fontweight='roman', fontsize=43)

--- a/pastis/util_pastis.py
+++ b/pastis/util_pastis.py
@@ -215,7 +215,7 @@ def apply_mode_to_luvoir(pmode, luvoir):
     one by one to the segmented mirror.
     :param pmode: array, a single PASTIS mode [nseg] or any other segment phase map in NANOMETERS
     :param luvoir: LuvoirAPLC
-    :return: hcipy.Wavefront of the segmented mirror
+    :return: hcipy.Wavefront of the segmented mirror, hcipy.Wavefront of the detector plane
     """
 
     # Flatten SM to be sure we have no residual aberrations
@@ -229,7 +229,7 @@ def apply_mode_to_luvoir(pmode, luvoir):
     # Propagate the aperture wavefront through the SM
     psf, planes = luvoir.calc_psf(return_intermediate='efield')
 
-    return planes['seg_mirror']
+    return planes['seg_mirror'], psf
 
 
 def read_continuous_dm_maps_hicat(path_to_dm_maps):


### PR DESCRIPTION
Additionally to saving the pupil plane modes to PDF and fits, in this PR I save the focal plane PASTIS modes to disk as well.
On top of that, I move the saving of direct and unaberrated coro PSF together with the coronagraph contrast floor from the analysis script to the matrix script.