### PR TITLE
Wrap all simulator imports in try..except.. blocks

### DIFF
--- a/pastis/calibration.py
+++ b/pastis/calibration.py
@@ -6,7 +6,6 @@ import time
 import numpy as np
 import matplotlib.pyplot as plt
 import astropy.units as u
-import webbpsf
 import logging
 
 from pastis.config import CONFIG_INI
@@ -14,6 +13,11 @@ import pastis.util_pastis as util
 import pastis.image_pastis as impastis
 
 log = logging.getLogger()
+
+try:
+    import webbpsf
+except ImportError:
+    log.info('WebbPSF was not imported.')
 
 
 if __name__ == '__main__':

--- a/pastis/contrast_calculation_simple.py
+++ b/pastis/contrast_calculation_simple.py
@@ -16,12 +16,10 @@ import astropy.units as u
 import logging
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
-import hcipy
 
 from pastis.config import CONFIG_INI
 from pastis.e2e_simulators.hicat_imaging import set_up_hicat
 from pastis.e2e_simulators.luvoir_imaging import LuvoirAPLC
-import hicat.simulators
 import pastis.image_pastis as impastis
 import pastis.util_pastis as util
 

--- a/pastis/e2e_simulators/hicat_imaging.py
+++ b/pastis/e2e_simulators/hicat_imaging.py
@@ -3,11 +3,16 @@ This module contains useful functions to interface with the HiCAT simulator.
 """
 
 import logging
-import hicat.simulators
+
 from pastis.config import CONFIG_INI
 import pastis.util_pastis as util
 
 log = logging.getLogger()
+
+try:
+    import hicat.simulators
+except ImportError:
+    log.info('HiCAT simulator not imported.')
 
 
 def set_up_hicat(apply_continuous_dm_maps=False):

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -1,15 +1,22 @@
 """
 This is a module containing functions and classes for imaging propagation with HCIPy, for now LUVOIR A.
 """
+import logging
 import os
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 from astropy.io import fits
 import hcipy
-from hcipy.optics.segmented_mirror import SegmentedMirror
 
 from pastis.config import CONFIG_INI
+
+log = logging.getLogger()
+
+try:
+    from hcipy.optics.segmented_mirror import SegmentedMirror
+except ImportError:
+    log.info('SegmentedMirror simulator from hcipy@980f39c was not imported.')
 
 
 class SegmentedTelescopeAPLC:

--- a/pastis/e2e_simulators/webbpsf_imaging.py
+++ b/pastis/e2e_simulators/webbpsf_imaging.py
@@ -8,12 +8,16 @@ from matplotlib.colors import LogNorm
 import astropy.units as u
 import logging
 import poppy
-import webbpsf
 
 from pastis.config import CONFIG_INI
 import pastis.util_pastis as util
 
 log = logging.getLogger()
+
+try:
+    import webbpsf
+except ImportError:
+    log.info('WebbPSF was not imported.')
 
 # Setting to ensure that PyCharm finds the webbpsf-data folder. If you don't know where it is, find it with:
 # webbpsf.utils.get_webbpsf_data_path()


### PR DESCRIPTION
The implemented simulators will not be available on all machines (HiCAT not available for people who don’t have access to the repo, LUVOIR not available unless you hack your hcipy import etc…), so the imports of the unavailable simulators will always fail and raise an error. What I do here is to wrap the simulator imports in `try... except...` blocks to avoid killing the code if a particular simulator is not available.

Turns out I only had to do that in the respective `e2e_simulator` modules, which is nice. The only exception is for some of the JWST/WebbPSF cases, but those are anticipating some refactoring anyway, so I can do that then.