### PR TITLE
Reintegrate webbpsf to run PASTIS on JWST (NIRCam)

### DIFF
--- a/Jupyter Notebooks/JWST and WebbPSF/3_Testing the E2E simulations.ipynb
+++ b/Jupyter Notebooks/JWST and WebbPSF/3_Testing the E2E simulations.ipynb
@@ -37,9 +37,9 @@
     "import image_pastis as impastis\n",
     "\n",
     "# Path to all the outputs from \"aperture_definition.py\".\n",
-    "dir = '/Users/ilaginja/Documents/data_from_repos/pastis_data/active/calibration'\n",
+    "data_dir = '/Users/ilaginja/Documents/data_from_repos/pastis_data/active/calibration'\n",
     "# Change into that directory\n",
-    "os.chdir(dir)\n",
+    "#os.chdir(data_dir)\n",
     "\n",
     "os.environ['WEBBPSF_PATH'] = CONFIG_PASTIS.get('local', 'webbpsf_data_path')\n",
     "print('Currenlty running on WebbPSF', webbpsf.version.version)"
@@ -48,27 +48,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Get some parameters\n",
-    "which_tel = CONFIG_PASTIS.get('telescope', 'name')\n",
-    "fpm = CONFIG_PASTIS.get(which_tel, 'focal_plane_mask')         # focal plane mask\n",
-    "lyot_stop = CONFIG_PASTIS.get(which_tel, 'pupil_plane_stop')   # Lyot stop\n",
-    "filter = CONFIG_PASTIS.get(which_tel, 'filter_name')                       # filter\n",
+    "fpm = CONFIG_PASTIS.get('JWST', 'focal_plane_mask')         # focal plane mask\n",
+    "lyot_stop = CONFIG_PASTIS.get('JWST', 'pupil_plane_stop')   # Lyot stop\n",
+    "filter = CONFIG_PASTIS.get('JWST', 'filter_name')                       # filter\n",
     "im_size_e2e = CONFIG_PASTIS.getint('numerical', 'im_size_px_webbpsf')          # image size in pixels\n",
     "wss_segs = webbpsf.constants.SEGNAMES_WSS_ORDER\n",
-    "nb_seg = CONFIG_PASTIS.getint(which_tel, 'nb_subapertures')\n",
+    "nb_seg = CONFIG_PASTIS.getint('JWST', 'nb_subapertures')\n",
     "zern_max = CONFIG_PASTIS.getint('zernikes', 'max_zern')\n",
-    "inner_wa = CONFIG_PASTIS.getint(which_tel, 'IWA')\n",
-    "outer_wa = CONFIG_PASTIS.getint(which_tel, 'OWA')\n",
-    "sampling = CONFIG_PASTIS.getfloat(which_tel, 'sampling')            # sampling\n",
+    "inner_wa = CONFIG_PASTIS.getint('JWST', 'IWA')\n",
+    "outer_wa = CONFIG_PASTIS.getint('JWST', 'OWA')\n",
+    "sampling = CONFIG_PASTIS.getfloat('JWST', 'sampling')            # sampling\n",
     "\n",
-    "nm_aber = CONFIG_PASTIS.getfloat('calibration', 'single_aberration') * u.nm   # [nm] amplitude of aberration\n",
-    "zern_number = CONFIG_PASTIS.getint('calibration', 'zernike')                  # Which (Noll) Zernike we are calibrating for\n",
-    "wss_zern_nb = util.noll_to_wss(zern_number)                                # Convert from Noll to WSS framework"
+    "nm_aber = CONFIG_PASTIS.getfloat('JWST', 'calibration_aberration') * u.nm   # [nm] amplitude of aberration\n",
+    "zern_number = CONFIG_PASTIS.getint('calibration', 'local_zernike')          # Which (Noll) Zernike we are calibrating for\n",
+    "wss_zern_nb = util.noll_to_wss(zern_number)                                 # Convert from Noll to WSS framework"
    ]
   },
   {
@@ -83,9 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create two NIRCam objects\n",
@@ -155,9 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Null the OTE OPDs for the PSFs, and also the science instrument (SI) internal WFE.\n",
@@ -220,9 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Display with matplotlib\n",
@@ -258,9 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Add the filter we want to use\n",
@@ -299,9 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Both nc (non-coro and coro) objects are still the same, so I'll display only one.\n",
@@ -321,9 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "normp = np.max(psf_direct)"
@@ -341,9 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Look at the different extensions of the WebbPSF image\n",
@@ -355,9 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Extract the numpy array\n",
@@ -371,9 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Display with matplotlibpsf = psf[1].data\n",
@@ -407,9 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "segnum = 5     # Which segment are we aberrating - I number them starting with 1\n",
@@ -423,9 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create arrays to hold Zernike aberration coefficients\n",
@@ -449,9 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Display the OTE\n",
@@ -464,9 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Calculate the PSF\n",
@@ -480,9 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Display with matplotlib\n",
@@ -510,9 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Subtract the pserfect direct PSF off the single-segment aberrated PSF\n",
@@ -537,9 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Repeat on a smaller image direclty instead of cropping it afterwards, for faster computation\n",
@@ -564,9 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"\n",
@@ -618,9 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"\n",
@@ -644,9 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Decide which two segments you want to aberrate\n",
@@ -672,9 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "aber_wss_loop = np.zeros([nb_seg, 8])\n",
@@ -698,9 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Calculate the PSF\n",
@@ -730,9 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#segs_3_11_noll_1_dir = np.copy(psf_zernpair)\n",
@@ -749,9 +702,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "save_dir1 = '/astro/opticslab1/PASTIS/jwst_data/E2E_pair_aberrations/2019-1-25-16h-18min_piston_100nm'\n",
@@ -778,9 +729,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "read_dir1 = '/astro/opticslab1/PASTIS/jwst_data/E2E_pair_aberrations/2019-1-18-17h-5min_piston_1000nm_pairs'\n",
@@ -805,9 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Gotta check how big the loaded images are!\n",
@@ -867,9 +814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load the analytical images\n",
@@ -895,9 +840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Chose what image size (in pixels) we want to display\n",
@@ -951,9 +894,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Now add the coronagraph to nc_coro\n",
@@ -972,9 +913,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# I can't use webbpsf.display_psf(psf_coro) because I couldn't figure out how to change the color scaling\n",
@@ -1000,9 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print('NIRCam images will have', 20/0.063, 'pixels on either side of the detector.')"
@@ -1018,9 +955,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# For comparison, the webbpsf display in physical units for the fov:\n",
@@ -1044,9 +979,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Define what segment to aberrate\n",
@@ -1090,9 +1023,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Calculate the PSF\n",
@@ -1107,9 +1038,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Display with matplotlib\n",
@@ -1140,9 +1069,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Decide which two segments you want to aberrate\n",
@@ -1171,9 +1098,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "aber_wss_loop = np.zeros([nb_seg, 8])\n",
@@ -1197,9 +1122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Calculate the PSF\n",
@@ -1225,9 +1148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create DH\n",
@@ -1246,9 +1167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#segs_3_11_noll_1_coro = np.copy(psf_coro_pair)\n",
@@ -1265,9 +1184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Save to central store\n",
@@ -1287,9 +1204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Read from central store\n",
@@ -1315,9 +1230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Have a look at the images\n",
@@ -1379,9 +1292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Chose what image size (in pixels) we want to display\n",
@@ -1416,9 +1327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Chose what image size (in pixels) we want to display\n",
@@ -1475,9 +1384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Chose what image size (in pixels) we want to display\n",
@@ -1527,9 +1434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -1550,7 +1455,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/Jupyter Notebooks/JWST and WebbPSF/3a_simple E2E simulations.ipynb
+++ b/Jupyter Notebooks/JWST and WebbPSF/3a_simple E2E simulations.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simple imaging with WebbPSF\n",
+    "\n",
+    "Creating JWST PSFs documentation notbeook: https://github.com/spacetelescope/webbpsf/blob/develop/notebooks/WebbPSF_tutorial.ipynb\n",
+    "\n",
+    "Simulated OTE moves (aberrating segments): https://github.com/spacetelescope/webbpsf/blob/develop/notebooks/Simulated%20OTE%20Mirror%20Move%20Demo.ipynb\n",
+    "\n",
+    "All info about JWST imaging here:\n",
+    "https://webbpsf.readthedocs.io/en/latest/jwst.html#\n",
+    "\n",
+    "NIRCam coronagraphy recommended strategies: https://jwst-docs.stsci.edu/near-infrared-camera/nircam-observing-strategies/nircam-coronagraphic-imaging-recommended-strategies\n",
+    "\n",
+    "JWST Inner Working Angles: https://jwst-docs.stsci.edu/methods-and-roadmaps/jwst-high-contrast-imaging/hci-supporting-technical-information/hci-inner-working-angle\n",
+    "\n",
+    "JWST High Contrast Imaging: https://jwst-docs.stsci.edu/methods-and-roadmaps/jwst-high-contrast-imaging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import astropy.units as u\n",
+    "import matplotlib\n",
+    "%matplotlib inline\n",
+    "from matplotlib.colors import LogNorm\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import webbpsf\n",
+    "\n",
+    "from pastis.config import CONFIG_PASTIS\n",
+    "from pastis.e2e_simulators import webbpsf_imaging\n",
+    "import pastis.util"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Display simple PSF after changing individual parameters in succession \n",
+    "\n",
+    "### Make NIRCam object and display optical train and PSF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nc = webbpsf.NIRCam()\n",
+    "nc.include_si_wfe = False\n",
+    "nc, ote = webbpsf.enable_adjustable_ote(nc)\n",
+    "ote.zero()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(20,10))\n",
+    "nc_psf = nc.calc_psf(nlambda=1, display=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display just PSF\n",
+    "webbpsf.display_psf(nc_psf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set the filter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nc.filter = CONFIG_PASTIS.get('JWST', 'filter_name')\n",
+    "plt.figure(figsize=(20,10))\n",
+    "nc_filter = nc.calc_psf(nlambda=1, display=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display just PSF\n",
+    "webbpsf.display_psf(nc_filter)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set the Lyot stop (pupil mask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nc.pupil_mask = CONFIG_PASTIS.get('JWST', 'pupil_plane_stop')\n",
+    "plt.figure(figsize=(20,10))\n",
+    "nc_pupil_mask = nc.calc_psf(nlambda=1, display=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display just PSF\n",
+    "webbpsf.display_psf(nc_pupil_mask)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set the FPM (image mask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nc.image_mask = CONFIG_PASTIS.get('JWST', 'focal_plane_mask')\n",
+    "plt.figure(figsize=(20,10))\n",
+    "nc_image_mask = nc.calc_psf(nlambda=1, display=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display just PSF\n",
+    "webbpsf.display_psf(nc_image_mask, vmin=1e-12, vmax=1e-6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get NIRCam object and its OTE form PASTIS E2E function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jwst = webbpsf_imaging.set_up_nircam()    # this returns a tuple of two: jwst[0] is the nircam object, jwst[1] its ote"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(19, 19))\n",
+    "jwst[0].display()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Make a direct PSF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(20,10))\n",
+    "direct = jwst[0].calc_psf(nlambda=1, display=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "webbpsf.display_psf(direct)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "direct_psf = direct[0].data\n",
+    "plt.figure(figsize=(10,10))\n",
+    "plt.imshow(direct_psf, norm=LogNorm())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "norm = direct_psf.max()\n",
+    "print(norm)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Make a coronagraphic PSF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jwst[0].image_mask = CONFIG_PASTIS.get('JWST', 'focal_plane_mask')\n",
+    "plt.figure(figsize=(20,10))\n",
+    "coro_image = jwst[0].calc_psf(nlambda=1, display=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coro_psf = coro_image[0].data / norm\n",
+    "plt.figure(figsize=(10,10))\n",
+    "plt.imshow(direct_psf, norm=LogNorm())\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create dark hole mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iwa = CONFIG_PASTIS.getfloat('JWST', 'IWA')\n",
+    "owa = CONFIG_PASTIS.getfloat('JWST', 'OWA')\n",
+    "sampling = 8#CONFIG_PASTIS.getfloat('JWST', 'sampling')\n",
+    "dh_mask = pastis.util.create_dark_hole(coro_psf, iwa, owa, sampling).astype('bool')\n",
+    "\n",
+    "plt.figure(figsize=(20,10))\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.imshow(dh_mask)\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.imshow(coro_psf * dh_mask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Measure average contrast in dark hole\n",
+    "contrast_floor = util.dh_mean(coro_psf, dh_mask)\n",
+    "print(contrast_floor)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Jupyter Notebooks/JWST and WebbPSF/3b_Aberrating the OTE segments.ipynb
+++ b/Jupyter Notebooks/JWST and WebbPSF/3b_Aberrating the OTE segments.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Aberrating the JWST segments on the OTE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import astropy.units as u\n",
+    "import matplotlib\n",
+    "%matplotlib inline\n",
+    "from matplotlib.colors import LogNorm\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import webbpsf\n",
+    "\n",
+    "from pastis.config import CONFIG_PASTIS\n",
+    "from pastis.e2e_simulators import webbpsf_imaging\n",
+    "import pastis.util"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get your coro images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jwst = webbpsf_imaging.set_up_nircam()    # this returns a tuple of two: jwst[0] is the nircam object, jwst[1] its ote\n",
+    "jwst[0].image_mask = CONFIG_PASTIS.get('JWST','focal_plane_mask')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(20,10))\n",
+    "direct = jwst[0].calc_psf(nlambda=1, display=True)\n",
+    "direct_psf = direct[0].data\n",
+    "norm = direct_psf.max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "plt.imshow(direct_psf, norm=LogNorm())\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "webbpsf_imaging.display_ote_and_psf(jwst[0], jwst[1], psf_vmax=1e-6, title='Unaberrated OTE')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Aberrate a segment pair"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#jwst[1].zero(zero_original=True)\n",
+    "jwst[1].zero()\n",
+    "jwst[1].move_seg_local('B6', piston=100, trans_unit='nm')\n",
+    "jwst[1].move_seg_local('B3', piston=100, trans_unit='nm')\n",
+    "webbpsf_imaging.display_ote_and_psf(jwst[0], jwst[1], psf_vmax=1e-6, title='Tilt one segment')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pastis/config_pastis.ini
+++ b/pastis/config_pastis.ini
@@ -15,6 +15,9 @@ name = LUVOIR
 [JWST]
 ; aberration for matrix calculation, in NANOMETERS
 calibration_aberration = 100.
+; log10 limits of PASTIS validity in nm WFE
+valid_range_lower = -1
+valid_range_upper = 3
 
 ; telescope
 nb_subapertures = 18

--- a/pastis/config_pastis.ini
+++ b/pastis/config_pastis.ini
@@ -16,8 +16,8 @@ name = LUVOIR
 ; aberration for matrix calculation, in NANOMETERS
 calibration_aberration = 100.
 ; log10 limits of PASTIS validity in nm WFE
-valid_range_lower = -1
-valid_range_upper = 3
+valid_range_lower = -0.5
+valid_range_upper = 3.5
 
 ; telescope
 nb_subapertures = 18

--- a/pastis/contrast_calculation_simple.py
+++ b/pastis/contrast_calculation_simple.py
@@ -322,8 +322,17 @@ def contrast_luvoir_num(coro_floor, norm, design, matrix_dir, rms=1*u.nm):
 
 
 def contrast_jwst_num(coro_floor, norm, matrix_dir, rms=50*u.nm):
+    """
+    Compute the contrast for a random segmented OTE misalignment on the JWST simulator.
+
+    :param coro_floor: float, coronagraph contrast floor
+    :param norm: float, normalization factor for PSFs: peak of unaberrated direct PSF
+    :param matrix_dir: str, directory of saved matrix
+    :param rms: astropy quantity (e.g. m or nm), WFE rms (OPD) to be put randomly over the entire segmented mirror
+    :return: 2x float, E2E and matrix contrast
+    """
     # Keep track of time
-    start_time = time.time()  # runtime currently is around 12 min
+    start_time = time.time()
 
     # Parameters
     nb_seg = CONFIG_PASTIS.getint('JWST', 'nb_subapertures')

--- a/pastis/contrast_calculation_simple.py
+++ b/pastis/contrast_calculation_simple.py
@@ -16,10 +16,12 @@ import astropy.units as u
 import logging
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
+import webbpsf
 
 from pastis.config import CONFIG_PASTIS
 from pastis.e2e_simulators.hicat_imaging import set_up_hicat
 from pastis.e2e_simulators.luvoir_imaging import LuvoirAPLC
+from pastis.e2e_simulators.webbpsf_imaging import set_up_nircam
 import pastis.image_pastis as impastis
 import pastis.util as util
 
@@ -317,6 +319,69 @@ def contrast_luvoir_num(coro_floor, norm, design, matrix_dir, rms=1*u.nm):
     log.info(f'Runtime for contrast_calculation_simple.py: {runtime} sec = {runtime/60} min')
 
     return contrast_luvoir, contrast_matrix
+
+
+def contrast_jwst_num(coro_floor, norm, matrix_dir, rms=50*u.nm):
+    # Keep track of time
+    start_time = time.time()  # runtime currently is around 12 min
+
+    # Parameters
+    nb_seg = CONFIG_PASTIS.getint('JWST', 'nb_subapertures')
+    iwa = CONFIG_PASTIS.getfloat('JWST', 'IWA')
+    owa = CONFIG_PASTIS.getfloat('JWST', 'OWA')
+    sampling = CONFIG_PASTIS.getfloat('JWST', 'sampling')
+
+    # Import numerical PASTIS matrix
+    filename = 'PASTISmatrix_num_piston_Noll1'
+    matrix_pastis = fits.getdata(os.path.join(matrix_dir, filename + '.fits'))
+
+    # Create random aberration coefficients on segments, scaled to total rms
+    aber = util.create_random_rms_values(nb_seg, rms)
+
+    ### E2E JWST sim
+    start_e2e = time.time()
+
+    jwst_sim = set_up_nircam()
+    jwst_sim[0].image_mask = CONFIG_PASTIS.get('JWST', 'focal_plane_mask')
+
+    log.info('Calculating E2E contrast...')
+    # Put aberration on OTE
+    wss_segs = webbpsf.constants.SEGNAMES_WSS_ORDER    # TODO: this can probably be put in a better place so to not repeat it
+    jwst_sim[1].zero()
+    for nseg in range(nb_seg):    # TODO: there is probably a single function that puts the aberration on the OTE at once
+        seg_num = wss_segs[nseg].split('-')[0]
+        jwst_sim[1].move_seg_local(seg_num, piston=aber[nseg].value, trans_unit='nm')
+
+    image = jwst_sim[0].calc_psf(nlambda=1)
+    psf_jwst = image[0].data / norm
+
+    # Create DH
+    dh_mask = util.create_dark_hole(psf_jwst, iwa=iwa, owa=owa, samp=sampling)
+    # Get the mean contrast
+    contrast_jwst = util.dh_mean(psf_jwst, dh_mask)
+    end_e2e = time.time()
+
+    ## MATRIX PASTIS
+    log.info('Generating contrast from matrix-PASTIS')
+    start_matrixpastis = time.time()
+    # Get mean contrast from matrix PASTIS
+    contrast_matrix = util.pastis_contrast(aber, matrix_pastis) + coro_floor   # calculating contrast with PASTIS matrix model
+    end_matrixpastis = time.time()
+
+    ## Outputs
+    log.info('\n--- CONTRASTS: ---')
+    log.info(f'Mean contrast from E2E: {contrast_jwst}')
+    log.info(f'Contrast from matrix PASTIS: {contrast_matrix}')
+
+    log.info('\n--- RUNTIMES: ---')
+    log.info(f'E2E: {end_e2e-start_e2e}sec = {(end_e2e-start_e2e)/60}min')
+    log.info(f'Matrix PASTIS: {end_matrixpastis-start_matrixpastis}sec = {(end_matrixpastis-start_matrixpastis)/60}min')
+
+    end_time = time.time()
+    runtime = end_time - start_time
+    log.info(f'Runtime for contrast_calculation_simple.py: {runtime} sec = {runtime/60} min')
+
+    return contrast_jwst, contrast_matrix
 
 
 if __name__ == '__main__':

--- a/pastis/e2e_simulators/webbpsf_imaging.py
+++ b/pastis/e2e_simulators/webbpsf_imaging.py
@@ -166,6 +166,28 @@ def set_up_nircam():
     return nircam, ote
 
 
+def display_ote_and_psf(inst, ote, opd_vmax=500, psf_vmax=0.1, title="OPD and PSF", **kwargs):
+    """
+    Display OTE and PSF of a JWST instrument next to each other.
+
+    Adapted from:
+    https://github.com/spacetelescope/webbpsf/blob/develop/notebooks/Simulated%20OTE%20Mirror%20Move%20Demo.ipynb
+    :param inst: WebbPSF instrument instance, e.g. webbpsf.NIRCam()
+    :param ote: OTE of inst, usually obtained with: instrument, ote = webbpsf.enable_adjustable_ote(instrument)
+    :param opd_vmax: float, max display value for the OPD
+    :param psf_vmax: float, max display valued for PSF
+    :param title: string, plot title
+    :param kwargs:
+    """
+    psf = inst.calc_psf(nlambda=1)
+    plt.figure(figsize=(12, 8))
+    ax1 = plt.subplot(121)
+    ote.display_opd(ax=ax1, vmax=opd_vmax, colorbar_orientation='horizontal', title='OPD with aberrated segments')
+    ax2 = plt.subplot(122)
+    webbpsf.display_psf(psf, ext=1, vmax=psf_vmax, vmin=psf_vmax/1e4, colorbar_orientation='horizontal', title="PSF simulation")
+    plt.suptitle(title, fontsize=16)
+
+
 if __name__ == '__main__':
 
     pass

--- a/pastis/e2e_simulators/webbpsf_imaging.py
+++ b/pastis/e2e_simulators/webbpsf_imaging.py
@@ -16,13 +16,14 @@ log = logging.getLogger()
 
 try:
     import webbpsf
+
+    # Setting to ensure that PyCharm finds the webbpsf-data folder. If you don't know where it is, find it with:
+    # webbpsf.utils.get_webbpsf_data_path()
+    # --> e.g.: >>source activate pastis   >>ipython   >>import webbpsf   >>webbpsf.utils.get_webbpsf_data_path()
+    os.environ['WEBBPSF_PATH'] = CONFIG_PASTIS.get('local', 'webbpsf_data_path')
+
 except ImportError:
     log.info('WebbPSF was not imported.')
-
-# Setting to ensure that PyCharm finds the webbpsf-data folder. If you don't know where it is, find it with:
-# webbpsf.utils.get_webbpsf_data_path()
-# --> e.g.: >>source activate astroconda   >>ipython   >>import webbpsf   >>webbpsf.utils.get_webbpsf_data_path()
-os.environ['WEBBPSF_PATH'] = CONFIG_PASTIS.get('local', 'webbpsf_data_path')
 
 
 NB_SEG = CONFIG_PASTIS.getint('JWST', 'nb_subapertures')

--- a/pastis/e2e_simulators/webbpsf_imaging.py
+++ b/pastis/e2e_simulators/webbpsf_imaging.py
@@ -146,36 +146,26 @@ def nircam_nocoro(filter, Aber_WSS):
     return psf_webbpsf
 
 
-def setup_coro(filter, fpm, ppm):
+def set_up_nircam():
     """
-    Set up a NIRCam coronagraph object.
-    :param filter: str, filter name
-    :param fpm: focal plane mask
-    :param ppm: pupil plane mask - Lyot stop
-    :return:
-    """
-    nc = webbpsf.NIRCam()
-    nc.filter = filter
-    nc.image_mask = fpm
-    nc.pupil_mask = ppm
+    Return a configured instance of the NIRCam simulator on JWST.
 
-    return nc
+    Sets up the Lyots stop and filter from the configfile, turns of science insturment (SI) internal WFE and zeros
+    the OTE.
+    :return: Tuple of NIRCam instance, and its OTE
+    """
+
+    nircam = webbpsf.NIRCam()
+    nircam.include_si_wfe = False
+    nircam.filter = CONFIG_PASTIS.get('JWST', 'filter_name')
+    nircam.pupil_mask = CONFIG_PASTIS.get('JWST', 'pupil_plane_stop')
+
+    nircam, ote = webbpsf.enable_adjustable_ote(nircam)
+    ote.zero()
+
+    return nircam, ote
 
 
 if __name__ == '__main__':
 
-    nc_coro = setup_coro('F335M', 'MASK335R', 'CIRCLYOT')
-    nc_coro, ote_coro = webbpsf.enable_adjustable_ote(nc_coro)
-
-    ote_coro.zero()
-    #ote_coro._apply_hexikes_to_seg('A1', [1e-6])
-    #ote_coro._apply_hexikes_to_seg('A3', [1e-6])
-    #ote_coro.move_seg_local('A6', xtilt=0.5)
-    psf = nc_coro.calc_psf(oversample=1)
-    psf = psf[1].data
-
-    plt.subplot(1,2,1)
-    ote_coro.display_opd()
-    plt.subplot(1,2,2)
-    plt.imshow(psf, norm=LogNorm())
-    plt.show()
+    pass

--- a/pastis/e2e_simulators/webbpsf_imaging.py
+++ b/pastis/e2e_simulators/webbpsf_imaging.py
@@ -186,8 +186,3 @@ def display_ote_and_psf(inst, ote, opd_vmax=500, psf_vmax=0.1, title="OPD and PS
     ax2 = plt.subplot(122)
     webbpsf.display_psf(psf, ext=2, vmax=psf_vmax, vmin=psf_vmax/1e4, colorbar_orientation='horizontal', title="PSF simulation")
     plt.suptitle(title, fontsize=16)
-
-
-if __name__ == '__main__':
-
-    pass

--- a/pastis/e2e_simulators/webbpsf_imaging.py
+++ b/pastis/e2e_simulators/webbpsf_imaging.py
@@ -161,7 +161,7 @@ def set_up_nircam():
     nircam.pupil_mask = CONFIG_PASTIS.get('JWST', 'pupil_plane_stop')
 
     nircam, ote = webbpsf.enable_adjustable_ote(nircam)
-    ote.zero()
+    ote.zero(zero_original=True)    # https://github.com/spacetelescope/webbpsf/blob/96537c459996f682ac6e9af808809ca13fb85e87/webbpsf/opds.py#L1125
 
     return nircam, ote
 

--- a/pastis/e2e_simulators/webbpsf_imaging.py
+++ b/pastis/e2e_simulators/webbpsf_imaging.py
@@ -184,7 +184,7 @@ def display_ote_and_psf(inst, ote, opd_vmax=500, psf_vmax=0.1, title="OPD and PS
     ax1 = plt.subplot(121)
     ote.display_opd(ax=ax1, vmax=opd_vmax, colorbar_orientation='horizontal', title='OPD with aberrated segments')
     ax2 = plt.subplot(122)
-    webbpsf.display_psf(psf, ext=1, vmax=psf_vmax, vmin=psf_vmax/1e4, colorbar_orientation='horizontal', title="PSF simulation")
+    webbpsf.display_psf(psf, ext=2, vmax=psf_vmax, vmin=psf_vmax/1e4, colorbar_orientation='horizontal', title="PSF simulation")
     plt.suptitle(title, fontsize=16)
 
 

--- a/pastis/hockeystick_contrast_curve.py
+++ b/pastis/hockeystick_contrast_curve.py
@@ -127,7 +127,7 @@ def hockeystick_curve(instrument, apodizer_choice=None, matrixdir='', resultdir=
     want to fill the aberration range with. At each point we calculate the contrast for all realizations and plot the
     mean of this set of results in a figure that shows contrast vs. WFE rms error.
 
-    :param instrument: string, 'LUVOIR' or 'HiCAT'
+    :param instrument: string, 'LUVOIR', 'HiCAT' or 'JWST'
     :param apodizer_choice: string, needed if instrument='LUVOIR'; use "small", "medium" or "large" FPM coronagraph
     :param matrixdir: string, Path to matrix that should be used.
     :param resultdir: string, Path to directory where results will be saved.
@@ -179,6 +179,8 @@ def hockeystick_curve(instrument, apodizer_choice=None, matrixdir='', resultdir=
                 c_e2e, c_matrix = consim.contrast_luvoir_num(contrast_floor, norm, apodizer_choice, matrix_dir=matrixdir, rms=rms)
             if instrument == 'HiCAT':
                 c_e2e, c_matrix = consim.contrast_hicat_num(contrast_floor, norm, matrix_dir=matrixdir, rms=rms)
+            if instrument == 'JWST':
+                c_e2e, c_matrix = consim.contrast_jwst_num(contrast_floor, norm, matrix_dir=matrixdir, rms=rms)
 
             e2e_rand.append(c_e2e)
             matrix_rand.append(c_matrix)

--- a/pastis/launchers/run_jwst.py
+++ b/pastis/launchers/run_jwst.py
@@ -1,0 +1,30 @@
+"""
+Launcher script to start a full JWST run: generate matrix and run full PASTIS analysis.
+"""
+import os
+
+from pastis.config import CONFIG_PASTIS
+from pastis.hockeystick_contrast_curve import hockeystick_curve
+from pastis.matrix_building_numerical import num_matrix_multiprocess
+from pastis.pastis_analysis import run_full_pastis_analysis
+import pastis.util as util
+
+
+if __name__ == '__main__':
+
+    # Generate the matrix
+    dir_run = num_matrix_multiprocess(instrument='JWST')
+
+    # Alternatively, pick data location to run PASTIS analysis on
+    #dir_run = os.path.join(CONFIG_PASTIS.get('local', 'local_data_path'), '2020-08-26T00-00-00_jwst')
+
+    # Set up loggers for data analysis
+    util.setup_pastis_logging(dir_run, 'pastis_analysis')
+
+    # Then generate hockeystick curve
+    result_dir = os.path.join(dir_run, 'results')
+    matrix_dir = os.path.join(dir_run, 'matrix_numerical')
+    hockeystick_curve(instrument='JWST', matrixdir=matrix_dir, resultdir=result_dir, range_points=10, no_realizations=3)
+
+    # Finally run the analysis
+    run_full_pastis_analysis(instrument='JWST', run_choice=dir_run, c_target=1e-7)

--- a/pastis/launchers/run_jwst.py
+++ b/pastis/launchers/run_jwst.py
@@ -27,4 +27,4 @@ if __name__ == '__main__':
     hockeystick_curve(instrument='JWST', matrixdir=matrix_dir, resultdir=result_dir, range_points=10, no_realizations=3)
 
     # Finally run the analysis
-    run_full_pastis_analysis(instrument='JWST', run_choice=dir_run, c_target=1e-7)
+    run_full_pastis_analysis(instrument='JWST', run_choice=dir_run, c_target=1e-6)

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -467,6 +467,19 @@ def calculate_unaberrated_contrast_and_normalization(instrument, design=None, re
 
 
 def _jwst_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_pair):
+    """
+    Function to calculate JWST mean contrast of one aberrated segment pair in NIRCam; for num_matrix_luvoir_multiprocess().
+    :param norm: float, direct PSF normalization factor (peak pixel of direct PSF)
+    :param wfe_aber: calibration aberration per segment in m
+    :param resDir: str, directory for matrix calculations
+    :param savepsfs: bool, if True, all PSFs will be saved to disk individually, as fits files
+    :param saveopds: bool, if True, all pupil surface maps of aberrated segment pairs will be saved to disk as PDF
+    :param segment_pair: tuple, pair of segments to aberrate, 0-indexed. If same segment gets passed in both tuple
+                         entries, the segment will be aberrated only once.
+                         Note how JWST segments start numbering at 0 just because that's python indexing, with 0 being
+                         the segment A1.
+    :return: contrast as float, and segment pair as tuple
+    """
 
     # Set up JWST simulator in coronagraphic state
     jwst_instrument, jwst_ote = set_up_nircam()

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -482,9 +482,9 @@ def _jwst_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_pa
 
     # Put aberration on correct segments. If i=j, apply only once!
     jwst_ote.zero()
-    jwst_ote.move_seg_local(seg_i, piston=wfe_aber, trans_unit='nm')
+    jwst_ote.move_seg_local(seg_i, piston=wfe_aber, trans_unit='m')
     if segment_pair[0] != segment_pair[1]:
-        jwst_ote.move_seg_local(seg_j, piston=wfe_aber, trans_unit='nm')
+        jwst_ote.move_seg_local(seg_j, piston=wfe_aber, trans_unit='m')
 
     log.info('Calculating coro image...')
     image = jwst_instrument.calc_psf(nlambda=1)

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -33,6 +33,8 @@ log = logging.getLogger()
 def num_matrix_jwst():
     """
     Generate a numerical PASTIS matrix for a JWST coronagraph.
+    -- Depracated function, the LUVOIR PASTIS matrix is better calculated with num_matrix_multiprocess(), which can
+    do this for your choice of one of the implemented instruments (LUVOIR, HiCAT, JWST). --
 
     All inputs are read from the (local) configfile and saved to the specified output directory.
     """
@@ -204,6 +206,8 @@ def num_matrix_jwst():
 def num_matrix_luvoir(design, savepsfs=False, saveopds=True):
     """
     Generate a numerical PASTIS matrix for a LUVOIR A coronagraph.
+    -- Depracated function, the LUVOIR PASTIS matrix is better calculated with num_matrix_multiprocess(), which can
+    do this for your choice of one of the implemented instruments (LUVOIR, HiCAT, JWST). --
 
     All inputs are read from the (local) configfile and saved to the specified output directory.
     The LUVOIR STDT delivery in May 2018 included three different apodizers

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -470,7 +470,7 @@ def _jwst_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_pa
 
     # Set up JWST simulator in coronagraphic state
     jwst_instrument, jwst_ote = set_up_nircam()
-    jwst_instrument[0].image_mask = CONFIG_PASTIS.get('JWST', 'focal_plane_mask')
+    jwst_instrument.image_mask = CONFIG_PASTIS.get('JWST', 'focal_plane_mask')
 
     # Put aberration on correct segments. If i=j, apply only once!
     log.info(f'PAIR: {segment_pair[0]}-{segment_pair[1]}')

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -519,7 +519,7 @@ def _luvoir_matrix_one_pair(design, norm, wfe_aber, zern_mode, resDir, savepsfs,
     Function to calculate LVUOIR-A mean contrast of one aberrated segment pair; for num_matrix_luvoir_multiprocess().
     :param design: str, what coronagraph design to use - 'small', 'medium' or 'large'
     :param norm: float, direct PSF normalization factor (peak pixel of direct PSF)
-    :param wfe_aber: float, calibration aberration per segment in nm
+    :param wfe_aber: float, calibration aberration per segment in m
     :param zern_mode: Zernike mode object, local Zernike aberration
     :param resDir: str, directory for matrix calculations
     :param savepsfs: bool, if True, all PSFs will be saved to disk individually, as fits files
@@ -572,7 +572,7 @@ def _hicat_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_p
     """
     Function to calculate HiCAT mean contrast of one aberrated segment pair; for num_matrix_luvoir_multiprocess().
     :param norm: float, direct PSF normalization factor (peak pixel of direct PSF)
-    :param wfe_aber: calibration aberration per segment in nm
+    :param wfe_aber: calibration aberration per segment in m
     :param resDir: str, directory for matrix calculations
     :param savepsfs: bool, if True, all PSFs will be saved to disk individually, as fits files
     :param saveopds: bool, if True, all pupil surface maps of aberrated segment pairs will be saved to disk as PDF

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -255,6 +255,7 @@ def cumulative_contrast_e2e(instrument, pmodes, sigmas, sim_instance, dh_mask, n
 
     cont_cum_e2e = []
     for maxmode in range(pmodes.shape[0]):
+        log.info(f'Working on mode {maxmode+1}/{pmodes.shape[0]}.')
 
         if individual:
             opd = pmodes[:, maxmode] * sigmas[maxmode]

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -12,10 +12,12 @@ import logging
 from matplotlib.colors import LogNorm
 import matplotlib.pyplot as plt
 import hcipy
+import webbpsf
 
 from pastis.config import CONFIG_PASTIS
 from pastis.e2e_simulators.hicat_imaging import set_up_hicat
 from pastis.e2e_simulators.luvoir_imaging import LuvoirAPLC
+from pastis.e2e_simulators.webbpsf_imaging import set_up_nircam
 from pastis.matrix_building_numerical import calculate_unaberrated_contrast_and_normalization
 import pastis.plotting as ppl
 import pastis.util as util
@@ -29,7 +31,7 @@ def modes_from_matrix(instrument, datadir, saving=True):
     this is equivalent to using an eigendecomposition, because the matrix is symmetric. Note how the SVD orders the
     modes and singular values in reverse order compared to an eigendecomposition.
 
-    :param instrument: string, "LUVOIR" or "HiCAT"
+    :param instrument: string, "LUVOIR", "HiCAT" or "JWST"
     :param datadir: string, path to overall data directory containing matrix and results folder
     :param saving: string, whether to save singular values, modes and their plots or not; default=True
     :return: pastis modes (which are the singular vectors/eigenvectors), singular values/eigenvalues
@@ -80,7 +82,7 @@ def full_modes_from_themselves(instrument, pmodes, datadir, sim_instance, saving
     Both the pupl plane and the focal plane modes get save into a PDF grid, and as a cube to fits. Optionally, you can
     save the pupil plane modes individually to PDF files by setting saving=True.
 
-    :param instrument: string, 'LUVOIR' or 'HiCAT'
+    :param instrument: string, 'LUVOIR', 'HiCAT' or 'JWST'
     :param pmodes: array of PASTIS modes [segnum, modenum], expected in nanometers
     :param datadir: string, path to overall data directory containing matrix and results folder
     :param sim_instance: class instance of the simulator for "instrument"
@@ -96,7 +98,7 @@ def full_modes_from_themselves(instrument, pmodes, datadir, sim_instance, saving
     all_modes_focal_plane = []
     for i, thismode in enumerate(seglist):
 
-        if instrument == "LUVOIR":
+        if instrument == 'LUVOIR':
             log.info(f'Working on mode {thismode}/{nseg}.')
             wf_sm, wf_detector = util.apply_mode_to_luvoir(pmodes[:, i], sim_instance)
             psf_detector = wf_detector.intensity.shaped
@@ -114,6 +116,22 @@ def full_modes_from_themselves(instrument, pmodes, datadir, sim_instance, saving
             phase_sm = inter[1].phase
             hicat_wavenumber = 2 * np.pi / (CONFIG_PASTIS.getfloat('HiCAT', 'lambda') / 1e9)   # /1e9 converts to meters
             all_modes.append(phase_sm / hicat_wavenumber)    # phase_sm is in rad, so this converts it to meters
+
+        if instrument == 'JWST':
+            log.info(f'Working on mode {thismode}/{nseg - 1}.')
+            sim_instance[1].zero()
+            wss_segs = webbpsf.constants.SEGNAMES_WSS_ORDER  # TODO: this can probably be put in a better place so to not repeat it
+            for segnum in range(nseg):  # TODO: there is probably a single function that puts the aberration on the OTE at once
+                seg_name = wss_segs[segnum].split('-')[0]
+                sim_instance[1].move_seg_local(seg_name, piston=pmodes[segnum, i], trans_unit='nm')
+
+            psf_detector_data, inter = sim_instance[0].calc_psf(nlambda=1, return_intermediates=True)
+            psf_detector = psf_detector_data[0].data
+            all_modes_focal_plane.append(psf_detector)
+
+            phase_ote = inter[1].phase
+            jwst_wavenumber = 2 * np.pi / (CONFIG_PASTIS.getfloat('JWST', 'lambda') / 1e9)   # /1e9 converts to meters
+            all_modes.append(phase_ote / jwst_wavenumber)    # phase_sm is in rad, so this converts it to meters
 
     ### Check for results directory structure and create if it doesn't exist
     log.info('Creating data directories')
@@ -136,6 +154,8 @@ def full_modes_from_themselves(instrument, pmodes, datadir, sim_instance, saving
             plt.subplot(12, 10, i + 1)
         if instrument == 'HiCAT':
             plt.subplot(8, 5, i + 1)
+        if instrument == 'JWST':
+            plt.subplot(6, 3, i + 1)
         plt.imshow(all_modes[i], cmap='RdBu')
         plt.axis('off')
         plt.title(f'Mode {thismode}')
@@ -166,6 +186,8 @@ def full_modes_from_themselves(instrument, pmodes, datadir, sim_instance, saving
             plt.subplot(12, 10, i + 1)
         if instrument == 'HiCAT':
             plt.subplot(8, 5, i + 1)
+        if instrument == 'JWST':
+            plt.subplot(6, 3, i + 1)
         plt.imshow(all_modes_focal_plane[i], cmap='inferno', norm=LogNorm())
         plt.axis('off')
         plt.title(f'Mode {thismode}')
@@ -405,10 +427,10 @@ def run_full_pastis_analysis(instrument, run_choice, design=None, c_target=1e-10
     8. analytically calculating the statistical mean contrast and its variance
     9. calculting segment-based error budget
 
-    :param instrument: str, "LUVOIR" or "HiCAT"
+    :param instrument: str, "LUVOIR", "HiCAT" or "JWST"
     :param run_choice: str, path to data and where outputs will be saved
-    :param design: str, optional, default=None, which means we read from the configfile: what coronagraph design
-               to use - 'small', 'medium' or 'large'
+    :param design: str, optional, default=None, which means we read from the configfile (if running for LUVOIR):
+                   what coronagraph design to use - 'small', 'medium' or 'large'
     :param c_target: float, target contrast
     :param n_repeat: number of realizations in both Monte Carlo simulations (modes and segments), default=100
     """
@@ -474,6 +496,27 @@ def run_full_pastis_analysis(instrument, run_choice, design=None, c_target=1e-10
         dh_mask = util.create_dark_hole(psf_unaber, iwa, owa, sampling).astype('bool')
 
         sim_instance = hicat_sim
+
+    if instrument == 'JWST':
+        jwst_sim = set_up_nircam()  # this returns a tuple of two: jwst_sim[0] is the nircam object, jwst_sim[1] its ote
+
+        # Generate reference PSF and unaberrated coronagraphic image
+        jwst_sim[0].image_mask = None
+        direct = jwst_sim[0].calc_psf(nlambda=1)
+        direct_psf = direct[0].data
+        norm = direct_psf.max()
+
+        jwst_sim[0].image_mask = CONFIG_PASTIS.get('JWST', 'focal_plane_mask')
+        coro_image = jwst_sim[0].calc_psf(nlambda=1)
+        psf_unaber = coro_image[0].data / norm
+
+        # Create DH mask
+        iwa = CONFIG_PASTIS.getfloat('JWST', 'IWA')
+        owa = CONFIG_PASTIS.getfloat('JWST', 'OWA')
+        sampling = CONFIG_PASTIS.getfloat('JWST', 'sampling')
+        dh_mask = util.create_dark_hole(psf_unaber, iwa, owa, sampling).astype('bool')
+
+        sim_instance = jwst_sim
 
     # TODO: this would also be part of the refactor mentioned above
     # Calculate coronagraph contrast floor

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -191,16 +191,19 @@ def calc_variance_of_mean_contrast(pastismatrix, cov_segments):
 
 def get_segment_list(instrument):
     """
-    Horribly hacky function to get correct segment number list for an instrument (LUVOIR or HiCAT).
+    Horribly hacky function to get correct segment number list for an instrument (LUVOIR, or HiCAT and JWST).
 
-    We can assume that both implemented instruments start their numbering at 0, at the center segment. LUVOIR doesn't
-    use the center segment though, so we start at 1 and go until 120, for a total of 120 segments. HiCAT does use it,
-    so we start at 0 and go to 36 for a total of 37 segments.
-    :param instrument: string, "HiCAT" or "LUVOIR"
-    :return: seglist, array of segment numbers (names!)
+    We can assume that all implemented instruments start their numbering at 0, at the center segment.
+    LUVOIR doesn't use the center segment though, so we start at 1 and go until 120, for a total of 120 segments.
+    HiCAT does use it, so we start at 0 and go to 36 for a total of 37 segments.
+    JWST does not have a center segment, but it uses custom segment names anyway, so we start the numbering with zero,
+    at the first segment that is actually controllable (A1).
+
+    :param instrument: string, "HiCAT", "LUVOIR" or "JWST"
+    :return: seglist, array of segment numbers (names! at least in LUVOIR and HiCAT case. For JWST, it's the segment indices.)
     """
-    if instrument not in ['LUVOIR', 'HiCAT']:
-        raise ValueError('The instrument you requested is not implemented. Try with "LUVOIR" or "HiCAT" instead.')
+    if instrument not in ['LUVOIR', 'HiCAT', 'JWST']:
+        raise ValueError('The instrument you requested is not implemented. Try with "LUVOIR", "HiCAT" or "JWST" instead.')
 
     seglist = np.arange(CONFIG_PASTIS.getint(instrument, 'nb_subapertures'))
 


### PR DESCRIPTION
This PR integrates the already partially integrated JWST (NIRCam) simulator, `webbpsf`, into the overall PASTIS functions. This will allow to run a full PASTIS analysis with the multiprocessed semi-analytical matrix through the entire analysis script.

This PR contains good examples of parts that could still be modularized, particularly the parts where I keep copying the block of code for all three instruments (LUVOIR, HiCAT, JWST) that applies a particular WFE to the entire segmented pupil.

Need to double-check sampling, which I use to define a dark hole region in the webbpsf images - but I will do this in a follow-up PR.