### PR TITLE
Split simulator classes

### DIFF
--- a/Jupyter Notebooks/LUVOIR/21_extend_LUVOIR_simulator.ipynb
+++ b/Jupyter Notebooks/LUVOIR/21_extend_LUVOIR_simulator.ipynb
@@ -176,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# For usage with Zernike mode mirror\n",
+    "# For usage with ripple mirror\n",
     "new_command = np.zeros(n_ripples*n_ripples)\n",
     "new_command[12] = 2e-9\n",
     "luvoir.ripple_mirror.actuators = new_command\n",
@@ -190,6 +190,7 @@
    "outputs": [],
    "source": [
     "# Create segmented Harris mode mirror\n",
+    "# !! THIS CELL TAKES QUITE A WHILE TO RUN !!\n",
     "fpath = '/Users/ilaginja/repos/PASTIS/Sensitivities2.xlsx'    # path to Harris spreadsheet\n",
     "pad_orientations = np.pi / 2 * np.ones(120)\n",
     "luvoir.create_segmented_harris_mirror(fpath, pad_orientations)"

--- a/Jupyter Notebooks/LUVOIR/22_refactor_sim_classes.ipynb
+++ b/Jupyter Notebooks/LUVOIR/22_refactor_sim_classes.ipynb
@@ -37,7 +37,7 @@
     "sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')\n",
     "optics_input = os.path.join(pastis.util.find_repo_location(), CONFIG_PASTIS.get('LUVOIR', 'optics_path_in_repo'))\n",
     "design = 'small'\n",
-    "luvoir = LuvoirAPLC(optics_input, design, sampling)"
+    "#luvoir = LuvoirAPLC(optics_input, design, sampling)"
    ]
   },
   {
@@ -436,6 +436,33 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "attempted-montgomery",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create multi mode segmented mirror\n",
+    "# !! THIS CELL TAKES QUITE A WHILE TO RUN !!\n",
+    "n_modes_segs = 3\n",
+    "luv.create_segmented_mirror(n_modes_segs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "portable-curve",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create segmented Harris mode mirror\n",
+    "# !! THIS CELL TAKES QUITE A WHILE TO RUN !!\n",
+    "fpath = '/Users/ilaginja/repos/PASTIS/Sensitivities2.xlsx'    # path to Harris spreadsheet\n",
+    "pad_orientations = np.pi / 2 * np.ones(120)\n",
+    "luv.create_segmented_harris_mirror(fpath, pad_orientations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "artistic-algorithm",
    "metadata": {},
    "outputs": [],
@@ -450,11 +477,73 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "covered-stadium",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with multi mode segmented mirror\n",
+    "new_command = np.zeros(luv.sm.num_actuators)\n",
+    "#new_command[5*3] = 2e-8\n",
+    "luv.sm.actuators = new_command"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "employed-works",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "luv.set_segment(120, 2, 2e-8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "correct-basement",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "luv.flatten()\n",
+    "luv.set_harris_segment(121, 1, 2e-8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "amazing-ceremony",
    "metadata": {},
    "outputs": [],
    "source": [
-    "luv_img, luv_direct = luv.calc_psf(display_intermediate=True, ref=True)"
+    "luv_img, luv_direct, inter = luv.calc_psf(display_intermediate=True, ref=True, return_intermediate='efield')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "coordinate-medicine",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "plt.imshow(inter['seg_mirror'].phase.shaped / inter['seg_mirror'].wavenumber, cmap='RdBu', origin='lower')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "interior-venice",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "this_max = np.max(inter['seg_mirror'].phase.shaped / inter['seg_mirror'].wavenumber)\n",
+    "this_min = np.min(inter['seg_mirror'].phase.shaped / inter['seg_mirror'].wavenumber)\n",
+    "print(this_max)\n",
+    "print(this_min)\n",
+    "ptv = np.abs(this_max)+np.abs(this_min)\n",
+    "print(ptv)\n",
+    "print(ptv/4)"
    ]
   },
   {
@@ -472,7 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "brutal-royalty",
+   "id": "important-definition",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/Jupyter Notebooks/LUVOIR/22_refactor_sim_classes.ipynb
+++ b/Jupyter Notebooks/LUVOIR/22_refactor_sim_classes.ipynb
@@ -1,0 +1,502 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "lesser-production",
+   "metadata": {},
+   "source": [
+    "# Refactoring our simulator classes to something more modular"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "shared-sociology",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LogNorm\n",
+    "import numpy as np\n",
+    "import hcipy\n",
+    "from astropy.io import fits\n",
+    "\n",
+    "from pastis.config import CONFIG_PASTIS\n",
+    "import pastis.util\n",
+    "from pastis.e2e_simulators.luvoir_imaging import SegmentedTelescope, LuvoirAPLC, LuvoirA_APLC, SegmentedAPLC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "beneficial-notice",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')\n",
+    "optics_input = os.path.join(pastis.util.find_repo_location(), CONFIG_PASTIS.get('LUVOIR', 'optics_path_in_repo'))\n",
+    "design = 'small'\n",
+    "luvoir = LuvoirAPLC(optics_input, design, sampling)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "noted-start",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "luvoir.seg_pos.size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "laughing-communications",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ob_luvoir = luvoir.calc_out_of_band_wfs()\n",
+    "plt.imshow(ob_luvoir.intensity.shaped)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "unexpected-chuck",
+   "metadata": {},
+   "source": [
+    "## Let's look at SegmentedTelescope first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "defined-negative",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_dir = optics_input\n",
+    "apod_design = design\n",
+    "\n",
+    "apod_dict = {'small': {'pxsize': 1000, 'fpm_rad': 3.5, 'fpm_px': 150, 'iwa': 3.4, 'owa': 12.,\n",
+    "                            'fname': '0_LUVOIR_N1000_FPM350M0150_IWA0340_OWA01200_C10_BW10_Nlam5_LS_IDD0120_OD0982_no_ls_struts.fits'},\n",
+    "                  'medium': {'pxsize': 1000, 'fpm_rad': 6.82, 'fpm_px': 250, 'iwa': 6.72, 'owa': 23.72,\n",
+    "                             'fname': '0_LUVOIR_N1000_FPM682M0250_IWA0672_OWA02372_C10_BW10_Nlam5_LS_IDD0120_OD0982_no_ls_struts.fits'},\n",
+    "                  'large': {'pxsize': 1000, 'fpm_rad': 13.38, 'fpm_px': 400, 'iwa': 13.28, 'owa': 46.88,\n",
+    "                            'fname': '0_LUVOIR_N1000_FPM1338M0400_IWA1328_OWA04688_C10_BW10_Nlam5_LS_IDD0120_OD0982_no_ls_struts.fits'}}\n",
+    "imlamD = 1.2 * apod_dict[apod_design]['owa']\n",
+    "\n",
+    "wvln = CONFIG_PASTIS.getfloat('LUVOIR', 'lambda') * 1e-9    # m\n",
+    "diameter = CONFIG_PASTIS.getfloat('LUVOIR', 'diameter')     # m\n",
+    "lam_over_d = wvln / diameter\n",
+    "\n",
+    "pupil_grid = hcipy.make_pupil_grid(dims=apod_dict[apod_design]['pxsize'], diameter=diameter)\n",
+    "\n",
+    "# Load segmented aperture\n",
+    "aper_path = CONFIG_PASTIS.get('LUVOIR', 'aperture_path_in_optics')\n",
+    "pup_read = hcipy.read_fits(os.path.join(input_dir, aper_path))\n",
+    "aperture = hcipy.Field(pup_read.ravel(), pupil_grid)\n",
+    "\n",
+    "# Load apodizer\n",
+    "apod_path = os.path.join('luvoir_stdt_baseline_bw10', apod_design + '_fpm', 'solutions',\n",
+    "                         apod_dict[apod_design]['fname'])\n",
+    "apod_read = hcipy.read_fits(os.path.join(input_dir, apod_path))\n",
+    "apodizer = hcipy.Field(apod_read.ravel(), pupil_grid)\n",
+    "\n",
+    "# Load Lyot Stop\n",
+    "ls_fname = CONFIG_PASTIS.get('LUVOIR', 'lyot_stop_path_in_optics')\n",
+    "ls_read = hcipy.read_fits(os.path.join(input_dir, ls_fname))\n",
+    "lyot_stop = hcipy.Field(ls_read.ravel(), pupil_grid)\n",
+    "\n",
+    "# Load indexed segmented aperture\n",
+    "aper_ind_path = CONFIG_PASTIS.get('LUVOIR', 'indexed_aperture_path_in_optics')\n",
+    "aper_ind_read = hcipy.read_fits(os.path.join(input_dir, aper_ind_path))\n",
+    "aper_ind = hcipy.Field(aper_ind_read.ravel(), pupil_grid)\n",
+    "\n",
+    "# Load segment positions from fits header\n",
+    "hdr = fits.getheader(os.path.join(input_dir, aper_ind_path))\n",
+    "nseg = CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures')\n",
+    "poslist = []\n",
+    "for i in range(nseg):\n",
+    "    segname = 'SEG' + str(i + 1)\n",
+    "    xin = hdr[segname + '_X']\n",
+    "    yin = hdr[segname + '_Y']\n",
+    "    poslist.append((xin, yin))\n",
+    "poslist = np.transpose(np.array(poslist))\n",
+    "seg_pos = hcipy.CartesianGrid(hcipy.UnstructuredCoords(poslist))\n",
+    "seg_pos = seg_pos.scaled(diameter)\n",
+    "\n",
+    "seg_diameter_circumscribed = 2 / np.sqrt(3) * 1.2225    # m\n",
+    "\n",
+    "# Create a focal plane mask\n",
+    "samp_foc = apod_dict[apod_design]['fpm_px'] / (apod_dict[apod_design]['fpm_rad'] * 2)\n",
+    "focal_grid_fpm = hcipy.make_focal_grid_from_pupil_grid(pupil_grid=pupil_grid, q=samp_foc, num_airy=apod_dict[apod_design]['fpm_rad'], wavelength=wvln)\n",
+    "fpm = 1 - hcipy.circular_aperture(2*apod_dict[apod_design]['fpm_rad'] * lam_over_d)(focal_grid_fpm)\n",
+    "\n",
+    "# Create a focal plane grid for the detector\n",
+    "focal_det = hcipy.make_focal_grid_from_pupil_grid(pupil_grid=pupil_grid, q=sampling, num_airy=imlamD, wavelength=wvln)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "proprietary-nirvana",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seg = SegmentedTelescope(wvln, diameter, aperture, aper_ind, seg_pos, seg_diameter_circumscribed, focal_det, sampling, imlamD)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "valued-pride",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create high-order (ripple) mode mirror\n",
+    "n_ripples = 5    # need to use odd number\n",
+    "seg.create_ripple_mirror(n_ripples)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "guilty-attraction",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a good ol' continuous DM\n",
+    "n_acts_across = 15 \n",
+    "seg.create_continuous_deformable_mirror(n_acts_across)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "medieval-classics",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create low-order (Zernike) mode mirror\n",
+    "n_modes_zernikes = 8\n",
+    "seg.create_global_zernike_mirror(n_modes_zernikes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dutch-people",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create segmented Harris mode mirror\n",
+    "# !! THIS CELL TAKES QUITE A WHILE TO RUN !!\n",
+    "fpath = '/Users/ilaginja/repos/PASTIS/Sensitivities2.xlsx'    # path to Harris spreadsheet\n",
+    "pad_orientations = np.pi / 2 * np.ones(120)\n",
+    "seg.create_segmented_harris_mirror(fpath, pad_orientations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mexican-proportion",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create multi mode segmented mirror\n",
+    "# !! THIS CELL TAKES QUITE A WHILE TO RUN !!\n",
+    "n_modes_segs = 5\n",
+    "seg.create_segmented_mirror(n_modes_segs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "logical-oxygen",
+   "metadata": {},
+   "source": [
+    "**CREATE MIRRORS ONLY ONCE**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "funded-transfer",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with ripple mirror\n",
+    "new_command = np.zeros(n_ripples*n_ripples)\n",
+    "#new_command[12] = 2e-8\n",
+    "seg.ripple_mirror.actuators = new_command"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "addressed-taxation",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with continuous deformable mirror\n",
+    "new_command = np.zeros(n_acts_across*n_acts_across)\n",
+    "new_command[66] = 2e-8\n",
+    "new_command[77] = 2e-8\n",
+    "#new_command[147] = 2e-7\n",
+    "#new_command[84] = 2e-7\n",
+    "#new_command[45] = -2e-7\n",
+    "#new_command[34] = 2e-7\n",
+    "#new_command[24] = 2e-7\n",
+    "#new_command[217] = -2e-7\n",
+    "#new_command[187] = -2e-7\n",
+    "#new_command[123] = 2e-7\n",
+    "#new_command[105] = -2e-7\n",
+    "#new_command[173] = 2e-7\n",
+    "seg.dm.actuators = new_command"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eastern-strand",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with Zernike mode mirror\n",
+    "new_command = np.zeros(n_modes_zernikes)\n",
+    "#new_command[7] = 2e-8\n",
+    "seg.zernike_mirror.actuators = new_command"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "conditional-pittsburgh",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with segmented Harris mode mirror\n",
+    "new_command = np.zeros(luvoir.harris_sm.num_actuators)\n",
+    "print(new_command.shape)\n",
+    "#new_command[18] = 1e-8\n",
+    "#new_command[37] = 2e-8\n",
+    "seg.harris_sm.actuators = new_command"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "restricted-associate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with multi mode segmented mirror\n",
+    "new_command = np.zeros(120*n_modes_segs)\n",
+    "#new_command[4] = 2e-8\n",
+    "#new_command[51] = 2e-4\n",
+    "#new_command[346] = 2e-8\n",
+    "seg.sm.actuators = new_command"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "continuous-caution",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image, inter = seg.calc_psf(display_intermediate=True, return_intermediate='efield')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "political-biography",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "plt.imshow(image.intensity.shaped, norm=LogNorm(), origin='lower')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "spatial-purse",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "found-bridges",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(inter['active_pupil'].phase.shaped, origin='lower')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "natural-visit",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obwfs = seg.calc_out_of_band_wfs()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "operational-logging",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(obwfs.intensity.shaped)\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "diverse-commitment",
+   "metadata": {},
+   "source": [
+    "## Now on to the SegmentedAPLC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adolescent-measure",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aplc = SegmentedAPLC(apodizer, lyot_stop, fpm, apod_dict[apod_design]['fpm_rad'], apod_dict[apod_design]['iwa'],\n",
+    "                     apod_dict[apod_design]['owa'], wvln=wvln, diameter=diameter, aper=aperture,\n",
+    "                     indexed_aper=aper_ind, seg_pos=seg_pos, seg_diameter=seg_diameter_circumscribed,\n",
+    "                     focal_grid=focal_det, sampling=sampling, imlamD=imlamD)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "better-isolation",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aplc_im = aplc.calc_psf(display_intermediate=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "collaborative-workplace",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lowfs_im = aplc.calc_low_order_wfs()\n",
+    "plt.imshow(lowfs_im.intensity.shaped)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "matched-revision",
+   "metadata": {},
+   "source": [
+    "## And finally, the new LUVOIR A with an APLC simulator class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "initial-principle",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "luv = LuvoirA_APLC(optics_input, design, sampling)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "turkish-thanksgiving",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create low-order (Zernike) mode mirror\n",
+    "n_modes_zernikes = 15\n",
+    "luv.create_global_zernike_mirror(n_modes_zernikes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "artistic-algorithm",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For usage with Zernike mode mirror\n",
+    "new_command = np.zeros(n_modes_zernikes)\n",
+    "new_command[12] = 2e-8\n",
+    "new_command[4] = 2e-8\n",
+    "luv.zernike_mirror.actuators = new_command"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "amazing-ceremony",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "luv_img, luv_direct = luv.calc_psf(display_intermediate=True, ref=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hearing-salmon",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "plt.imshow(luv_img.shaped/luv_direct.max(), norm=LogNorm(), cmap='inferno')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "brutal-royalty",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -17,6 +17,64 @@ from pastis.e2e_simulators.indexed_segmented_mirror import SegmentedMirror
 log = logging.getLogger()
 
 
+class SegmentedTelescope:
+    """
+    A segmented telescope with active components in the pupil plane (DMs).
+    """
+    def __init__(self, wvln, diameter, aper, indexed_aper, seg_pos, seg_diameter, focal_grid):
+
+        self.wvln = wvln
+        self.diam = diameter
+        self.aperture = aper
+        self.aper_ind = indexed_aper
+        self.seg_pos = seg_pos
+        self.segment_circumscribed_diameter = seg_diameter
+        self.nseg
+
+        self.pupil_grid = indexed_aper.grid
+        self.focal_det = focal_grid
+        self.sampling
+        self.imlamD
+        self.lam_over_d
+
+        self.prop = hcipy.FraunhoferPropagator(self.pupil_grid, focal_grid)
+        self.wf_aper = hcipy.Wavefront(aper, wavelength=self.wvln)
+
+        self.sm = SegmentedMirror(indexed_aperture=indexed_aper, seg_pos=seg_pos)    # TODO: replace this with None when fully ready to start using create_segmented_mirror()
+        self.harris_sm = None
+        self.zernike_mirror = None
+        self.ripple_mirror = None
+        self.dm = None
+        self.zwfs = None
+
+
+class SegmentedAPLC:
+    """ A segmented APLC """
+    def __init__(self):
+        super().__init__()
+
+        self.apodizer
+        self.lyotstop
+        self.fpm
+        self.fpm_rad
+        self.coro
+        self.coro_no_ls
+        self.dh_mask
+
+
+class LuvoirA_APLC:
+    """ LUVOIR A with APLC simulator """
+    def __init__(self, input_dir, apod_design):
+
+        self.apod_dict = {'small': {'pxsize': 1000, 'fpm_rad': 3.5, 'fpm_px': 150, 'iwa': 3.4, 'owa': 12.,
+                                    'fname': '0_LUVOIR_N1000_FPM350M0150_IWA0340_OWA01200_C10_BW10_Nlam5_LS_IDD0120_OD0982_no_ls_struts.fits'},
+                          'medium': {'pxsize': 1000, 'fpm_rad': 6.82, 'fpm_px': 250, 'iwa': 6.72, 'owa': 23.72,
+                                     'fname': '0_LUVOIR_N1000_FPM682M0250_IWA0672_OWA02372_C10_BW10_Nlam5_LS_IDD0120_OD0982_no_ls_struts.fits'},
+                          'large': {'pxsize': 1000, 'fpm_rad': 13.38, 'fpm_px': 400, 'iwa': 13.28, 'owa': 46.88,
+                                    'fname': '0_LUVOIR_N1000_FPM1338M0400_IWA1328_OWA04688_C10_BW10_Nlam5_LS_IDD0120_OD0982_no_ls_struts.fits'}}
+        super().__init__()
+
+
 class SegmentedTelescopeAPLC:
     """ A segmented telescope with an APLC and actuated segments.
 

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -328,7 +328,7 @@ class SegmentedTelescope:
         if self.dm is not None:
             self.dm.flatten()
 
-    def propagate_active_pupils(self):
+    def _propagate_active_pupils(self):
         """ Propagate aperture wavefront "through" all active entrance pupil elements (DMs).
         Returns:
         --------
@@ -393,7 +393,7 @@ class SegmentedTelescope:
         """
 
         # Propagate aperture wavefront "through" all active entrance pupil elements (DMs)
-        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self.propagate_active_pupils()
+        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self._propagate_active_pupils()
 
         wf_image = self.prop(wf_active_pupil)
 
@@ -474,7 +474,7 @@ class SegmentedTelescope:
             self.create_zernike_wfs()
 
         # Propagate aperture wavefront "through" all active entrance pupil elements (DMs)
-        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self.propagate_active_pupils()
+        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self._propagate_active_pupils()
 
         ob_wfs = self.zwfs(wf_active_pupil)
         return ob_wfs
@@ -546,7 +546,7 @@ class SegmentedAPLC(SegmentedTelescope):
         """
 
         # Propagate aperture wavefront "through" all active entrance pupil elements (DMs)
-        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self.propagate_active_pupils()
+        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self._propagate_active_pupils()
 
         # Create fake FPM for plotting
         fpm_plot = 1 - hcipy.circular_aperture(2 * self.fpm_rad * self.lam_over_d)(self.focal_det)
@@ -686,7 +686,7 @@ class SegmentedAPLC(SegmentedTelescope):
             self.create_zernike_wfs()
 
         # Propagate aperture wavefront "through" all active entrance pupil elements (DMs)
-        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self.propagate_active_pupils()
+        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self._propagate_active_pupils()
 
         # Create apodizer as hcipy.Apodizer() object to be able to propagate through it
         apod_prop = hcipy.Apodizer(self.apodizer)

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -167,6 +167,9 @@ class SegmentedTelescope:
         amplitude : float
             Aberration amplitude in meters of surface.   # FIXME: rms or ptv?
         """
+        if segid == 0 and not self.center_segment:
+            raise NotImplementedError("'self.center_segment' is set to 'False', so there is not center segment to command.")
+
         if isinstance(self.sm, hcipy.optics.DeformableMirror):
             if zernike_number > self.seg_n_zernikes:
                 raise NotImplementedError(f"'self.sm' has only been instantiated for {self.seg_n_zernikes} Zernike modes per segment.")
@@ -294,6 +297,9 @@ class SegmentedTelescope:
         """
         if mode_number > self.n_harris_modes:
             raise NotImplementedError(f"'self.harris_sm' has only been instantiated for {self.n_harris_modes} modes per segment.")
+
+        if segid == 0 and not self.center_segment:
+            raise NotImplementedError("'self.center_segment' is set to 'False', so there is not center segment to command.")
 
         if not self.center_segment:
             segid -= 1

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -174,8 +174,9 @@ class SegmentedTelescope:
             raise NotImplementedError("'self.center_segment' is set to 'False', so there is not center segment to command.")
 
         if isinstance(self.sm, hcipy.optics.DeformableMirror):
-            if zernike_number > self.seg_n_zernikes:
-                raise NotImplementedError(f"'self.sm' has only been instantiated for {self.seg_n_zernikes} Zernike modes per segment.")
+            if zernike_number >= self.seg_n_zernikes:
+                raise NotImplementedError(f"'self.sm' has only been instantiated for {self.seg_n_zernikes} Zernike "
+                                          f"modes per segment, indexed with 0.")
 
             if not self.center_segment:
                 segid -= 1
@@ -304,8 +305,9 @@ class SegmentedTelescope:
             Whether to override all other segment commands with zero, default False, which means the new segment
             aberration will be added to what is already on the segmented mirror.
         """
-        if mode_number > self.n_harris_modes:
-            raise NotImplementedError(f"'self.harris_sm' has only been instantiated for {self.n_harris_modes} modes per segment.")
+        if mode_number >= self.n_harris_modes:
+            raise NotImplementedError(f"'self.harris_sm' has only been instantiated for {self.n_harris_modes} modes "
+                                      f"per segment, indexed with 0.")
 
         if segid == 0 and not self.center_segment:
             raise NotImplementedError("'self.center_segment' is set to 'False', so there is not center segment to command.")

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -21,7 +21,7 @@ class SegmentedTelescope:
     """
     A segmented telescope with active components in the pupil plane (DMs).
     """
-    def __init__(self, wvln, diameter, aper, indexed_aper, seg_pos, seg_diameter, focal_grid):
+    def __init__(self, wvln, diameter, aper, indexed_aper, seg_pos, seg_diameter, focal_grid, sampling, imlamD):
 
         self.wvln = wvln
         self.diam = diameter
@@ -29,13 +29,13 @@ class SegmentedTelescope:
         self.aper_ind = indexed_aper
         self.seg_pos = seg_pos
         self.segment_circumscribed_diameter = seg_diameter
-        self.nseg
+        self.nseg = seg_pos.size
 
         self.pupil_grid = indexed_aper.grid
         self.focal_det = focal_grid
-        self.sampling
-        self.imlamD
-        self.lam_over_d
+        self.sampling = sampling
+        self.imlamD = imlamD
+        self.lam_over_d = wvln / diameter
 
         self.prop = hcipy.FraunhoferPropagator(self.pupil_grid, focal_grid)
         self.wf_aper = hcipy.Wavefront(aper, wavelength=self.wvln)
@@ -47,32 +47,628 @@ class SegmentedTelescope:
         self.dm = None
         self.zwfs = None
 
+    def _create_evaluated_segment_grid(self):
+        """
+        Create a list of segments evaluated on the pupil_grid.
 
-class SegmentedAPLC:
-    """ A segmented APLC """
-    def __init__(self):
-        super().__init__()
+        Returns:
+        --------
+        seg_evaluated: list
+            all segments evaluated individually on self.pupil_grid
+        """
 
-        self.apodizer
-        self.lyotstop
-        self.fpm
-        self.fpm_rad
-        self.coro
-        self.coro_no_ls
-        self.dh_mask
+        # Create single hexagonal segment and full segmented aperture from the single segment, with segment positions
+        segment_field_generator = hcipy.hexagonal_aperture(self.segment_circumscribed_diameter, np.pi / 2)
+        _aper_in_sm, segs_in_sm = hcipy.make_segmented_aperture(segment_field_generator, self.seg_pos,
+                                                                return_segments=True)
+
+        # Evaluate all segments individually on the pupil_grid
+        seg_evaluated = []
+        for seg_tmp in segs_in_sm:
+            tmp_evaluated = hcipy.evaluate_supersampled(seg_tmp, self.pupil_grid, 1)
+            seg_evaluated.append(tmp_evaluated)
+
+        return seg_evaluated
+
+    def create_segmented_mirror(self, n_zernikes):
+        """
+        This creates an actuated segmented mirror from hcipy's DeformableMirror, with n_zernikes Zernike modes per segment.
+
+        Parameters:
+        ----------
+        n_zernikes : int
+            how many Zernikes to create per segment
+        """
+
+        seg_evaluated = self._create_evaluated_segment_grid()
+
+        # Create a single segment influence function with all Zernikes n_zernikes
+        first_seg = 0  # Create this first influence function on the center segment only
+        local_zernike_basis = hcipy.mode_basis.make_zernike_basis(n_zernikes,
+                                                                  self.segment_circumscribed_diameter,
+                                                                  self.pupil_grid.shifted(-self.seg_pos[first_seg]),
+                                                                  starting_mode=1)
+        # For all Zernikes, adjust their transformation matrix (by doing what?)
+        for zernike_num in range(0, n_zernikes):
+            local_zernike_basis._transformation_matrix[:, zernike_num] = seg_evaluated[
+                                                                             first_seg] * local_zernike_basis._transformation_matrix[
+                                                                                          :, zernike_num]
+
+        # Expand the basis of influence functions from one segment to all segments
+        for seg_num in range(1, self.nseg):
+            local_zernike_basis_tmp = hcipy.mode_basis.make_zernike_basis(n_zernikes,
+                                                                          self.segment_circumscribed_diameter,
+                                                                          self.pupil_grid.shifted(
+                                                                              -self.seg_pos[seg_num]),
+                                                                          starting_mode=1)
+            # Adjust each transformation matrix again for some reason
+            for zernike_num in range(0, n_zernikes):
+                local_zernike_basis_tmp._transformation_matrix[:, zernike_num] = seg_evaluated[
+                                                                                     seg_num] * local_zernike_basis_tmp._transformation_matrix[
+                                                                                                :, zernike_num]
+            local_zernike_basis.extend(local_zernike_basis_tmp)  # extend our basis with this new segment
+
+        self.sm = hcipy.optics.DeformableMirror(local_zernike_basis)
+
+    def create_segmented_harris_mirror(self, filepath, pad_orientation):
+        """Generate a basis made of the thermal modes provided by Harris.
+
+        Thermal modes: a, h, i, j, k
+        Mechanical modes: e, f, g
+        Other modes: b, c, d
+
+        Parameters:
+        ----------
+        filepath : string
+            absolute path to the xls spreadsheet containing the Harris segment modes
+        pad_orientation : ndarray
+            angles of orientation of the mounting pads of the primary, in rad, one per segment
+        """
+
+        # Read the spreadsheet containing the Harris segment modes
+        try:
+            df = pd.read_excel(filepath)
+        except FileNotFoundError:
+            log.warning(f"Could not find the Harris spreadsheet under '{filepath}', "
+                        f"please double-check your path and that the file exists.")
+            return
+
+        # Read all modes as arrays
+        valuesA = np.asarray(df.a)
+        valuesB = np.asarray(df.b)
+        valuesC = np.asarray(df.c)
+        valuesD = np.asarray(df.d)
+        valuesE = np.asarray(df.e)
+        valuesF = np.asarray(df.f)
+        valuesG = np.asarray(df.g)
+        valuesH = np.asarray(df.h)
+        valuesI = np.asarray(df.i)
+        valuesJ = np.asarray(df.j)
+        valuesK = np.asarray(df.k)
+
+        seg_x = np.asarray(df.X)
+        seg_y = np.asarray(df.Y)
+        harris_seg_diameter = np.max([np.max(seg_x) - np.min(seg_x), np.max(seg_y) - np.min(seg_y)])
+
+        pup_dims = self.pupil_grid.dims
+        x_grid = np.asarray(df.X) * self.segment_circumscribed_diameter / harris_seg_diameter
+        y_grid = np.asarray(df.Y) * self.segment_circumscribed_diameter / harris_seg_diameter
+        points = np.transpose(np.asarray([x_grid, y_grid]))
+
+        seg_evaluated = self._create_evaluated_segment_grid()
+
+        def _transform_harris_mode(values, xrot, yrot, points, seg_evaluated, seg_num):
+            """ Take imported Harris mode data and transform into a segment mode on our aperture."""
+            zval = griddata(points, values, (xrot, yrot), method='linear')
+            zval[np.isnan(zval)] = 0
+            zval = zval.ravel() * seg_evaluated[seg_num]
+            return zval
+
+        harris_base_thermal = []
+        for seg_num in range(0, self.nseg):
+            grid_seg = self.pupil_grid.shifted(-self.seg_pos[seg_num])
+            x_line_grid = np.asarray(grid_seg.x)
+            y_line_grid = np.asarray(grid_seg.y)
+
+            # Rotate the modes grids according to the orientation of the mounting pads
+            phi = pad_orientation[seg_num]
+            x_rotation = x_line_grid * np.cos(phi) + y_line_grid * np.sin(phi)
+            y_rotation = -x_line_grid * np.sin(phi) + y_line_grid * np.cos(phi)
+
+            # Transform all needed Harris modes from data to modes on our segmented aperture
+            ZA = _transform_harris_mode(valuesA, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZB = _transform_harris_mode(valuesB, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZC = _transform_harris_mode(valuesC, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZD = _transform_harris_mode(valuesD, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZE = _transform_harris_mode(valuesE, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZF = _transform_harris_mode(valuesF, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZG = _transform_harris_mode(valuesG, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZH = _transform_harris_mode(valuesH, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZI = _transform_harris_mode(valuesI, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZJ = _transform_harris_mode(valuesJ, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+            ZK = _transform_harris_mode(valuesK, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+
+            harris_base_thermal.append([ZA, ZB, ZC, ZD, ZE, ZF, ZG, ZH, ZI, ZJ, ZK])
+
+        # Create full mode basis of all Harris modes on all segments
+        harris_base_thermal = np.asarray(harris_base_thermal)
+        n_single_modes = harris_base_thermal.shape[1]
+        harris_base_thermal = harris_base_thermal.reshape(self.nseg * n_single_modes, pup_dims[0] ** 2)
+        harris_thermal_mode_basis = hcipy.ModeBasis(np.transpose(harris_base_thermal), grid=self.pupil_grid)
+
+        self.harris_sm = hcipy.optics.DeformableMirror(harris_thermal_mode_basis)
+
+    def create_global_zernike_mirror(self, n_zernikes):
+        """
+        Create a Zernike mirror in the pupil plane, with a global Zenrike modal basis of n_zernikes modes.
+
+        Parameters:
+        ----------
+        n_zernikes : int
+            number of Zernikes to enable the Zernike mirror for.
+        """
+        global_zernike_basis = hcipy.mode_basis.make_zernike_basis(n_zernikes,
+                                                                   self.diam,
+                                                                   self.pupil_grid,
+                                                                   starting_mode=1)
+        self.zernike_mirror = hcipy.optics.DeformableMirror(global_zernike_basis)
+
+    def create_ripple_mirror(self, n_fourier):
+        """
+        Create a Dm that applies Fourier sine and cosine modes in the entrance pupil plane, up to n_fourier cycles per aperture.
+        Parameters:
+        ----------
+        n_fourier : int
+            Maximum number for cycles per apertures, use an odd number (!)
+        """
+        fourier_grid = hcipy.make_pupil_grid(dims=n_fourier, diameter=n_fourier)
+        fourier_basis = hcipy.mode_basis.make_fourier_basis(self.pupil_grid, fourier_grid, sort_by_energy=True)
+        self.ripple_mirror = hcipy.optics.DeformableMirror(fourier_basis)
+
+    def create_continuous_deformable_mirror(self, n_actuators_across):
+        """
+        Create a continuous deformable mirror in the pupil plane, with n_actuators_across across the pupil.
+
+        Parameters:
+        ----------
+        n_actuators_across : int
+            number of actuators across the pupil plane
+        """
+        actuator_spacing = self.diam / n_actuators_across
+        influence_functions = hcipy.make_xinetics_influence_functions(self.pupil_grid,
+                                                                      n_actuators_across,
+                                                                      actuator_spacing)
+        self.dm = hcipy.DeformableMirror(influence_functions)
+
+    def flatten(self):
+        """
+        Flatten all deformable mirrors in this simulator instance, if they exist.
+        """
+        if self.sm is not None:
+            self.sm.flatten()
+        if self.harris_sm is not None:
+            self.harris_sm.flatten()
+        if self.zernike_mirror is not None:
+            self.zernike_mirror.flatten()
+        if self.ripple_mirror is not None:
+            self.ripple_mirror.flatten()
+        if self.dm is not None:
+            self.dm.flatten()
+
+    def propagate_active_pupils(self):
+        """ Propagate aperture wavefront "through" all active entrance pupil elements (DMs).
+        Returns:
+        --------
+        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm : hcipy.Wavefronts
+            E-field after each respective DM individually; all DMs in the case of wf_active_pupil
+        """
+
+        # Create empty field for components that are None
+        values = np.ones_like(self.pupil_grid.x)
+        transparent_field = hcipy.Field(values, self.pupil_grid)
+
+        # Calculate wavefront after all active pupil components depending on which of the DMs exist
+        wf_active_pupil = self.wf_aper
+
+        if self.sm is not None:
+            wf_active_pupil = self.sm(wf_active_pupil)
+            wf_sm = self.sm(self.wf_aper)
+        else:
+            wf_sm = hcipy.Wavefront(transparent_field, wavelength=self.wvln)
+        if self.harris_sm is not None:
+            wf_active_pupil = self.harris_sm(wf_active_pupil)
+            wf_harris_sm = self.harris_sm(self.wf_aper)
+        else:
+            wf_harris_sm = hcipy.Wavefront(transparent_field, wavelength=self.wvln)
+        if self.zernike_mirror is not None:
+            wf_active_pupil = self.zernike_mirror(wf_active_pupil)
+            wf_zm = self.zernike_mirror(self.wf_aper)
+        else:
+            wf_zm = hcipy.Wavefront(transparent_field, wavelength=self.wvln)
+        if self.ripple_mirror is not None:
+            wf_active_pupil = self.ripple_mirror(wf_active_pupil)
+            wf_ripples = self.ripple_mirror(self.wf_aper)
+        else:
+            wf_ripples = hcipy.Wavefront(transparent_field, wavelength=self.wvln)
+        if self.dm is not None:
+            wf_active_pupil = self.dm(wf_active_pupil)
+            wf_dm = self.dm(self.wf_aper)
+        else:
+            wf_dm = hcipy.Wavefront(transparent_field, wavelength=self.wvln)
+
+        return wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm
+
+    def calc_psf(self, display_intermediate=False,  return_intermediate=None):
+        """
+        Calculate the PSF of this segmented telescope, and return optionally all E-fields.
+
+        Parameters:
+        ----------
+        display_intermediate : bool
+            Whether or not to display images of all planes.
+        return_intermediate : string
+            default None; if "efield", will also return E-fields of each plane and DM
+
+        Returns:
+        --------
+        wf_image.intensity : Field
+            returned if return_intermediate=None (default)
+        wf_image : hcipy.Wavefront
+            returned if return_intermediate='efield'
+        intermediates : dict
+            Dictionary containing the Wavefronts of all the planes, returned if return_intermediate='efield'
+        """
+
+        # Propagate aperture wavefront "through" all active entrance pupil elements (DMs)
+        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self.propagate_active_pupils()
+
+        wf_image = self.prop(wf_active_pupil)
+
+        if display_intermediate:
+            plt.figure(figsize=(15, 15))
+
+            plt.subplot(3, 3, 1)
+            hcipy.imshow_field(self.wf_aper.intensity, mask=self.aperture, cmap='Greys_r')
+            plt.title('Primary mirror')
+
+            plt.subplot(3, 3, 2)
+            hcipy.imshow_field(wf_sm.phase, mask=self.aperture, cmap='RdBu')
+            plt.title('Segmented mirror phase')
+
+            plt.subplot(3, 3, 3)
+            hcipy.imshow_field(wf_zm.phase, mask=self.aperture, cmap='RdBu')
+            plt.title('Global Zernike phase')
+
+            plt.subplot(3, 3, 4)
+            hcipy.imshow_field(wf_dm.phase, mask=self.aperture, cmap='RdBu')
+            plt.title('Deformable mirror phase')
+
+            plt.subplot(3, 3, 5)
+            hcipy.imshow_field(wf_harris_sm.phase, mask=self.aperture, cmap='RdBu')
+            plt.title('Harris mode mirror phase')
+
+            plt.subplot(3, 3, 6)
+            hcipy.imshow_field(wf_ripples.phase, mask=self.aperture, cmap='RdBu')
+            plt.title('High modes mirror phase')
+
+            plt.subplot(3, 3, 7)
+            hcipy.imshow(wf_active_pupil.phase, mask=self.aperture, cmap='RdBu')
+            plt.title('Total phase in entrance pupil')
+
+            plt.subplot(3, 3, 8)
+            hcipy.imshow(wf_image.intensity / wf_image.intensity.max(), cmap='inferno')
+            plt.title('Focal plane image')
+
+        if return_intermediate == 'efield':
+            # Return the E-fields in all planes; except intensity in focal plane after FPM
+            intermediates = {'seg_mirror': wf_sm,
+                             'zernike_mirror': wf_zm,
+                             'dm': wf_dm,
+                             'harris_seg_mirror': wf_harris_sm,
+                             'ripple_mirror': wf_ripples,
+                             'active_pupil': wf_active_pupil}
+            return wf_image, intermediates
+
+        return wf_image.intensity
+
+    def create_zernike_wfs(self, step=None, spot_diam=None, spot_points=None):
+        """ Create a Zernike wavefront sensor object. """
+        if step is None:
+            step = np.pi / 2
+        if spot_diam is None:
+            spot_diam = 1.06
+        if spot_points is None:
+            spot_points = 128
+
+        self.zwfs = hcipy.wavefront_sensing.ZernikeWavefrontSensorOptics(self.pupil_grid,
+                                                                         phase_step=step,
+                                                                         phase_dot_diameter=spot_diam,
+                                                                         num_pix=spot_points,
+                                                                         pupil_diameter=1/self.diam,
+                                                                         reference_wavelength=1/self.wvln)
+
+    def calc_out_of_band_wfs(self):
+        """ Propagate pupil through an out-of-band wavefront sensor.
+        Returns:
+        --------
+        ob_wfs : hcipy.Wavefront
+            E-field on OBWFS detector
+        """
+
+        # If ZWFS hasn't been created yet, do it now
+        if self.zwfs is None:
+            self.create_zernike_wfs()
+
+        # Propagate aperture wavefront "through" all active entrance pupil elements (DMs)
+        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self.propagate_active_pupils()
+
+        ob_wfs = self.zwfs(wf_active_pupil)
+        return ob_wfs
 
 
-class LuvoirA_APLC:
+class SegmentedAPLC(SegmentedTelescope):
+    """ A segmented Apodized Pupil Lyot Coronagraph (APLC) """
+    def __init__(self, apod, lyot_stop, fpm, fpm_rad, iwa, owa, **kwargs):
+        self.apodizer = apod
+        self.lyotstop = lyot_stop
+        self.fpm = fpm
+        self.fpm_rad = fpm_rad
+        super().__init__(**kwargs)
+
+        self.coro = hcipy.LyotCoronagraph(self.pupil_grid, fpm, lyot_stop)
+        self.coro_no_ls = hcipy.LyotCoronagraph(self.pupil_grid, fpm)
+        self.iwa = iwa
+        self.owa = owa
+        dh_outer = hcipy.circular_aperture(2 * owa * self.lam_over_d)(self.focal_det)
+        dh_inner = hcipy.circular_aperture(2 * iwa * self.lam_over_d)(self.focal_det)
+        self.dh_mask = (dh_outer - dh_inner).astype('bool')
+
+    def calc_psf(self, ref=False, display_intermediate=False,  return_intermediate=None):
+        """Calculate the PSF of the segmented telescope, normalized to contrast units.
+
+        Parameters:
+        ----------
+        ref : bool
+            Keyword for additionally returning the reference PSF without the FPM.
+        display_intermediate : bool
+            Whether or not to display images of all planes.
+        return_intermediate : string
+            Either 'intensity', return the intensity in all planes; except phase on the SM (first plane)
+            or 'efield', return the E-fields in all planes. Default none.
+
+        Returns:
+        --------
+        wf_im_coro.intensity : Field
+            Coronagraphic image, normalized to contrast units by max of reference image (even when ref
+            not returned).
+        wf_im_ref.intensity : Field, optional
+            Reference image without FPM.
+        intermediates : dict of Fields, optional
+            Intermediate plane intensity images; except for phases on DMs
+        wf_im_coro : Wavefront
+            Wavefront in last focal plane.
+        wf_im_ref : Wavefront, optional
+            Wavefront of reference image without FPM.
+        intermediates : dict of Wavefronts, optional
+            Intermediate plane E-fields; except intensity in focal plane after FPM.
+        """
+
+        # Propagate aperture wavefront "through" all active entrance pupil elements (DMs)
+        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self.propagate_active_pupils()
+
+        # Create fake FPM for plotting
+        fpm_plot = 1 - hcipy.circular_aperture(2 * self.fpm_rad * self.lam_over_d)(self.focal_det)
+
+        # Create apodizer as hcipy.Apodizer() object to be able to propagate through it
+        apod_prop = hcipy.Apodizer(self.apodizer)
+
+        # Calculate wavefront after apodizer plane
+        wf_apod = apod_prop(wf_active_pupil)
+
+        # Calculate wavefronts of the full coronagraphic propagation
+        wf_lyot = self.coro(wf_apod)
+        wf_im_coro = self.prop(wf_lyot)
+
+        # Calculate wavefronts in extra planes
+        wf_before_fpm = self.prop(wf_apod)
+        int_after_fpm = np.log10(wf_before_fpm.intensity / wf_before_fpm.intensity.max()) * fpm_plot  # this is the intensity straight
+        wf_before_lyot = self.coro_no_ls(wf_apod)
+
+        # Calculate wavefronts of the reference propagation (no FPM)
+        wf_ref_pup = hcipy.Wavefront(self.aperture * self.apodizer * self.lyotstop, wavelength=self.wvln)
+        wf_im_ref = self.prop(wf_ref_pup)
+
+        # Display intermediate planes
+        if display_intermediate:
+
+            plt.figure(figsize=(15, 15))
+
+            plt.subplot(3, 4, 1)
+            hcipy.imshow_field(self.wf_aper.intensity, mask=self.aperture, cmap='Greys_r')
+            plt.title('Primary mirror')
+
+            plt.subplot(3, 4, 2)
+            hcipy.imshow_field(wf_sm.phase, mask=self.aperture, cmap='RdBu')
+            plt.title('Segmented mirror phase')
+
+            plt.subplot(3, 4, 3)
+            hcipy.imshow_field(wf_zm.phase, mask=self.aperture, cmap='RdBu')
+            plt.title('Global Zernike phase')
+
+            plt.subplot(3, 4, 4)
+            hcipy.imshow_field(wf_dm.phase, mask=self.aperture, cmap='RdBu')
+            plt.title('Deformable mirror phase')
+
+            plt.subplot(3, 4, 5)
+            hcipy.imshow_field(wf_harris_sm.phase, mask=self.aperture, cmap='RdBu')
+            plt.title('Harris mode mirror phase')
+
+            plt.subplot(3, 4, 6)
+            hcipy.imshow_field(wf_ripples.phase, mask=self.aperture, cmap='RdBu')
+            plt.title('High modes mirror phase')
+
+            plt.subplot(3, 4, 7)
+            hcipy.imshow_field(wf_apod.intensity, cmap='inferno')
+            plt.title('Apodizer')
+
+            plt.subplot(3, 4, 8)
+            hcipy.imshow_field(wf_before_fpm.intensity / wf_before_fpm.intensity.max(), norm=LogNorm(), cmap='inferno')
+            plt.title('Before FPM')
+
+            plt.subplot(3, 4, 9)
+            hcipy.imshow_field(int_after_fpm / wf_before_fpm.intensity.max(), cmap='inferno')
+            plt.title('After FPM')
+
+            plt.subplot(3, 4, 10)
+            hcipy.imshow_field(wf_before_lyot.intensity / wf_before_lyot.intensity.max(),
+                               norm=LogNorm(vmin=1e-3, vmax=1), cmap='inferno')
+            plt.title('Before Lyot stop')
+
+            plt.subplot(3, 4, 11)
+            hcipy.imshow_field(wf_lyot.intensity / wf_lyot.intensity.max(),
+                               norm=LogNorm(vmin=1e-3, vmax=1), cmap='inferno', mask=self.lyotstop)
+            plt.title('After Lyot stop')
+
+            plt.subplot(3, 4, 12)
+            hcipy.imshow_field(wf_im_coro.intensity / wf_im_ref.intensity.max(),
+                               norm=LogNorm(vmin=1e-10, vmax=1e-3), cmap='inferno')
+            plt.title('Coro image')
+            plt.colorbar()
+
+        if return_intermediate == 'intensity':
+
+            # Return the intensity in all planes; except phases on all DMs, and combined phase from active pupils
+            intermediates = {'seg_mirror': wf_sm.phase,
+                             'zernike_mirror': wf_zm.phase,
+                             'dm': wf_dm.phase,
+                             'harris_seg_mirror': wf_harris_sm.phase,
+                             'ripple_mirror': wf_ripples.phase,
+                             'active_pupil': wf_active_pupil.phase,
+                             'apod': wf_apod.intensity,
+                             'before_fpm': wf_before_fpm.intensity / wf_before_fpm.intensity.max(),
+                             'after_fpm': int_after_fpm / wf_before_fpm.intensity.max(),
+                             'before_lyot': wf_before_lyot.intensity / wf_before_lyot.intensity.max(),
+                             'after_lyot': wf_lyot.intensity / wf_lyot.intensity.max()}
+
+            if ref:
+                return wf_im_coro.intensity, wf_im_ref.intensity, intermediates
+            else:
+                return wf_im_coro.intensity, intermediates
+
+        if return_intermediate == 'efield':
+
+            # Return the E-fields in all planes; except intensity in focal plane after FPM
+            intermediates = {'seg_mirror': wf_sm,
+                             'zernike_mirror': wf_zm,
+                             'dm': wf_dm,
+                             'harris_seg_mirror': wf_harris_sm,
+                             'ripple_mirror': wf_ripples,
+                             'active_pupil': wf_active_pupil,
+                             'apod': wf_apod,
+                             'before_fpm': wf_before_fpm,
+                             'after_fpm': int_after_fpm,
+                             'before_lyot': wf_before_lyot,
+                             'after_lyot': wf_lyot}
+
+            if ref:
+                return wf_im_coro, wf_im_ref, intermediates
+            else:
+                return wf_im_coro, intermediates
+
+        if ref:
+            return wf_im_coro.intensity, wf_im_ref.intensity
+
+        return wf_im_coro.intensity
+
+    def calc_low_order_wfs(self):
+        """ Propagate pupil through a low-order wavefront sensor.
+        Returns:
+        --------
+        lowfs : hcipy.Wavefront
+            E-field on LOWFS detector
+        """
+
+        # If ZWFS hasn't been created yet, do it now
+        if self.zwfs is None:
+            self.create_zernike_wfs()
+
+        # Propagate aperture wavefront "through" all active entrance pupil elements (DMs)
+        wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self.propagate_active_pupils()
+
+        # Create apodizer as hcipy.Apodizer() object to be able to propagate through it
+        apod_prop = hcipy.Apodizer(self.apodizer)
+
+        wf_pre_lowfs = apod_prop(wf_active_pupil)
+        lowfs = self.zwfs(wf_pre_lowfs)
+        return lowfs
+
+
+class LuvoirA_APLC(SegmentedAPLC):
     """ LUVOIR A with APLC simulator """
-    def __init__(self, input_dir, apod_design):
-
+    def __init__(self, input_dir, apod_design, sampling):
+        self.apod_design = apod_design
         self.apod_dict = {'small': {'pxsize': 1000, 'fpm_rad': 3.5, 'fpm_px': 150, 'iwa': 3.4, 'owa': 12.,
                                     'fname': '0_LUVOIR_N1000_FPM350M0150_IWA0340_OWA01200_C10_BW10_Nlam5_LS_IDD0120_OD0982_no_ls_struts.fits'},
                           'medium': {'pxsize': 1000, 'fpm_rad': 6.82, 'fpm_px': 250, 'iwa': 6.72, 'owa': 23.72,
                                      'fname': '0_LUVOIR_N1000_FPM682M0250_IWA0672_OWA02372_C10_BW10_Nlam5_LS_IDD0120_OD0982_no_ls_struts.fits'},
                           'large': {'pxsize': 1000, 'fpm_rad': 13.38, 'fpm_px': 400, 'iwa': 13.28, 'owa': 46.88,
                                     'fname': '0_LUVOIR_N1000_FPM1338M0400_IWA1328_OWA04688_C10_BW10_Nlam5_LS_IDD0120_OD0982_no_ls_struts.fits'}}
-        super().__init__()
+        imlamD = 1.2 * self.apod_dict[apod_design]['owa']
+
+        wvln = CONFIG_PASTIS.getfloat('LUVOIR', 'lambda') * 1e-9    # m
+        diameter = CONFIG_PASTIS.getfloat('LUVOIR', 'diameter')     # m
+        lam_over_d = wvln / diameter
+
+        pupil_grid = hcipy.make_pupil_grid(dims=self.apod_dict[apod_design]['pxsize'], diameter=diameter)
+
+        # Load segmented aperture
+        aper_path = CONFIG_PASTIS.get('LUVOIR', 'aperture_path_in_optics')
+        pup_read = hcipy.read_fits(os.path.join(input_dir, aper_path))
+        aperture = hcipy.Field(pup_read.ravel(), pupil_grid)
+
+        # Load apodizer
+        apod_path = os.path.join('luvoir_stdt_baseline_bw10', apod_design + '_fpm', 'solutions',
+                                 self.apod_dict[apod_design]['fname'])
+        apod_read = hcipy.read_fits(os.path.join(input_dir, apod_path))
+        apodizer = hcipy.Field(apod_read.ravel(), pupil_grid)
+
+        # Load Lyot Stop
+        ls_fname = CONFIG_PASTIS.get('LUVOIR', 'lyot_stop_path_in_optics')
+        ls_read = hcipy.read_fits(os.path.join(input_dir, ls_fname))
+        lyot_stop = hcipy.Field(ls_read.ravel(), pupil_grid)
+
+        # Load indexed segmented aperture
+        aper_ind_path = CONFIG_PASTIS.get('LUVOIR', 'indexed_aperture_path_in_optics')
+        aper_ind_read = hcipy.read_fits(os.path.join(input_dir, aper_ind_path))
+        aper_ind = hcipy.Field(aper_ind_read.ravel(), pupil_grid)
+
+        # Load segment positions from fits header
+        hdr = fits.getheader(os.path.join(input_dir, aper_ind_path))
+        nseg = CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures')
+        poslist = []
+        for i in range(nseg):
+            segname = 'SEG' + str(i + 1)
+            xin = hdr[segname + '_X']
+            yin = hdr[segname + '_Y']
+            poslist.append((xin, yin))
+        poslist = np.transpose(np.array(poslist))
+        seg_pos = hcipy.CartesianGrid(hcipy.UnstructuredCoords(poslist))
+        seg_pos = seg_pos.scaled(diameter)
+
+        seg_diameter_circumscribed = 2 / np.sqrt(3) * 1.2225    # m
+
+        # Create a focal plane mask
+        samp_foc = self.apod_dict[apod_design]['fpm_px'] / (self.apod_dict[apod_design]['fpm_rad'] * 2)
+        focal_grid_fpm = hcipy.make_focal_grid_from_pupil_grid(pupil_grid=pupil_grid, q=samp_foc, num_airy=self.apod_dict[apod_design]['fpm_rad'], wavelength=wvln)
+        fpm = 1 - hcipy.circular_aperture(2*self.apod_dict[apod_design]['fpm_rad'] * lam_over_d)(focal_grid_fpm)
+
+        # Create a focal plane grid for the detector
+        focal_det = hcipy.make_focal_grid_from_pupil_grid(pupil_grid=pupil_grid, q=sampling, num_airy=imlamD, wavelength=wvln)
+
+        super().__init__(apod=apodizer, lyot_stop=lyot_stop, fpm=fpm, fpm_rad=self.apod_dict[apod_design]['fpm_rad'],
+                         iwa=self.apod_dict[apod_design]['iwa'], owa=self.apod_dict[apod_design]['owa'],
+                         wvln=wvln, diameter=diameter, aper=aperture, indexed_aper=aper_ind, seg_pos=seg_pos,
+                         seg_diameter=seg_diameter_circumscribed, focal_grid=focal_det, sampling=sampling, imlamD=imlamD)
 
 
 class SegmentedTelescopeAPLC:

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -691,7 +691,11 @@ class SegmentedAPLC(SegmentedTelescope):
         # Create apodizer as hcipy.Apodizer() object to be able to propagate through it
         apod_prop = hcipy.Apodizer(self.apodizer)
 
-        wf_pre_lowfs = apod_prop(wf_active_pupil)
+        # Apply spatial filter
+        apod_plane = apod_prop(wf_active_pupil)
+        through_fpm = apod_plane.electric_field - self.coro_no_ls(apod_plane).electric_field
+        wf_pre_lowfs = hcipy.Wavefront(through_fpm, self.wvln)
+
         lowfs = self.zwfs(wf_pre_lowfs)
         return lowfs
 

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -276,6 +276,32 @@ class SegmentedTelescope:
 
         self.harris_sm = hcipy.optics.DeformableMirror(harris_thermal_mode_basis)
 
+    def set_harris_segment(self, segid, mode_number, amplitude):
+        """
+        Set an individual segment of the Harris segmented mirror to a single Harris mode.
+
+        Parameters:
+        ----------
+        segid : int
+            Id number of the segment you want to set. Center segment is always 0, whether it is obscured or not.
+        mode_number : int
+            Which local Harris mode to apply to segment with ID segid. Ordering:
+                Thermal modes: 0, 7, 8, 9, 10
+                Mechanical modes: 4, 5, 6
+                Other modes: 1, 2, 3
+        amplitude : float
+            Aberration amplitude in  ? meters of surface.   # FIXME: meters? surface? rms or ptv?
+        """
+        if mode_number > self.n_harris_modes:
+            raise NotImplementedError(f"'self.harris_sm' has only been instantiated for {self.n_harris_modes} modes per segment.")
+
+        if not self.center_segment:
+            segid -= 1
+
+        new_command = np.zeros(self.harris_sm.num_actuators)
+        new_command[self.n_harris_modes * segid + mode_number] = amplitude
+        self.harris_sm.actuators = new_command
+
     def create_global_zernike_mirror(self, n_zernikes):
         """
         Create a Zernike mirror in the pupil plane, with a global Zenrike modal basis of n_zernikes modes.

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -173,6 +173,11 @@ class SegmentedTelescope:
         if segid == 0 and not self.center_segment:
             raise NotImplementedError("'self.center_segment' is set to 'False', so there is not center segment to command.")
 
+        segment_cutoff_id = self.nseg if self.center_segment is False else self.nseg-1
+        if segid > segment_cutoff_id:
+            raise NotImplementedError(f"Your telescope has {self.nseg} active segments and the highest existing "
+                                      f"segment index is segment number {segment_cutoff_id}; you requested {segid}.")
+
         if isinstance(self.sm, hcipy.optics.DeformableMirror):
             if zernike_number >= self.seg_n_zernikes:
                 raise NotImplementedError(f"'self.sm' has only been instantiated for {self.seg_n_zernikes} Zernike "
@@ -311,6 +316,11 @@ class SegmentedTelescope:
 
         if segid == 0 and not self.center_segment:
             raise NotImplementedError("'self.center_segment' is set to 'False', so there is not center segment to command.")
+
+        segment_cutoff_id = self.nseg if self.center_segment is False else self.nseg-1
+        if segid > segment_cutoff_id:
+            raise NotImplementedError(f"Your telescope has {self.nseg} active segments and the highest existing "
+                                      f"segment index is segment number {segment_cutoff_id}; you requested {segid}.")
 
         if not self.center_segment:
             segid -= 1

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -163,9 +163,9 @@ class SegmentedTelescope:
         segid : int
             Id number of the segment you want to set. Center segment is always 0, whether it is obscured or not.
         zernike_number : int
-            Which local Zernike mode to apply to segment with ID segid. Ordered with Noll and starts with 1.   FIXME: double-check Zernike numbering
+            Which local Zernike mode to apply to segment ID segid. Ordered after Noll and they start with 0 (piston).
         amplitude : float
-            Aberration amplitude in meters of surface.   # FIXME: rms or ptv?
+            Aberration amplitude in meters rms of surface.
         """
         if segid == 0 and not self.center_segment:
             raise NotImplementedError("'self.center_segment' is set to 'False', so there is not center segment to command.")

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -386,11 +386,11 @@ class SegmentedTelescope:
             plt.title('High modes mirror phase')
 
             plt.subplot(3, 3, 7)
-            hcipy.imshow(wf_active_pupil.phase, mask=self.aperture, cmap='RdBu')
+            hcipy.imshow_field(wf_active_pupil.phase, mask=self.aperture, cmap='RdBu')
             plt.title('Total phase in entrance pupil')
 
             plt.subplot(3, 3, 8)
-            hcipy.imshow(wf_image.intensity / wf_image.intensity.max(), cmap='inferno')
+            hcipy.imshow_field(wf_image.intensity / wf_image.intensity.max(), norm=LogNorm(), cmap='inferno')
             plt.title('Focal plane image')
 
         if return_intermediate == 'efield':

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -344,6 +344,26 @@ class SegmentedTelescope:
                                                                       actuator_spacing)
         self.dm = hcipy.DeformableMirror(influence_functions)
 
+    def remove_segmented_mirror(self):
+        """ Remove the segmented mirror with local Zernikes as class attribute, replace with PTT segmented mirror. """
+        self.sm = SegmentedMirror(indexed_aperture=self.aper_ind, seg_pos=self.seg_pos)
+
+    def remove_segmented_harris_mirror(self):
+        """ Remove the segmented Harris mirror as class attribute. """
+        self.harris_sm = None
+
+    def remove_global_zernike_mirror(self):
+        """ Remove the global Zernike mirror as class attribute. """
+        self.zernike_mirror = None
+
+    def remove_ripple_mirror(self):
+        """ Remove the high-spatial frequency ripple mirror as class attribute. """
+        self.ripple_mirror = None
+
+    def remove_continuous_deformable_mirror(self):
+        """ Remove the continuous deformable mirror as class attribute. """
+        self.dm = None
+
     def flatten(self):
         """
         Flatten all deformable mirrors in this simulator instance, if they exist.

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -812,6 +812,9 @@ class LuvoirA_APLC(SegmentedAPLC):
 class SegmentedTelescopeAPLC:
     """ A segmented telescope with an APLC and actuated segments.
 
+    !-- NOTE: This class only still exists for back-compatibility. Please use SegmentedTelescope and SegmentedAPLC for new
+    implementations. --!
+
     By default instantiates just with a segmented mirror that can do piston, tip and tilt with the pre-defined methods.
     Use the deformable mirror methods to create more flexible DMs as class attributes:
         self.sm
@@ -1350,6 +1353,8 @@ class SegmentedTelescopeAPLC:
 
 class LuvoirAPLC(SegmentedTelescopeAPLC):
     """ Simple E2E simulator for LUVOIR A (with APLC).
+
+    !-- NOTE: This class only still exists for back-compatibility. Please use LuvoirA_APLC for new implementations. --!
 
     All this does is instantiate a SegmentedTelescopeAPLC() by feeding it the appropriate parameters to make it a
     LUVOIR A simulator with one of the three baseline APLC designs.

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -265,8 +265,8 @@ class SegmentedTelescope:
 
         # Create full mode basis of all Harris modes on all segments
         harris_base_thermal = np.asarray(harris_base_thermal)
-        n_single_modes = harris_base_thermal.shape[1]
-        harris_base_thermal = harris_base_thermal.reshape(self.nseg * n_single_modes, pup_dims[0] ** 2)
+        self.n_harris_modes = harris_base_thermal.shape[1]
+        harris_base_thermal = harris_base_thermal.reshape(self.nseg * self.n_harris_modes, pup_dims[0] ** 2)
         harris_thermal_mode_basis = hcipy.ModeBasis(np.transpose(harris_base_thermal), grid=self.pupil_grid)
 
         self.harris_sm = hcipy.optics.DeformableMirror(harris_thermal_mode_basis)
@@ -981,8 +981,8 @@ class SegmentedTelescopeAPLC:
 
         # Create full mode basis of all Harris modes on all segments
         harris_base_thermal = np.asarray(harris_base_thermal)
-        n_single_modes = harris_base_thermal.shape[1]
-        harris_base_thermal = harris_base_thermal.reshape(self.nseg * n_single_modes, pup_dims[0] ** 2)
+        self.n_harris_modes = harris_base_thermal.shape[1]
+        harris_base_thermal = harris_base_thermal.reshape(self.nseg * self.n_harris_modes, pup_dims[0] ** 2)
         harris_thermal_mode_basis = hcipy.ModeBasis(np.transpose(harris_base_thermal), grid=self.pupil_grid)
 
         self.harris_sm = hcipy.optics.DeformableMirror(harris_thermal_mode_basis)

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -576,6 +576,10 @@ class SegmentedAPLC(SegmentedTelescope):
             Intermediate plane E-fields; except intensity in focal plane after FPM.
         """
 
+        if isinstance(return_intermediate, bool):
+            raise TypeError(f"'return_intermediate' needs to be 'efield' or 'intensity' if you want all "
+                            f"E-fields returned by 'calc_psf()'.")
+
         # Propagate aperture wavefront "through" all active entrance pupil elements (DMs)
         wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self._propagate_active_pupils()
 
@@ -1134,6 +1138,10 @@ class SegmentedTelescopeAPLC:
         intermediates : dict of Wavefronts, optional
             Intermediate plane E-fields; except intensity in focal plane after FPM.
         """
+        
+        if isinstance(return_intermediate, bool):
+            raise TypeError(f"'return_intermediate' needs to be 'efield' or 'intensity' if you want all "
+                            f"E-fields returned by 'calc_psf()'.")
 
         # Propagate aperture wavefront "through" all active entrance pupil elements (DMs)
         wf_active_pupil, wf_sm, wf_harris_sm, wf_zm, wf_ripples, wf_dm = self._propagate_active_pupils()

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -33,6 +33,11 @@ class SegmentedTelescope:
     You can command each DM by passing it an array of length "num_actuators", e.g.
         self.sm.actuators = dm_command
 
+    The segments are numbered in such a way that the center segment is *always* indexed with 0, no matter if it actually
+    exists or not. This means that e.g. for Luvoir A, the first segment in the innermost ring is still indexed with 1,
+    even if there is no active segment in the center of the pupil. For LUVOIR B or JWST, it is the same: the now present
+    center segment is indexed with 0, and all consecutive segments are indexed with 1, 2, 3, ..., self.nseg.
+
     Parameters:
     ----------
     wvln : float
@@ -64,7 +69,7 @@ class SegmentedTelescope:
         self.seg_pos = seg_pos
         self.segment_circumscribed_diameter = seg_diameter
         self.nseg = seg_pos.size
-        self.center_segment = False    # Currently only working with telescopes without center segment
+        self.center_segment = False    # Currently only working with telescopes without active center segment
 
         self.pupil_grid = indexed_aper.grid
         self.focal_det = focal_grid
@@ -119,7 +124,7 @@ class SegmentedTelescope:
         seg_evaluated = self._create_evaluated_segment_grid()
 
         # Create a single segment influence function with all Zernikes n_zernikes
-        first_seg = 0  # Create this first influence function on the center segment only
+        first_seg = 0  # Create this first influence function on the first segment only
         local_zernike_basis = hcipy.mode_basis.make_zernike_basis(n_zernikes,
                                                                   self.segment_circumscribed_diameter,
                                                                   self.pupil_grid.shifted(-self.seg_pos[first_seg]),


### PR DESCRIPTION
I am splitting up the simulator classes that we were using so far for LUVOIR (`SegmentedTelescopeAPLC` and `LuvoirAPLC`) into three new classes that inherit form each other sequencially:

- `SegmentedTelescope`
- `SegmentedAPLC(SegmentedTelescope)`
- `LuvoirA_APLC(SegmentedAPLC)`

Theh idea behind this is to make the `SegmentedTelescope` and `SegmentedAPLC` classes more general, looking ahead to implementations of other coronagraphs and specific observatories. Other coronagraphs can be implemented as e.g. `SegmentedVVC`, and a segmented telescope that uses a vortex coronagraph can then inherit from `SegmentedVVC`.

This PR keeps everything back-compatible; and it does not swap in the new classes for the old ones yet in spots where the simulator is used.