### PR TITLE
Calculate simulated PASTIS matrices from E-fields

### DIFF
--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -203,7 +203,7 @@ def _luvoir_matrix_single_mode(number_all_modes, wfe_aber, luvoir_sim, resDir, s
     if saveefields:
         fname_real = f'efield_real_mode{mode_no}'
         hcipy.write_fits(efield_focal_plane.real, os.path.join(resDir, 'efields', fname_real + '.fits'))
-        fname_imag = f'efield_real_mode{mode_no}'
+        fname_imag = f'efield_imag_mode{mode_no}'
         hcipy.write_fits(efield_focal_plane.imag, os.path.join(resDir, 'efields', fname_imag + '.fits'))
 
     if saveopds:

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -830,13 +830,13 @@ class MatrixIntensityLuvoirA(PastisMatrixIntensities):
         self.calculate_matrix_pair = functools.partial(_luvoir_matrix_one_pair, self.design, self.norm, self.wfe_aber,
                                                        self.resDir, self.savepsfs, self.saveopds)
 
-    def calculate_ref_image(self, save_coro_floor=False, save_psfs=False, outpath=''):
+    def calculate_ref_image(self, save_coro_floor=True, save_psfs=True):
         self.contrast_floor, self.norm, self.coro_simulator = calculate_unaberrated_contrast_and_normalization('LUVOIR',
                                                                                                                self.design,
                                                                                                                return_coro_simulator=True,
                                                                                                                save_coro_floor=save_coro_floor,
                                                                                                                save_psfs=save_psfs,
-                                                                                                               outpath=outpath)
+                                                                                                               outpath=self.overall_dir)
 
 
 class MatrixIntensityHicat(PastisMatrixIntensities):
@@ -852,12 +852,12 @@ class MatrixIntensityHicat(PastisMatrixIntensities):
         self.calculate_matrix_pair = functools.partial(_hicat_matrix_one_pair, self.norm, self.wfe_aber, self.resDir,
                                                        self.savepsfs, self.saveopds)
 
-    def calculate_ref_image(self, save_coro_floor=False, save_psfs=False, outpath=''):
+    def calculate_ref_image(self, save_coro_floor=True, save_psfs=True):
         self.contrast_floor, self.norm, self.coro_simulator = calculate_unaberrated_contrast_and_normalization('HiCAT',
                                                                                                                return_coro_simulator=True,
                                                                                                                save_coro_floor=save_coro_floor,
                                                                                                                save_psfs=save_psfs,
-                                                                                                               outpath=outpath)
+                                                                                                               outpath=self.overall_dir)
 
 
 class MatrixIntensityJWST(PastisMatrixIntensities):
@@ -870,12 +870,12 @@ class MatrixIntensityJWST(PastisMatrixIntensities):
         self.calculate_matrix_pair = functools.partial(_jwst_matrix_one_pair, self.norm, self.wfe_aber, self.resDir,
                                                        self.savepsfs, self.saveopds)
 
-    def calculate_ref_image(self, save_coro_floor=False, save_psfs=False, outpath=''):
+    def calculate_ref_image(self, save_coro_floor=True, save_psfs=True):
         self.contrast_floor, self.norm, self.coro_simulator = calculate_unaberrated_contrast_and_normalization('JWST',
                                                                                                                return_coro_simulator=True,
                                                                                                                save_coro_floor=save_coro_floor,
                                                                                                                save_psfs=save_psfs,
-                                                                                                               outpath=outpath)
+                                                                                                               outpath=self.overall_dir)
 
 
 if __name__ == '__main__':

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -805,7 +805,7 @@ class MatrixEfieldLuvoirA(PastisMatrixEfields):
         _unaberrated_coro_psf, direct = self.luvoir.calc_psf(ref=True)
         self.norm = np.max(direct)
 
-        # Calculate reference E-field in focal plane, with all DMs flat
+        # Calculate reference E-field in focal plane, without any aberrations applied
         unaberrated_ref_efield, _inter = self.luvoir.calc_psf(return_intermediate='efield')
         self.efield_ref = unaberrated_ref_efield.electric_field
 

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -640,7 +640,6 @@ class PastisMatrixIntensities(PastisMatrix):
     instrument = None
 
     def __init__(self, design=None, initial_path='', savepsfs=True, saveopds=True):
-
         super().__init__(design=design, initial_path=initial_path)
 
         self.savepsfs = savepsfs

--- a/pastis/matrix_building_numerical.py
+++ b/pastis/matrix_building_numerical.py
@@ -677,33 +677,64 @@ class PastisMatrixIntensities(PastisMatrix):
         aberrated segment/actuator pair. This needs to create self.calculate_matrix_pair."""
 
 
-""" WIP
-class PastisMatrixEfield(PastisMatrix):
+class PastisMatrixEfields(PastisMatrix):
+    instrument = None
 
-    def __init__(self, instrument, design=None, initial_path=''):
-        super().__init__(instrument=instrument, design=design, initial_path=initial_path)
-
-    def calculate_ref_fields(self):
-        pass
-
-    def calculate_single_mode_fields(self):
-        pass
-
-    def calculate_pastis_matrix_from_efields(self):
-        self.matrix_pastis = None
+    def __init__(self, design=None, initial_path=''):
+        super().__init__(design=design, initial_path=initial_path)
+        self.calculate_one_mode = None
+        self.efields_per_mode = np.zeros([self.nb_seg])
 
     def calc(self):
         start_time = time.time()
 
-        self.calculate_ref_fields()
-        self.calculate_single_mode_fields()
+        self.calculate_ref_efield()
+        self.setup_single_mode_function()
+        self.calculate_efields()
         self.calculate_pastis_matrix_from_efields()
 
         end_time = time.time()
         log.info(
-            f'Runtime for PastisMatrixIntensities().calc(): {end_time - start_time}sec = {(end_time - start_time) / 60}min')
+            f'Runtime for PastisMatrixEfields().calc(): {end_time - start_time}sec = {(end_time - start_time) / 60}min')
         log.info(f'Data saved to {self.resDir}')
-"""
+
+    def calculate_efields(self):
+        for i in range(self.nb_seg):
+            self.efields_per_mode[i] = self.calculate_one_mode(i)
+
+        # Save E-fields to file?
+
+    def calculate_pastis_matrix_from_efields(self):
+        self.matrix_pastis = None
+
+        # Save matrix to file
+        filename_matrix = f'pastis_matrix'
+        hcipy.write_fits(self.matrix_pastis, os.path.join(self.resDir, filename_matrix + '.fits'))
+        ppl.plot_pastis_matrix(self.matrix_pastis, self.wvln * 1e9, out_dir=self.resDir, save=True)  # convert wavelength to nm
+        log.info(f'PASTIS matrix saved to: {os.path.join(self.resDir, filename_matrix + ".fits")}')
+
+    @abstractmethod
+    def calculate_ref_efield(self):
+        pass
+
+    @abstractmethod
+    def setup_single_mode_function(self):
+        pass
+
+
+class MatrixEfieldLuvoirA(PastisMatrixEfields):
+    instrument = 'LUVOIR'
+
+    def __init__(self, design='small', initial_path=''):
+        super().__init__(design=design)
+
+        # Create simulator instance and save as attribute
+
+    def calculate_ref_efield(self):
+        pass
+
+    def setup_single_mode_function(self):
+        pass
 
 
 class MatrixIntensityLuvoirA(PastisMatrixIntensities):


### PR DESCRIPTION
Implement a way to calculate simulated PASTIS matrices efficiently from E-fields rather than intensities. The recent refactor and modularization in #98 makes this much easier, and I am following a similar subclassing approach for this PR.

Here I am implementing for LUVOIR-A only, and only for the multi-mode segmented mirror that's based on hcipy. Making the used modes/DMs swappable will happen in a follow-up PR, as well as writing subclasses for other instruments.