### PR TITLE
Include drifting coronagraph floor to PASTIS matrix calculation

### DIFF
--- a/Jupyter Notebooks/HiCAT/19_comparison matrices less pairs.ipynb
+++ b/Jupyter Notebooks/HiCAT/19_comparison matrices less pairs.ipynb
@@ -23,9 +23,8 @@
     "from matplotlib.colors import LogNorm\n",
     "import hcipy as hc\n",
     "\n",
-    "os.chdir('/Users/ilaginja/repos/PASTIS/pastis')\n",
-    "from config import CONFIG_PASTIS\n",
-    "import util as util\n",
+    "from pastis.config import CONFIG_PASTIS\n",
+    "import pastis.util as util\n",
     "datadir = CONFIG_PASTIS.get('local', 'local_data_path')"
    ]
   },
@@ -312,7 +311,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Compare the half original contrst matrix to new contrsat matrix\n",
+    "## Compare the half original contrast matrix to new contrast matrix\n",
     "... which is only half anyway"
    ]
   },
@@ -564,6 +563,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Here we assume that the coro floor is already subtracted from the contrast matrix\n",
     "off_orig = calculate_off_axis_elements(37, con_stand, seglist)\n",
     "off_new = calculate_off_axis_elements(37, con_new_symm, seglist)"
    ]
@@ -741,7 +741,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/Jupyter Notebooks/LUVOIR/20_drifting coro floor.ipynb
+++ b/Jupyter Notebooks/LUVOIR/20_drifting coro floor.ipynb
@@ -1,0 +1,691 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Drifting coro floor\n",
+    "\n",
+    "Incorporating a drifting coro floor into the calculation of the PASTIS matrix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Motivation\n",
+    "\n",
+    "Throughout all our previous work, the coronagraph floor (contrast floor) $c_0$ has been assumed to be constant across the time we need to measure the full PASTIS matrix. As we have seen on HiCAT though, this is not the case, so we need to allow for a drifting contrast floor in the semi-analytic calculation of the PASTIS matrix.\n",
+    "\n",
+    "## Reminder: static coro floor\n",
+    "\n",
+    "In the JATIS 2021 paper, we have Eq. 15:\n",
+    "\n",
+    "$$c_{ij} = c_0 + a_c^2 m_{ii} + a_c^2 m_{jj} + 2 a_c^2 m_{ij}$$\n",
+    "\n",
+    "Solving for the diagonal elements $m_{ii}$ yields ($m_{ij} = 0$):\n",
+    "\n",
+    "$$m_{ii} = \\frac{c_{ii} - c_0}{a_c^2}$$\n",
+    "\n",
+    "Using the above and solving for $m_{ij}$ yields:\n",
+    "\n",
+    "$$m_{ij} = \\frac{c_{ij} + c_0 - c_{ii} - c_{jj}}{2 a_c^2}$$\n",
+    "\n",
+    "## Development for drifting coro floor\n",
+    "\n",
+    "The above assumes that $c_0$ stays constant across all measurements of $c_{ij}$. This is not true on HiCAT, so we have to work in a $c_0$ that depends on $c_{ij}$. We can do this starting from the Eq. 15 in the JATIS paper (see above). The equation for the diagonal elements $m_{ii}$ stays the same, but we now want to derive the non-diagonal elements from the already calculated diagonal elements, not the $c_{ij}$. In that way, each measurement $c_{ij}$, and each matrix element $m_{ij}$ only depends on its specific, time-dependent measurement of $c_0$.\n",
+    "\n",
+    "In this case:\n",
+    "\n",
+    "$$m_{ii} = \\frac{c_{ii} - c_{0ij}}{a_c^2}$$\n",
+    "\n",
+    "and:\n",
+    "\n",
+    "$$m_{ij} = \\frac{c_{ij} - c_{0ij}}{2 a_c^2} - \\frac{m_{ii}}{2} - \\frac{m_{jj}}{2}$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Comparing some matrix results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.io import fits\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from pastis.matrix_building_numerical import pastis_from_contrast_matrix\n",
+    "import pastis.util"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname_old = '/Users/ilaginja/data_from_repos/pastis_data/2021-01-08T23-22-15_luvoir-small_develop/matrix_numerical/PASTISmatrix_num_piston_Noll1.fits'\n",
+    "fname_new = '/Users/ilaginja/data_from_repos/pastis_data/2021-01-09T01-01-53_luvoir-small_drift_0842c7/matrix_numerical/PASTISmatrix_num_piston_Noll1.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmatrix_old = fits.getdata(fname_old)\n",
+    "pmatrix_new = fits.getdata(fname_new)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(15, 5))\n",
+    "\n",
+    "plt.subplot(1, 3, 1)\n",
+    "plt.imshow(pmatrix_old, origin='lower')\n",
+    "plt.title('pmatrix_old')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 2)\n",
+    "plt.imshow(pmatrix_new, origin='lower')\n",
+    "plt.title('pmatrix_new')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 3)\n",
+    "plt.imshow(pmatrix_old - pmatrix_new, origin='lower')\n",
+    "plt.title('diff')\n",
+    "\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(pmatrix_old[50,50])\n",
+    "print(pmatrix_new[50,50])\n",
+    "print(pmatrix_old[50,50] - pmatrix_new[50,50])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(pmatrix_old[45,111])\n",
+    "print(pmatrix_new[45,111])\n",
+    "print(pmatrix_old[45,111] - pmatrix_new[45,111])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = np.array([[1,2,3,],[4,5,6],[7,8,9]])\n",
+    "b = np.array([[1,24,3,],[4,15,6],[7,28,9]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(a)\n",
+    "print(b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(np.diag(b))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.fill_diagonal(a, np.diag(b))\n",
+    "print(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compare contrast matrices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cname_new = '/Users/ilaginja/data_from_repos/pastis_data/2021-01-08T13-02-27_luvoir-small/matrix_numerical/contrast_matrix.fits'\n",
+    "cname_old = '/Users/ilaginja/data_from_repos/pastis_data/2021-01-08T14-47-37_luvoir-small/matrix_numerical/pair-wise_contrasts.fits'\n",
+    "cname_new_norm_at_end = '/Users/ilaginja/data_from_repos/pastis_data/2021-01-08T19-28-09_luvoir-small/matrix_numerical/contrast_matrix.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm_new = fits.getdata(cname_new)\n",
+    "cm_old_subtracted = fits.getdata(cname_old)\n",
+    "cm_new_end = fits.getdata(cname_new_norm_at_end)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cm_old had the coro floor subtracted, so I have to readd it - but only to the filled half of the matrix\n",
+    "coro_floor_old = 4.315823935036038e-11\n",
+    "coro_floor_matrix = np.zeros((120, 120))\n",
+    "seg_combos = list(pastis.util.segment_pairs_non_repeating(120))\n",
+    "len(seg_combos)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for pair in pastis.util.segment_pairs_non_repeating(120):    # this util function returns a generator\n",
+    "    if pair[0] != pair[1]:    # exclude diagonal elements\n",
+    "        coro_floor_matrix[pair[0], pair[1]] = coro_floor_old\n",
+    "# Fill diagonal\n",
+    "np.fill_diagonal(coro_floor_matrix, coro_floor_old)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm_old = cm_old_subtracted + coro_floor_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 10))\n",
+    "\n",
+    "plt.subplot(2, 2, 1)\n",
+    "plt.imshow(cm_new, origin='lower')\n",
+    "plt.title('cm_new')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(2, 2, 2)\n",
+    "plt.imshow(cm_old, origin='lower')\n",
+    "plt.title('cm_old')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(2, 2, 3)\n",
+    "plt.imshow(cm_new_end, origin='lower')\n",
+    "plt.title('cm_old_end')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(2, 2, 4)\n",
+    "plt.imshow(cm_old-cm_new_end, origin='lower')\n",
+    "plt.title('diff')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(cm_old[50,50])\n",
+    "print(cm_new_end[50,50])\n",
+    "print(cm_old[50,50] - cm_new_end[50,50])\n",
+    "print(np.min(cm_old-cm_new_end))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Top left triangle\n",
+    "print(cm_old[111,45])\n",
+    "print(cm_new_end[111,45])\n",
+    "print(cm_old[111,45] - cm_new_end[111,45])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Bottom right triangle\n",
+    "print(cm_old[45,111])\n",
+    "print(cm_new_end[45,111])\n",
+    "print(cm_old[45,111] - cm_new_end[45,111])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The contrat matrices are exactly the same, which is good. Now I can start debugging the analytical calculation procedure for the PASTIS matrix.\n",
+    "I'll have a brief look at the difference anyway."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "diff = cm_old - cm_new"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "plt.imshow(diff)\n",
+    "plt.xlim(95,119)\n",
+    "plt.ylim(85, 119)\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(diff[100,100])\n",
+    "print(diff[114,114])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculate M from C"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seglist = pastis.util.get_segment_list('LUVOIR')\n",
+    "\n",
+    "# need uubtracted contrast matrices\n",
+    "#contrast_matrix = cm_old_subtracted\n",
+    "contrast_matrix = cm_new - coro_floor_matrix\n",
+    "#contrast_matrix = cm_new_end - coro_floor_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## OLD WAY SHORT\n",
+    "# make sure you're at the old commit\n",
+    "matrix_pastis_dev_short = pastis_from_contrast_matrix(contrast_matrix, seglist, 1e-9)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(15, 5))\n",
+    "\n",
+    "plt.subplot(1, 3, 1)\n",
+    "plt.imshow(matrix_pastis_dev_short, origin='lower')\n",
+    "plt.title('matrix_pastis_short')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 2)\n",
+    "plt.imshow(pmatrix_old, origin='lower')\n",
+    "plt.title('pmatrix_old')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 3)\n",
+    "plt.imshow(matrix_pastis_dev_short - pmatrix_old, origin='lower')\n",
+    "plt.title('diff')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Difference is zero, as it should be. Good, moving on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## OLD WAY\n",
+    "# make sure you're at the old commit\n",
+    "\n",
+    "# Create future (half filled) PASTIS matrix\n",
+    "matrix_pastis_half = np.copy(contrast_matrix)     # This will be the final PASTIS matrix.\n",
+    "\n",
+    "# Calculate the off-axis elements in the (half) PASTIS matrix\n",
+    "for pair in pastis.util.segment_pairs_non_repeating(contrast_matrix.shape[0]):    # this util function returns a generator\n",
+    "    if pair[0] != pair[1]:    # exclude diagonal elements\n",
+    "        matrix_off_val = (contrast_matrix[pair[0], pair[1]] - contrast_matrix[pair[0], pair[0]] - contrast_matrix[pair[1], pair[1]]) / 2.\n",
+    "        matrix_pastis_half[pair[0], pair[1]] = matrix_off_val\n",
+    "        print(f'Off-axis for i{seglist[pair[0]]}-j{seglist[pair[1]]}: {matrix_off_val}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Symmetrize the half-PASTIS matrix\n",
+    "print('Symmetrizing PASTIS matrix')\n",
+    "matrix_pastis_dev = pastis.util.symmetrize(matrix_pastis_half)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Normalizing PASTIS matrix')\n",
+    "matrix_pastis_dev /= np.square(1e-9 * 1e9)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(15, 5))\n",
+    "\n",
+    "plt.subplot(1, 3, 1)\n",
+    "plt.imshow(matrix_pastis_dev, origin='lower')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 2)\n",
+    "plt.imshow(pmatrix_old, origin='lower')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 3)\n",
+    "plt.imshow(matrix_pastis_dev - pmatrix_old, origin='lower')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ok this means I can reporoduce the old way step by step, both with the old as well as with the new contrast matrix. Whether the normalization happens at the beginning or at the end does not change the result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seglist = pastis.util.get_segment_list('LUVOIR')\n",
+    "wfe_aber = 1e-9\n",
+    "\n",
+    "# need unsubtracted contrast matrices\n",
+    "contrast_matrix = cm_old\n",
+    "#contrast_matrix = cm_new #- coro_floor_matrix\n",
+    "#contrast_matrix = cm_new_end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NEW WAY SHORT\n",
+    "# make sure you're at the new commit\n",
+    "matrix_pastis_commit = pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber, coro_floor_old)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(15, 5))\n",
+    "\n",
+    "plt.subplot(1, 3, 1)\n",
+    "plt.imshow(matrix_pastis_commit, origin='lower')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 2)\n",
+    "plt.imshow(pmatrix_old, origin='lower')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 3)\n",
+    "plt.imshow(matrix_pastis_commit - pmatrix_old, origin='lower')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NEW WAY"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Normalization\n",
+    "print('Normalization')\n",
+    "contrast_matrix /= np.square(wfe_aber * 1e9)  # 1e9 converts the calibration aberration back to nanometers\n",
+    "coro_floor = coro_floor_old / np.square(wfe_aber * 1e9)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create future (half filled) PASTIS matrix\n",
+    "matrix_pastis_half = np.zeros_like(contrast_matrix)     # This will be the final PASTIS matrix.\n",
+    "#matrix_pastis_half = np.copy(contrast_matrix)\n",
+    "\n",
+    "# First calculate the on-axis elements, which just need to have the coronagraph floor subtracted\n",
+    "np.fill_diagonal(matrix_pastis_half, np.diag(contrast_matrix)-coro_floor)\n",
+    "#log.info('On-axis elements of PASTIS matrix calculated')\n",
+    "\n",
+    "# Calculate the off-axis elements in the (half) PASTIS matrix\n",
+    "for pair in pastis.util.segment_pairs_non_repeating(contrast_matrix.shape[0]):    # this util function returns a generator\n",
+    "    if pair[0] != pair[1]:    # exclude diagonal elements\n",
+    "        matrix_off_val = (contrast_matrix[pair[0], pair[1]] + coro_floor - contrast_matrix[pair[0], pair[0]] - contrast_matrix[pair[1], pair[1]]) / 2.\n",
+    "        matrix_pastis_half[pair[0], pair[1]] = matrix_off_val\n",
+    "        #print(f'Off-axis for i{seglist[pair[0]]}-j{seglist[pair[1]]}: {matrix_off_val}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Symmetrize the half-PASTIS matrix\n",
+    "print('Symmetrizing PASTIS matrix')\n",
+    "matrix_pastis_commit = pastis.util.symmetrize(matrix_pastis_half)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Old off-axis calculation\n",
+    "\n",
+    "# Create future (half filled) PASTIS matrix\n",
+    "matrix_pastis_half = np.copy(contrast_matrix)    # This will be the final PASTIS matrix.\n",
+    "\n",
+    "# Calculate the off-axis elements in the (half) PASTIS matrix\n",
+    "for pair in pastis.util.segment_pairs_non_repeating(contrast_matrix.shape[0]):    # this util function returns a generator\n",
+    "    if pair[0] != pair[1]:    # exclude diagonal elements\n",
+    "        matrix_off_val = (contrast_matrix[pair[0], pair[1]] - contrast_matrix[pair[0], pair[0]] - contrast_matrix[pair[1], pair[1]]) / 2.\n",
+    "        matrix_pastis_half[pair[0], pair[1]] = matrix_off_val\n",
+    "        print(f'Off-axis for i{seglist[pair[0]]}-j{seglist[pair[1]]}: {matrix_off_val}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(15, 5))\n",
+    "\n",
+    "plt.subplot(1, 3, 1)\n",
+    "plt.imshow(matrix_pastis_commit, origin='lower')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 2)\n",
+    "plt.imshow(pmatrix_old, origin='lower')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 3)\n",
+    "plt.imshow(matrix_pastis_commit - pmatrix_old, origin='lower')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matrix_pastis_half = np.zeros_like(contrast_matrix)\n",
+    "np.fill_diagonal(matrix_pastis_half, np.diag(contrast_matrix))\n",
+    "plt.imshow(matrix_pastis_half)\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zer = np.zeros_like(contrast_matrix)\n",
+    "plt.imshow(zer)\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zer -= coro_floor_old\n",
+    "plt.imshow(zer)\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zer = np.triu(zer)\n",
+    "plt.imshow(zer)\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/README.md
+++ b/README.md
@@ -356,7 +356,8 @@ directory structure is as follows:
 |       |-- OTE_images
 |           |-- opd[...].pdf                     # PDF images of each segment pair aberration in the pupil
 |           |-- ...
-|      |-- pair-wise_contrasts.fits:             # contrast matrix - E2E DH average contrasts per aberrated segment pair (only half of it since it is symmetric), contrast floor is already subtracted
+|      |-- contrast_matrix.fits:                 # contrast matrix - E2E DH average contrasts per aberrated segment pair (only half of it since it is symmetric), contrast floor is NOT subtracted
+|      |-- contrast_matrix.pdf:                  # PDF image of contrast matrix
 |      |-- pastis_matrix_example.log             # logging output of matrix calculation
 |      |-- pastis_matrix.pdf                     # PDF image of the calculated PASTIS matrix 
 |      |-- PASTISmatrix_num_piston_Noll1.fits    # the PASTIS matrix

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -712,6 +712,11 @@ def calculate_semi_analytic_pastis_from_contrast(contrast_matrix, seglist, coro_
 
     # Assuming drifting coronagraph floor across all pair-aberrated measurements
     elif isinstance(coro_floor, np.ndarray):
+
+        # Check that the coro_floor array has same dimensions like the contrast_matrix array
+        if coro_floor.shape != contrast_matrix.shape:
+            raise ValueError('coro_floor needs to have same dimensions like contrast_matrix')
+
         for pair in util.segment_pairs_non_repeating(contrast_matrix.shape[0]):    # this util function returns a generator
 
             # First calculate the on-axis elements, which just need to have the coronagraph floor subtracted

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -712,7 +712,7 @@ def calculate_semi_analytic_pastis_from_contrast(contrast_matrix, seglist, coro_
                 matrix_pastis_half[pair[0], pair[1]] = matrix_off_val
                 log.info(f'Off-axis for i{seglist[pair[0]]}-j{seglist[pair[1]]}: {matrix_off_val}')
 
-    # Assuming drifting coronagraph floor across all pair-aberrated measurements
+    # Assuming drifting coronagraph floor across all pair-aberrated measurements  #TODO: this is untested
     elif isinstance(coro_floor, np.ndarray):
         log.info('coro_floor is drifting --> np.ndarray')
 

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -695,13 +695,14 @@ def calculate_semi_analytic_pastis_from_contrast(contrast_matrix, seglist, coro_
     """
 
     # Create future (half filled) PASTIS matrix
-    matrix_pastis_half = np.zeros_like(contrast_matrix)     # This will be the final PASTIS matrix.
+    matrix_pastis_half = np.zeros_like(contrast_matrix)
 
     # Assuming constant coronagraph floor across all pair-aberrated measurements
     if isinstance(coro_floor, float):
+        log.info('coro_floor is a constant --> float')
 
         # First calculate the on-axis elements, which just need to have the coronagraph floor subtracted
-        np.fill_diagonal(matrix_pastis_half, np.diag(contrast_matrix)-coro_floor)
+        np.fill_diagonal(matrix_pastis_half, np.diag(contrast_matrix) - coro_floor)
         log.info('On-axis elements of PASTIS matrix calculated')
 
         # Calculate the off-axis elements in the (half) PASTIS matrix
@@ -713,6 +714,7 @@ def calculate_semi_analytic_pastis_from_contrast(contrast_matrix, seglist, coro_
 
     # Assuming drifting coronagraph floor across all pair-aberrated measurements
     elif isinstance(coro_floor, np.ndarray):
+        log.info('coro_floor is drifting --> np.ndarray')
 
         # Check that the coro_floor array has same dimensions like the contrast_matrix array
         if coro_floor.shape != contrast_matrix.shape:

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -862,7 +862,7 @@ def num_matrix_multiprocess(instrument, design=None, initial_path='', savepsfs=T
     plt.savefig(os.path.join(resDir, 'contrast_matrix.pdf'))
 
     # Calculate the PASTIS matrix from the contrast matrix: analytical matrix element calculation and normalization
-    matrix_pastis = pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber, contrast_floor)
+    matrix_pastis = pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber, float(contrast_floor))
 
     # Save matrix to file
     filename_matrix = f'PASTISmatrix_num_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}'    #TODO: I hate my old naming convention. Change this.

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -633,61 +633,102 @@ def _hicat_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, segment_p
     return contrast, segment_pair
 
 
-def pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber):
+def pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber, coro_floor):
     """
-    Calculate the final PASTIS matrix from the input contrast matrix (coro floor already subtracted, but only half filled).
+    Calculate the final PASTIS matrix from the input contrast matrix (only half filled).
 
     The contrast matrix is a nseg x nseg matrix where only half of it is filled, including the diagonal, and the other
-    half is filled with zeros. It holds the DH mean contrast values of each aberrated segment pair, with an WFE
+    half is filled with zeros. It holds the DH mean contrast values of each aberrated segment pair, with a WFE
     amplitude of the calibration aberration wfe_aber, in m. Hence, the input contrast matrix is not normalized to the
-    desired units yet. The coronagraph floor already needs to be subtracted from it at this point though.
-    This function calculates the off-axis elements of the PASTIS matrix and then normalizes it by the calibration
-    aberration to get a matrix with units of contrast / nm^2.
-    Finally, it symmetrizes the matrix to output the full PASTIS matrix.
+    desired units yet. The coronagraph floor is NOT subtracted from it at this point yet, but also passed in.
+    This function first normalizes the contrast matrix and coro floor by the calibration aberration to get a matrix with
+    units of contrast / nm^2. Then, it calculates the PASTIS matrix, and it adapts to whether we assume a static
+    coronagraph floor (passed in as a single float) or a drifting coronagraph floor (passed in as a 2D array, per
+    segment pair measurement). Finally, it symmetrizes the matrix to output the full PASTIS matrix.
 
-    :param contrast_matrix: nd.array, nseg x nseg matrix holding DH mean contast values of all aberrated segment pairs,
-                            with the coro floor already subtracted, but only half of the matrix has non-zero values
+    :param contrast_matrix: nd.array, nseg x nseg matrix holding DH mean contast values of all aberrated segment pairs;
+                            only half of the matrix has non-zero values, contrast floor NOT SUBTRACTED yet.
     :param seglist: list of segment indices (e.g. 0, 1, 2, ...36 [HiCAT]; or 1, 2, ..., 120 [LUVOIR])
     :param wfe_aber: float, calibration aberration in m, this is the aberration that was used to generate contrast_matrix
-    :return: the finalized PASTIS matrix in units of contrast per nanometers squared, nd.array of nseg x nseg
+    :param coro_floor: float, or nd.array of same dims like contrast_matrix. In simulations we usually assume a static
+                       coronagraph floor across the measurements for the PASTIS matrix and can use a single number.
+                       When we have a drifting coro floor though, we need one contrast floor number per measurement.
+    :return: the finalized PASTIS matrix in units of contrast per nanometers squared, ndarray of nseg x nseg
     """
 
-    # Calculate the off-axis elements in the PASTIS matrix
-    log.info('Calculating off-axis elements of PASTIS matrix')
-    matrix_pastis_half = calculate_off_axis_elements(contrast_matrix, seglist)
+    # Normalize contrast matrix, and coronagraph floor, to the input aberration - this defines what units the PASTIS
+    # matrix will be in. The PASTIS matrix propagation function (util.pastis_contrast()) then needs to take in the
+    # aberration vector in these same units. I have chosen to keep this to 1nm, so, we normalize the PASTIS matrix to
+    # units of nanometers (contrast / nanometers squared).
+    log.info('Normalizing contrast matrix and coronagraph floor')
+    contrast_matrix /= np.square(wfe_aber * 1e9)  # 1e9 converts the calibration aberration back to nanometers
+    coro_floor /= np.square(wfe_aber * 1e9)
+
+    # Calculate the semi-analytical PASTIS matrix from the contrast matrix
+    log.info('Calculating the semi-analytical PASTIS matrix from the contrast matrix')
+    matrix_pastis_half = calculate_semi_analytic_pastis_from_contrast(contrast_matrix, seglist, coro_floor)
 
     # Symmetrize the half-PASTIS matrix
     log.info('Symmetrizing PASTIS matrix')
     matrix_pastis = util.symmetrize(matrix_pastis_half)
 
-    # Normalize matrix for the input aberration - this defines what units the PASTIS matrix will be in. The PASTIS
-    # matrix propagation function (util.pastis_contrast()) then needs to take in the aberration vector in these same
-    # units. I have chosen to keep this to 1nm, so, we normalize the PASTIS matrix to units of nanometers.
-    log.info('Normalizing PASTIS matrix')
-    matrix_pastis /= np.square(wfe_aber * 1e9)  # 1e9 converts the calibration aberration back to nanometers
-
     return matrix_pastis
 
 
-def calculate_off_axis_elements(contrast_matrix, seglist):
+def calculate_semi_analytic_pastis_from_contrast(contrast_matrix, seglist, coro_floor):
     """
-    Calculate the off-axis elements of the (half) PASTIS matrix, from the contrast matrix (coro floor already subtracted).
+    Perform the semi-analytical calculation to go from contrast matrix to PASTIS matrix, depending on assumption for
+    coronagraph floor drift.
 
-    :param contrast_matrix: nd.array, nseg x nseg matrix holding DH mean contast values of all aberrated segment pairs,
-                            with the coro floor already subtracted
+    This function calculates the elements of the (half !) PASTIS matrix from the contrast matrix in which the
+    coronagraph has not been subtracted yet. The calculation is only performed on the half-PASTIS matrix, so it will
+    need to be symmetrized after this step.
+    The calculation is slightly different for the two cases in which the coronagraph is either assumed to be constant
+    across all pair-wise aberrated measurements, or is drifting.
+
+    :param contrast_matrix: nd.array, nseg x nseg matrix holding DH mean contrast values of all aberrated segment pairs
     :param seglist: list of segment indices (e.g. 0, 1, 2, ...36 [HiCAT]; or 1, 2, ..., 120 [LUVOIR])
-    :return: unnormalized half-PASTIS matrix, nd.array of nseg x nseg where one of its matrix triangles will be all zeros
+    :param coro_floor: float or nd.array of same dims like contrast_matrix. In simulations we usually assume a static
+                       coronagraph floor across the measurements for the PASTIS matrix and can use a single number.
+                       When we have a drifting coro floor though, we need one contrast floor number per measurement.
+    :return: half-PASTIS matrix, nd.array of nseg x nseg where one of its matrix triangles will be all zeros
     """
 
     # Create future (half filled) PASTIS matrix
     matrix_pastis_half = np.copy(contrast_matrix)     # This will be the final PASTIS matrix.
 
-    # Calculate the off-axis elements in the (half) PASTIS matrix
-    for pair in util.segment_pairs_non_repeating(contrast_matrix.shape[0]):    # this util function returns a generator
-        if pair[0] != pair[1]:    # exclude diagonal elements
-            matrix_off_val = (contrast_matrix[pair[0], pair[1]] - contrast_matrix[pair[0], pair[0]] - contrast_matrix[pair[1], pair[1]]) / 2.
-            matrix_pastis_half[pair[0], pair[1]] = matrix_off_val
-            log.info(f'Off-axis for i{seglist[pair[0]]}-j{seglist[pair[1]]}: {matrix_off_val}')
+    # Assuming constant coronagraph floor across all pair-aberrated measurements
+    if isinstance(coro_floor, float):
+
+        # Subtract the constant coronagraph floor
+        matrix_pastis_half -= coro_floor
+
+        # Calculate the off-axis elements in the (half) PASTIS matrix
+        for pair in util.segment_pairs_non_repeating(contrast_matrix.shape[0]):    # this util function returns a generator
+            if pair[0] != pair[1]:    # exclude diagonal elements
+                matrix_off_val = (contrast_matrix[pair[0], pair[1]] - contrast_matrix[pair[0], pair[0]] - contrast_matrix[pair[1], pair[1]]) / 2.
+                matrix_pastis_half[pair[0], pair[1]] = matrix_off_val
+                log.info(f'Off-axis for i{seglist[pair[0]]}-j{seglist[pair[1]]}: {matrix_off_val}')
+
+    # Assuming drifting coronagraph floor across all pair-aberrated measurements
+    elif isinstance(coro_floor, np.ndarray):
+        for pair in util.segment_pairs_non_repeating(contrast_matrix.shape[0]):    # this util function returns a generator
+
+            # First calculate the on-axis elements, which just need to have the coronagraph floor subtracted
+            if pair[0] == pair[1]:
+                matrix_diag_val = matrix_pastis_half[0] - coro_floor[0]
+                matrix_pastis_half[pair[0], pair[0]] = matrix_diag_val
+                log.info(f'On-axis for i{seglist[pair[0]]}-j{seglist[pair[1]]}: {matrix_diag_val}')
+
+            # Then calculate the off-axis elements
+            if pair[0] != pair[1]:    # exclude diagonal elements
+                matrix_off_val = (contrast_matrix[pair[0], pair[1]] - coro_floor[pair[0], pair[1]] - matrix_pastis_half[pair[0], pair[0]] - matrix_pastis_half[pair[1], pair[1]]) / 2.
+                matrix_pastis_half[pair[0], pair[1]] = matrix_off_val
+                log.info(f'Off-axis for i{seglist[pair[0]]}-j{seglist[pair[1]]}: {matrix_off_val}')
+
+    else:
+        raise TypeError('"coro_floor" needs to be either a float, if working with a constant coronagraph floor, or an '
+                        'ndarray, if working with a drifting coronagraph floor.')
 
     return matrix_pastis_half
 
@@ -804,25 +845,25 @@ def num_matrix_multiprocess(instrument, design=None, initial_path='', savepsfs=T
     # results is a list of tuples that contain the return from the partial function, in this case: result[i] = (c, (seg1, seg2))
     contrast_matrix = np.zeros([nb_seg, nb_seg])  # Generate empty matrix
     for i in range(len(results)):
-        # Fill according entry in the matrix and subtract baseline contrast
-        contrast_matrix[results[i][1][0], results[i][1][1]] = results[i][0] - contrast_floor
+        # Fill according entry in the contrast matrix
+        contrast_matrix[results[i][1][0], results[i][1][1]] = results[i][0]
     mypool.close()
 
-    # Save all contrasts to disk, WITH subtraction of coronagraph floor
-    hcipy.write_fits(contrast_matrix, os.path.join(resDir, 'pair-wise_contrasts.fits'))
+    # Save all contrasts to disk, WITHOUT subtraction of coronagraph floor
+    hcipy.write_fits(contrast_matrix, os.path.join(resDir, 'contrast_matrix.fits'))
     plt.figure(figsize=(10, 10))
     plt.imshow(contrast_matrix)
     plt.colorbar()
     plt.savefig(os.path.join(resDir, 'contrast_matrix.pdf'))
 
-    # Calculate the PASTIS matrix from the contrast matrix: off-axis elements and normalization
-    matrix_pastis = pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber)
+    # Calculate the PASTIS matrix from the contrast matrix: analytical matrix element calculation and normalization
+    matrix_pastis = pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber, contrast_floor)
 
     # Save matrix to file
-    filename_matrix = f'PASTISmatrix_num_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}'
+    filename_matrix = f'PASTISmatrix_num_{zern_mode.name}_{zern_mode.convention + str(zern_mode.index)}'    #TODO: I hate my old naming convention. Change this.
     hcipy.write_fits(matrix_pastis, os.path.join(resDir, filename_matrix + '.fits'))
     ppl.plot_pastis_matrix(matrix_pastis, wvln*1e9, out_dir=resDir, save=True)    # convert wavelength to nm
-    log.info(f'Matrix saved to: {os.path.join(resDir, filename_matrix + ".fits")}')
+    log.info(f'PASTIS matrix saved to: {os.path.join(resDir, filename_matrix + ".fits")}')
 
     # Tell us how long it took to finish.
     end_time = time.time()

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -707,7 +707,7 @@ def calculate_semi_analytic_pastis_from_contrast(contrast_matrix, seglist, coro_
         # Calculate the off-axis elements in the (half) PASTIS matrix
         for pair in util.segment_pairs_non_repeating(contrast_matrix.shape[0]):    # this util function returns a generator
             if pair[0] != pair[1]:    # exclude diagonal elements
-                matrix_off_val = (contrast_matrix[pair[0], pair[1]] - contrast_matrix[pair[0], pair[0]] - contrast_matrix[pair[1], pair[1]]) / 2.
+                matrix_off_val = (contrast_matrix[pair[0], pair[1]] + coro_floor - contrast_matrix[pair[0], pair[0]] - contrast_matrix[pair[1], pair[1]]) / 2.
                 matrix_pastis_half[pair[0], pair[1]] = matrix_off_val
                 log.info(f'Off-axis for i{seglist[pair[0]]}-j{seglist[pair[1]]}: {matrix_off_val}')
 

--- a/pastis/pastis_analysis.py
+++ b/pastis/pastis_analysis.py
@@ -451,7 +451,7 @@ def run_full_pastis_analysis(instrument, run_choice, design=None, c_target=1e-10
     # Which parts are we running?
     calculate_modes = True
     calculate_sigmas = True
-    run_monte_carlo_modes = False
+    run_monte_carlo_modes = True
     calc_cumulative_contrast = True
     calculate_mus = True
     run_monte_carlo_segments = True

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -31,6 +31,28 @@ def test_luvoir_matrix_regression():
     assert np.allclose(new_matrix, LUVOIR_MATRIX_SMALL, rtol=1e-8, atol=1e-24), 'Calculated LUVOIR small PASTIS matrix is wrong.'
 
 
+def test_semi_analytic_matrix_from_contrast_matrix():
+    """ Test that the analytical calculation of the semi-analytical PASTIS matrix calculation is correct. """
+
+    # Load a correct contrast matrix
+    #TODO: add comment stating what experient run the contrast matrix is from
+    contrast_matrix_path = os.path.join(test_data_dir, 'data', 'pastis_matrices', 'contrast_matrix_LUVOIR_small_piston-only.fits')
+    contrast_matrix = fits.getdata(contrast_matrix_path)
+
+    # Hard-code the contrast floor and calibration aberration it was generated with
+    coro_floor = 1    #TODO: insert real number
+    wfe_aber = 1e-9    # m
+
+    # Create seglist
+    seglist = util.get_segment_list('LUVOIR')
+
+    # Feed all that into matrix_calc.pastis_from_contrast_matrix()
+    pastis_matrix = matrix_calc.pastis_from_contrast_matrix(contrast_matrix, seglist, wfe_aber, coro_floor)
+
+    # Compare to PASTIS matrix in the tests folder
+    assert np.allclose(pastis_matrix, LUVOIR_MATRIX_SMALL, rtol=1e-8, atol=1e-24), 'Calculated LUVOIR small PASTIS matrix is wrong.'
+
+
 def test_pastis_forward_model():
     """ Test that the PASTIS matrix propagates aberrations correctly
     This is essentially a test for the hockey stick curve, inside its valid range. """

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -3,11 +3,12 @@ from astropy.io import fits
 import astropy.units as u
 import numpy as np
 
-from pastis.matrix_building_numerical import calculate_unaberrated_contrast_and_normalization, num_matrix_multiprocess
+import pastis.matrix_building_numerical as matrix_calc
 from pastis import util
 
 
 # Read the LUVOIR-A small APLC PASTIS matrix
+# TODO: add data dir the matrix is from as comment
 test_data_dir = os.path.join(util.find_package_location(), 'tests')
 matrix_path = os.path.join(test_data_dir, 'data', 'pastis_matrices', 'LUVOIR_small_matrix_piston-only.fits')
 
@@ -19,7 +20,7 @@ def test_luvoir_matrix_regression():
     """ Check multiprocessed matrix calculation against previously calculated matrix """
 
     # Calculate new LUVOIR small PASTIS matrix
-    new_matrix_path = num_matrix_multiprocess(instrument='LUVOIR', design='small', savepsfs=False, saveopds=False)
+    new_matrix_path = matrix_calc.num_matrix_multiprocess(instrument='LUVOIR', design='small', savepsfs=False, saveopds=False)
     new_matrix = fits.getdata(os.path.join(new_matrix_path, 'matrix_numerical', 'PASTISmatrix_num_piston_Noll1.fits'))
 
     # Check that the calculated PASTIS matrix is symmetric
@@ -40,7 +41,7 @@ def test_pastis_forward_model():
     absolute_tolerances = [1e-15, 1e-9, 1e-8]
 
     # Calculate coronagraph floor, direct PSF peak normalization factor, and return E2E sim instance
-    contrast_floor, norm, luvoir_sim = calculate_unaberrated_contrast_and_normalization('LUVOIR', 'small')
+    contrast_floor, norm, luvoir_sim = matrix_calc.calculate_unaberrated_contrast_and_normalization('LUVOIR', 'small')
 
     for rms, rel_tol, abs_tol in zip(rms_values, relative_tolerances, absolute_tolerances):
         # Create random aberration coefficients on segments, scaled to total rms

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -31,7 +31,7 @@ def test_luvoir_matrix_regression():
     assert np.allclose(new_matrix, LUVOIR_MATRIX_SMALL, rtol=1e-8, atol=1e-24), 'Calculated LUVOIR small PASTIS matrix is wrong.'
 
 
-def test_semi_analytic_matrix_from_contrast_matrix():
+def x_test_semi_analytic_matrix_from_contrast_matrix():
     """ Test that the analytical calculation of the semi-analytical PASTIS matrix calculation is correct. """
 
     # Load a correct contrast matrix


### PR DESCRIPTION
Previously, we have been assuming a constant contrast floor (=coronagraph floor) across all measurements required for the construction of the PASTIS matrix, i.e. all DH average contrast measurements from pair-wise aberrated segments. This PR enables the calculation of the PASTIS matrix when we have a drifting contrast floor and each pair-wise aberrated image comes with a measurement of the contrast floor at a time close enough to assume it doesn't change between the two measurements.

These changes include:
- Normalize the contrast matrix and coronagraph floor to their final units right after they are calculated, instead of at the very end of the PASTIS matrix calculation.
- Implement the case in which we have a drifting coronagraph floor and these measurements are passed in as a 2D array, instead of a single float number.
- Support both cases (single, constant coronagraph floor and 2D array of drifting contrast floor measurements) in the calculation of the semi-analytical PASTIS matrix.
- The contrast matrix saved out to disk will not **not** have the coronagraph floor subtracted off anymore. This is just a change in a final output file that does not get used further downstream, but this was a source for confusion before so I tried to be very clear in the README and all docstrings and comments.

Note how the currently implemented simulations all assume a constant coronagraph floor, so this is the only case that's being tested for this PR. Testing of the drifting contrast floor will be done separately, in a new PR.