### PR TITLE
Add Harris and ripple DMs to simulator

### DIFF
--- a/Jupyter Notebooks/LUVOIR/21_extend_LUVOIR_simulator.ipynb
+++ b/Jupyter Notebooks/LUVOIR/21_extend_LUVOIR_simulator.ipynb
@@ -78,8 +78,8 @@
    "outputs": [],
    "source": [
     "# For old SegmentedMirror (indexed aperture)\n",
-    "luvoir.set_segment(18, 20e-9, 0, 0)\n",
-    "luvoir.set_segment(75, 20e-9, 0, 0)"
+    "#luvoir.set_segment(18, 20e-9, 0, 0)\n",
+    "#luvoir.set_segment(75, 20e-9, 0, 0)"
    ]
   },
   {
@@ -88,11 +88,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# For new SegmentedMirror (hcipy deformable mirror)\n",
-    "new_command = np.zeros(120*2)\n",
+    "# Create multi mode segmented mirror\n",
+    "n_modes_segs = 5\n",
+    "luvoir.create_segmented_mirror(n_modes_segs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with multi mode segmented mirror\n",
+    "new_command = np.zeros(120*n_modes_segs)\n",
     "new_command[4] = 2e-9\n",
-    "new_command[54] = 2e-9\n",
-    "luvoir.sm.actuators = new_command"
+    "new_command[53] = 2e-9\n",
+    "new_command[346] = 2e-9\n",
+    "luvoir.sm.actuators = new_command\n",
+    "coro_im_aber1 = luvoir.calc_psf(display_intermediate=True, ref=False)"
    ]
   },
   {
@@ -101,6 +114,98 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Create low-order (Zernike) mode mirror\n",
+    "n_modes_zernikes = 8\n",
+    "luvoir.create_global_zernike_mirror(n_modes_zernikes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with Zernike mode mirror\n",
+    "new_command = np.zeros(n_modes_zernikes)\n",
+    "new_command[7] = 2e-9\n",
+    "luvoir.zernike_mirror.actuators = new_command\n",
+    "coro_im_aber1 = luvoir.calc_psf(display_intermediate=True, ref=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a good ol' continuous DM\n",
+    "n_acts_across = 15 \n",
+    "luvoir.create_continuous_deformable_mirror(n_acts_across)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with continuous deformable mirror\n",
+    "new_command = np.zeros(n_acts_across*n_acts_across)\n",
+    "new_command[66] = 2e-9\n",
+    "new_command[77] = 2e-9\n",
+    "new_command[147] = 2e-9\n",
+    "luvoir.dm.actuators = new_command\n",
+    "coro_im_aber1 = luvoir.calc_psf(display_intermediate=True, ref=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create high-order (ripple) mode mirror\n",
+    "n_ripples = 5    # need to use odd number\n",
+    "luvoir.create_ripple_mirror(n_ripples)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with Zernike mode mirror\n",
+    "new_command = np.zeros(n_ripples*n_ripples)\n",
+    "new_command[12] = 2e-9\n",
+    "luvoir.ripple_mirror.actuators = new_command\n",
+    "coro_im_aber1 = luvoir.calc_psf(display_intermediate=True, ref=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create segmented Harris mode mirror\n",
+    "fpath = '/Users/ilaginja/repos/PASTIS/Sensitivities2.xlsx'    # path to Harris spreadsheet\n",
+    "pad_orientations = np.pi / 2 * np.ones(120)\n",
+    "luvoir.create_segmented_harris_mirror(fpath, pad_orientations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with segmented Harris mode mirror\n",
+    "new_command = np.zeros(luvoir.harris_sm.num_actuators)\n",
+    "print(new_command.shape)\n",
+    "new_command[18] = 1e-9\n",
+    "new_command[37] = 2e-9\n",
+    "luvoir.harris_sm.actuators = new_command\n",
     "coro_im_aber1 = luvoir.calc_psf(display_intermediate=True, ref=False)"
    ]
   },

--- a/Jupyter Notebooks/LUVOIR/21_extend_LUVOIR_simulator.ipynb
+++ b/Jupyter Notebooks/LUVOIR/21_extend_LUVOIR_simulator.ipynb
@@ -89,6 +89,7 @@
    "outputs": [],
    "source": [
     "# Create multi mode segmented mirror\n",
+    "# !! THIS CELL TAKES QUITE A WHILE TO RUN !!\n",
     "n_modes_segs = 5\n",
     "luvoir.create_segmented_mirror(n_modes_segs)"
    ]

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - jupyter
   - matplotlib
   - numpy
+  - openpyxl
   - pandas
   - pip
   - progressbar2

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -146,8 +146,8 @@ class SegmentedTelescopeAPLC:
         ----------
         filepath : string
             absolute path to the xls spreadsheet containing the Harris segment modes
-        pad_orientation : type?
-            orientation of the mounting pads of the primary, one array/list entry per segment?
+        pad_orientation : ndarray
+            angles of orientation of the mounting pads of the primary, in rad, one per segment
         """
 
         # Read the spreadsheet containing the Harris segment modes

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -20,6 +20,18 @@ log = logging.getLogger()
 class SegmentedTelescopeAPLC:
     """ A segmented telescope with an APLC and actuated segments.
 
+    By default instantiates just with a segmented mirror that can do piston, tip and tilt with the pre-defined methods.
+    Use the deformable mirror methods to create more flexible DMs as class attributes:
+        self.sm
+        self.harris_sm
+        self.zernike_mirror
+        self.ripple_mirror
+        self.dm
+    You can retrieve the number of modes/influence functions/actuators of each DM by calling its num_actuators attribute, e.g.
+        self.harris_sm.num_actuators
+    You can command each DM by passing it an array of length "num_actuators", e.g.
+        self.sm.actuators = dm_command
+
     Parameters:
     ----------
     aper : Field
@@ -35,10 +47,11 @@ class SegmentedTelescopeAPLC:
         Lyot stop
     fpm : Field
         Focal plane mask
-    focal_grid :
+    focal_grid : hcipy focal grid
         Focal plane grid to put final image on
     params : dict
-        wavelength, telescope diameter, image radius in lambda/D, FPM radius in lambda/D, segment circumscribed diameter in m
+        wavelength in m, telescope diameter in m, image radius in lambda/D, FPM radius in lambda/D,
+        segment circumscribed diameter in m
     """
 
     def __init__(self, aper, indexed_aperture, seg_pos, apod, lyotst, fpm, focal_grid, params):

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -203,12 +203,18 @@ class SegmentedTelescopeAPLC:
 
             # Transform all needed Harris modes from data to modes on our segmented aperture
             ZA = _transform_harris_mode(valuesA, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZB = _transform_harris_mode(valuesB, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZC = _transform_harris_mode(valuesC, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZD = _transform_harris_mode(valuesD, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZE = _transform_harris_mode(valuesE, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZF = _transform_harris_mode(valuesF, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZG = _transform_harris_mode(valuesG, x_rotation, y_rotation, points, seg_evaluated, seg_num)
             ZH = _transform_harris_mode(valuesH, x_rotation, y_rotation, points, seg_evaluated, seg_num)
             ZI = _transform_harris_mode(valuesI, x_rotation, y_rotation, points, seg_evaluated, seg_num)
             ZJ = _transform_harris_mode(valuesJ, x_rotation, y_rotation, points, seg_evaluated, seg_num)
             ZK = _transform_harris_mode(valuesK, x_rotation, y_rotation, points, seg_evaluated, seg_num)
 
-            harris_base_thermal.append([ZA, ZH, ZI, ZJ, ZK])
+            harris_base_thermal.append([ZA, ZB, ZC, ZD, ZE, ZF, ZG, ZH, ZI, ZJ, ZK])
 
         # Create full mode basis of all Harris modes on all segments
         harris_base_thermal = np.asarray(harris_base_thermal)

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -193,20 +193,20 @@ class SegmentedTelescopeAPLC:
         for seg_num in range(0, self.nseg):
 
             grid_seg = self.pupil_grid.shifted(-self.seg_pos[seg_num])
-            xL1D = np.asarray(grid_seg.x)
-            yL1D = np.asarray(grid_seg.y)
+            x_line_grid = np.asarray(grid_seg.x)
+            y_line_grid = np.asarray(grid_seg.y)
 
             # Rotate the modes grids according to the orientation of the mounting pads
             phi = pad_orientation[seg_num]
-            XRot = xL1D * np.cos(phi) + yL1D * np.sin(phi)
-            YRot = -xL1D * np.sin(phi) + yL1D * np.cos(phi)
+            x_rotation = x_line_grid * np.cos(phi) + y_line_grid * np.sin(phi)
+            y_rotation = -x_line_grid * np.sin(phi) + y_line_grid * np.cos(phi)
 
             # Transform all needed Harris modes from data to modes on our segmented aperture
-            ZA = _transform_harris_mode(valuesA, XRot, YRot, points, seg_evaluated, seg_num)
-            ZH = _transform_harris_mode(valuesH, XRot, YRot, points, seg_evaluated, seg_num)
-            ZI = _transform_harris_mode(valuesI, XRot, YRot, points, seg_evaluated, seg_num)
-            ZJ = _transform_harris_mode(valuesJ, XRot, YRot, points, seg_evaluated, seg_num)
-            ZK = _transform_harris_mode(valuesK, XRot, YRot, points, seg_evaluated, seg_num)
+            ZA = _transform_harris_mode(valuesA, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZH = _transform_harris_mode(valuesH, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZI = _transform_harris_mode(valuesI, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZJ = _transform_harris_mode(valuesJ, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZK = _transform_harris_mode(valuesK, x_rotation, y_rotation, points, seg_evaluated, seg_num)
 
             harris_base_thermal.append([ZA, ZH, ZI, ZJ, ZK])
 

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -272,7 +272,7 @@ class SegmentedTelescopeAPLC:
         Parameters:
         ----------
         ref : bool
-            Keyword for additionally returning the refrence PSF without the FPM.
+            Keyword for additionally returning the reference PSF without the FPM.
         display_intermediate : bool
             Keyword for display of all planes.
         return_intermediate : string
@@ -286,7 +286,7 @@ class SegmentedTelescopeAPLC:
         wf_im_ref.intensity : Field, optional
             Reference image without FPM.
         intermediates : dict of Fields, optional
-            Intermediate plane intensity images; except for full wavefront on segmented mirror.
+            Intermediate plane intensity images; except for phases on DMs
         wf_im_coro : Wavefront
             Wavefront in last focal plane.
         wf_im_ref : Wavefront, optional
@@ -409,10 +409,13 @@ class SegmentedTelescopeAPLC:
 
         if return_intermediate == 'intensity':
 
-            # TODO make sure to also return all additional deformable mirrors
-
-            # Return the intensity in all planes; except phase on the SM (first plane)
+            # Return the intensity in all planes; except phases on all DMs, and combined phase from active pupils
             intermediates = {'seg_mirror': wf_sm.phase,
+                             'zernike_mirror': wf_zm.phase,
+                             'dm': wf_dm.phase,
+                             'harris_seg_mirror': wf_harris_sm.phase,
+                             'ripple_mirror': wf_ripples.phase,
+                             'active_pupil': wf_active_pupil.phase,
                              'apod': wf_apod.intensity,
                              'before_fpm': wf_before_fpm.intensity / wf_before_fpm.intensity.max(),
                              'after_fpm': int_after_fpm / wf_before_fpm.intensity.max(),
@@ -426,10 +429,13 @@ class SegmentedTelescopeAPLC:
 
         if return_intermediate == 'efield':
 
-            # TODO make sure to also return all additional deformable mirrors
-
             # Return the E-fields in all planes; except intensity in focal plane after FPM
             intermediates = {'seg_mirror': wf_sm,
+                             'zernike_mirror': wf_zm,
+                             'dm': wf_dm,
+                             'harris_seg_mirror': wf_harris_sm,
+                             'ripple_mirror': wf_ripples,
+                             'active_pupil': wf_active_pupil,
                              'apod': wf_apod,
                              'before_fpm': wf_before_fpm,
                              'after_fpm': int_after_fpm,


### PR DESCRIPTION
Like in #87, this doesn't change the scripts that calculate the matrix or do the analysis, but this adds functionality to the simulator:
- create and use a DM putting Fourier modes on the primary mirror
- create and use a segmented DM that applies custom Harris modes to the primary mirror
I have implemented the Harris segmented mirror such that it can exist at the same time like the Zernike segmented mirror, in case we ever want to use both at the same time.

This should fully enable us to run @lpueyo's notebooks off of the default branch. Fyi @ananyasahoo1904 