### PR TITLE
Add LUVOIR B dark hole attribute and adjust wvln units

### DIFF
--- a/notebooks/LUVOIR-B/1_functions_for_LUVOIRB.ipynb
+++ b/notebooks/LUVOIR-B/1_functions_for_LUVOIRB.ipynb
@@ -100,7 +100,7 @@
     "D_pup = CONFIG_PASTIS.getfloat('LUVOIR-B', 'D_pup')\n",
     "samp_foc = CONFIG_PASTIS.getfloat('LUVOIR-B', 'sampling')\n",
     "rad_foc = CONFIG_PASTIS.getfloat('LUVOIR-B', 'imlamD')\n",
-    "wavelength = CONFIG_PASTIS.getfloat('LUVOIR-B', 'lambda')\n",
+    "wavelength = CONFIG_PASTIS.getfloat('LUVOIR-B', 'lambda') * 1e-9  # m\n",
     "\n",
     "print(f'nPup: {nPup}')\n",
     "print(f'D_pup: {D_pup}')\n",

--- a/pastis/config_pastis.ini
+++ b/pastis/config_pastis.ini
@@ -132,7 +132,7 @@ pupil_pixels = 1000
 D_pup = 0.048
 sampling = 4
 imlamD = 36
-lambda = 500e-9
+lambda = 500
 num_actuators_across = 24
 
 [numerical]

--- a/pastis/config_pastis.ini
+++ b/pastis/config_pastis.ini
@@ -134,6 +134,8 @@ sampling = 4
 imlamD = 36
 lambda = 500
 num_actuators_across = 24
+IWA = 2
+OWA = 28
 
 [numerical]
 ; size_seg used to be 100 in atlast case, 118 for JWST 512 px images, 239 for JWST 1024 px images

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -132,6 +132,13 @@ class LuvoirBVortex(SegmentedTelescope):
         self.charge = charge
         self.coro = hcipy.VortexCoronagraph(self.pupil_grid, charge, scaling_factor=4)
 
+        # Set up DH mask
+        iwa = CONFIG_PASTIS.getfloat('LUVOIR-B', 'IWA')
+        owa = CONFIG_PASTIS.getfloat('LUVOIR-B', 'OWA')
+        dh_outer = hcipy.circular_aperture(2 * owa * self.lam_over_d)(self.focal_grid)
+        dh_inner = hcipy.circular_aperture(2 * iwa * self.lam_over_d)(self.focal_grid)
+        self.dh_mask = (dh_outer - dh_inner).astype('bool')
+
     def set_up_telescope(self):
 
         # Read all input data files

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -149,7 +149,7 @@ class LuvoirBVortex(SegmentedTelescope):
         self.D_pup = CONFIG_PASTIS.getfloat('LUVOIR-B', 'D_pup')
         self.samp_foc = CONFIG_PASTIS.getfloat('LUVOIR-B', 'sampling')
         self.rad_foc = CONFIG_PASTIS.getfloat('LUVOIR-B', 'imlamD')
-        self.wavelength = CONFIG_PASTIS.getfloat('LUVOIR-B', 'lambda')
+        self.wavelength = CONFIG_PASTIS.getfloat('LUVOIR-B', 'lambda') * 1e-9   # m
 
         nPup_arrays = apod_stop_data.shape[0]
         nPup_dms = dm1_data.shape[0]


### PR DESCRIPTION
Adding the attribute `self.dh_mask` to the LUVOIR-B simulator so that it can be used in all instances like the we do it for LUVOIR-A.
Also, define the wavelength units in the configfile as nm rather than m since the entire pastis package works in units of nm unless stated otherwise. This way I am trying to avoid unit conversion problems until (if ever) I make the unit management easier throughout the package.