### PR TITLE
Simplify equation for independent segment requirements

### DIFF
--- a/pastis/tests/test_pastis_analysis.py
+++ b/pastis/tests/test_pastis_analysis.py
@@ -76,7 +76,7 @@ def test_analytical_mean_and_variance():
     pmodes, svals, vh = np.linalg.svd(LUVOIR_MATRIX_SMALL, full_matrices=True)
 
     # Calculate independent segment weights
-    mus = pastis_analysis.calculate_segment_constraints(pmodes, LUVOIR_MATRIX_SMALL, C_TARGET, CORO_FLOOR) * u.nm
+    mus = pastis_analysis.calculate_segment_constraints(LUVOIR_MATRIX_SMALL, C_TARGET, CORO_FLOOR) * u.nm
 
     # Calculate independent segment based covariance matrix
     Ca = np.diag(np.square(mus.value))


### PR DESCRIPTION
This PR changes the equation for the independent segment requirements (mu) to the final, simplified form we present in the JATIS paper. Tested and confirmed to give exactly the same results like the current equation implemented in the code.