### PR TITLE
Unify print of empirical and analytical calculations

### DIFF
--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -731,7 +731,7 @@ def run_full_pastis_analysis(instrument, run_choice, design=None, c_target=1e-10
         mean_stat_c = util.calc_statistical_mean_contrast(matrix, Ca, coro_floor)
         var_c = util.calc_variance_of_mean_contrast(matrix, Ca)
         log.info(f'Analytical statistical mean: {mean_stat_c}')
-        log.info(f'Analytical standard deviation: {var_c}')
+        log.info(f'Analytical standard deviation: {np.sqrt(var_c)}')
 
         with open(os.path.join(workdir, 'results', f'statistical_contrast_analytical_{c_target}.txt'), 'w') as file:
             file.write(f'Analytical, statistical mean: {mean_stat_c}')


### PR DESCRIPTION
While I save the mean and the **variance** of both the empirical and analytical calculations of the statistical contrast to file, I was printing the analytical variance even if the print statement said: "Analytical standard deviation".

I change the printed parameter to print the `np.sqrt()` of the variance.