### PR TITLE
Fix dh_mask in RST code

### DIFF
--- a/pastis/contrast_calculation_simple.py
+++ b/pastis/contrast_calculation_simple.py
@@ -434,7 +434,8 @@ def contrast_rst_num(coro_floor, norm, matrix_dir, rms=50*u.nm):
     psf = image[0].data / norm
 
     # Get the mean contrast
-    dh_mask = util.create_dark_hole(psf, iwa, owa, sampling)
+    rst_sim.working_area(im=psf, inner_rad=iwa, outer_rad=owa)
+    dh_mask = rst_sim.WA
     contrast_rst = util.dh_mean(psf, dh_mask)
     end_e2e = time.time()
 

--- a/pastis/matrix_generation/matrix_building_numerical.py
+++ b/pastis/matrix_generation/matrix_building_numerical.py
@@ -268,7 +268,9 @@ def calculate_unaberrated_contrast_and_normalization(instrument, design=None, re
         coro_image = rst_sim.calc_psf(nlambda=1, fov_arcsec=1.6)
         coro_psf = coro_image[0].data / norm
 
-        rst_sim.working_area(im=coro_psf)
+        iwa = CONFIG_PASTIS.getfloat('RST', 'IWA')
+        owa = CONFIG_PASTIS.getfloat('RST', 'OWA')
+        rst_sim.working_area(im=coro_psf, inner_rad=iwa, outer_rad=owa)
         dh_mask = rst_sim.WA
 
         # Return the coronagraphic simulator (a tuple in the RST case!)
@@ -505,8 +507,8 @@ def _rst_matrix_one_pair(norm, wfe_aber, resDir, savepsfs, saveopds, actuator_pa
     log.info('Calculating mean contrast in dark hole')
     iwa = CONFIG_PASTIS.getfloat('RST', 'IWA')
     owa = CONFIG_PASTIS.getfloat('RST', 'OWA')
-    sampling = CONFIG_PASTIS.getfloat('RST', 'sampling')
-    dh_mask = util.create_dark_hole(psf, iwa, owa, sampling)
+    rst_cgi.working_area(im=psf, inner_rad=iwa, outer_rad=owa)
+    dh_mask = rst_cgi.WA
     contrast = util.dh_mean(psf, dh_mask)
 
     return contrast, actuator_pair


### PR DESCRIPTION
Replace the default circular DH mask calculated from `pastis.util.create_dark_hole()` with the actual DH mask contained in the CGI simulator, currently a double-sided wedge DH.