### PR TITLE
Extend E-field classes for matrix generation

### DIFF
--- a/pastis/config_pastis.ini
+++ b/pastis/config_pastis.ini
@@ -139,6 +139,9 @@ aperture_path_in_optics = inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000.fits
 indexed_aperture_path_in_optics = inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N1000_indexed.fits
 lyot_stop_path_in_optics = inputs/LS_LUVOIR_ID0120_OD0982_no_struts_gy_ovsamp4_N1000.fits
 
+; absolute path to Harris spreadsheet, currently hosted off the repo
+harris_data_path = '/Users/yourname/somewhere/Sensitivities2.xlsx'
+
 ; coronagraph
 ; iwa and owa from dictionaries within files. could move that to util.
 

--- a/pastis/config_pastis.ini
+++ b/pastis/config_pastis.ini
@@ -140,7 +140,7 @@ indexed_aperture_path_in_optics = inputs/TelAp_LUVOIR_gap_pad01_bw_ovsamp04_N100
 lyot_stop_path_in_optics = inputs/LS_LUVOIR_ID0120_OD0982_no_struts_gy_ovsamp4_N1000.fits
 
 ; absolute path to Harris spreadsheet, currently hosted off the repo
-harris_data_path = '/Users/yourname/somewhere/Sensitivities2.xlsx'
+harris_data_path = /Users/yourname/somewhere/Sensitivities2.xlsx
 
 ; coronagraph
 ; iwa and owa from dictionaries within files. could move that to util.

--- a/pastis/e2e_simulators/generic_segmented_telescopes.py
+++ b/pastis/e2e_simulators/generic_segmented_telescopes.py
@@ -529,7 +529,6 @@ class SegmentedTelescope:
 
         # Create full mode basis of selected Harris modes on all segments
         harris_base = np.asarray(harris_base)
-        print(harris_base.shape)
         self.n_harris_modes = harris_base.shape[1]
         harris_base = harris_base.reshape(self.nseg * self.n_harris_modes, pup_dims[0] ** 2)
         harris_mode_basis = hcipy.ModeBasis(np.transpose(harris_base), grid=self.pupil_grid)

--- a/pastis/e2e_simulators/luvoir_imaging.py
+++ b/pastis/e2e_simulators/luvoir_imaging.py
@@ -192,6 +192,26 @@ class LuvoirBVortex(SegmentedTelescope):
         self.segment_circum_diameter = 2 / np.sqrt(3) * 0.955 * (self.D_pup/8)   # m
 
     def calc_psf(self, ref=False, display_intermediate=False,  return_intermediate=None):
+        """ Calculate the PSF of LUVOIR B, and return optionally all E-fields.
+
+        Parameters:
+        ----------
+        ref : bool
+            Whether or not to return the reference (direct) PSF
+        display_intermediate : bool
+            Whether or not to display images of all planes.
+        return_intermediate : string
+            default None; if "efield", will also return E-fields of each plane and DM
+
+        Returns:
+        --------
+        wf_im_coro.intensity : Field
+            returned if return_intermediate=None (default)
+        wf_im_coro : hcipy.Wavefront
+            returned if return_intermediate='efield'
+        intermediates : dict
+            Dictionary containing the Wavefronts of all the planes, returned if return_intermediate='efield'
+        """
 
         if isinstance(return_intermediate, bool):
             raise TypeError(f"'return_intermediate' needs to be 'efield' or 'intensity' if you want all "

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -12,10 +12,10 @@ if __name__ == '__main__':
     fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
     pad_orientations = np.pi / 2 * np.ones(120)
 
-    DM_SPEC = (fpath, pad_orientations)
+    DM_SPEC = (fpath, pad_orientations, False, True, False)
     # DM_SPEC = tuple or int, specification for the used DM -
     #    for seg_mirror: int, number of local Zernike modes on each segment
-    #    for harris_seg_mirror: tuple (string, array), absolute path to Harris spreadsheet, pad orientations
+    #    for harris_seg_mirror: tuple (string, array, bool, bool, bool), absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets (thermal, mechanical, other)
     #    for zernike_mirror: int, number of global Zernikes
 
     # First generate a couple of matrices

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -1,3 +1,4 @@
+import numpy as np
 from pastis.config import CONFIG_PASTIS
 from pastis.matrix_generation.matrix_from_efields import MatrixEfieldLuvoirA
 
@@ -5,8 +6,13 @@ from pastis.matrix_generation.matrix_from_efields import MatrixEfieldLuvoirA
 if __name__ == '__main__':
 
     APLC_DESIGN = 'small'
-    DM = 'seg_mirror'   # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    DM_SPEC = 3
+    DM = 'harris_seg_mirror'   # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
+
+    # Needed for Harris mirror
+    fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
+    pad_orientations = np.pi / 2 * np.ones(120)
+
+    DM_SPEC = (fpath, pad_orientations)
     # DM_SPEC = tuple or int, specification for the used DM -
     #    for seg_mirror: int, number of local Zernike modes on each segment
     #    for harris_seg_mirror: tuple (string, array), absolute path to Harris spreadsheet, pad orientations

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -1,0 +1,20 @@
+from pastis.config import CONFIG_PASTIS
+from pastis.matrix_generation.matrix_from_efields import MatrixEfieldLuvoirA
+
+
+if __name__ == '__main__':
+
+    APLC_DESIGN = 'small'
+    DM = 'seg_mirror'   # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
+    DM_SPEC = 3
+    # DM_SPEC = tuple or int, specification for the used DM -
+    #    for seg_mirror: int, number of local Zernike modes on each segment
+    #    for harris_seg_mirror: tuple (string, array), absolute path to Harris spreadsheet, pad orientations
+    #    for zernike_mirror: int, number of global Zernikes
+
+    # First generate a couple of matrices
+    run_matrix = MatrixEfieldLuvoirA(which_dm=DM, dm_spec=DM_SPEC, design=APLC_DESIGN,
+                                     initial_path=CONFIG_PASTIS.get('local', 'local_data_path'))
+    run_matrix.calc()
+    dir_run = run_matrix.overall_dir
+    print(f'All saved to {dir_run}.')

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -254,7 +254,7 @@ class MatrixEfieldRST(PastisMatrixEfields):
                                                     self.rst_cgi, self.resDir, self.save_efields, self.saveopds)
 
 
-def _luvoir_matrix_single_mode(number_all_modes, wfe_aber, luvoir_sim, resDir, saveefields, saveopds, mode_no):
+def _luvoir_matrix_single_mode(which_dm, number_all_modes, wfe_aber, luvoir_sim, resDir, saveefields, saveopds, mode_no):
     """
     Calculate the LUVOIR-A mean E-field of one aberrated mode; for PastisMatrixEfields().
     :param which_dm: string, which DM - "seg_mirror", "harris_seg_mirror", "zernike_mirror"

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -257,8 +257,8 @@ class MatrixEfieldRST(PastisMatrixEfields):
 def _luvoir_matrix_single_mode(number_all_modes, wfe_aber, luvoir_sim, resDir, saveefields, saveopds, mode_no):
     """
     Calculate the LUVOIR-A mean E-field of one aberrated mode; for PastisMatrixEfields().
-    :param number_all_modes: int, total number of all modes
     :param which_dm: string, which DM - "seg_mirror", "harris_seg_mirror", "zernike_mirror"
+    :param number_all_modes: int, total number of all modes
     :param wfe_aber: float, calibration aberration in meters
     :param luvoir_sim: instance of LUVOIR simulator
     :param resDir: str, directory for matrix calculation results

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -155,7 +155,7 @@ class MatrixEfieldLuvoirA(PastisMatrixEfields):
         :param which_dm: string, which DM to calculate the matrix for - "seg_mirror", "harris_seg_mirror", "zernike_mirror"
         :param dm_spec: tuple or int, specification for the used DM -
                         for seg_mirror: int, number of local Zernike modes on each segment
-                        for harris_seg_mirror: tuple (string, array), absolute path to Harris spreadsheet, pad orientations
+                        for harris_seg_mirror: tuple (string, array, bool, bool, bool), absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets
                         for zernike_mirror: int, number of global Zernikes
         :param design: str, what coronagraph design to use - 'small', 'medium' or 'large'
         :param initial_path: string, path to top-level directory where result folder should be saved to.
@@ -185,6 +185,7 @@ class MatrixEfieldLuvoirA(PastisMatrixEfields):
     def setup_deformable_mirror(self):
         """ Set up the deformable mirror for the modes you're using and define the total number of mode actuators. """
 
+        log.info('Setting up deformable mirror...')
         if self.which_dm == 'seg_mirror':
             n_modes_segs = self.dm_spec
             log.info(f'Creating segmented mirror with {n_modes_segs} local modes on each segment...')
@@ -192,10 +193,10 @@ class MatrixEfieldLuvoirA(PastisMatrixEfields):
             self.number_all_modes = self.luvoir.sm.num_actuators
 
         elif self.which_dm == 'harris_seg_mirror':
-            fpath, pad_orientations = self.dm_spec
+            fpath, pad_orientations, therm, mech, other = self.dm_spec
             log.info(f'Reading Harris spreadsheet from {fpath}')
             log.info(f'Using pad orientations: {pad_orientations}')
-            self.luvoir.create_segmented_harris_mirror(fpath, pad_orientations)
+            self.luvoir.create_segmented_harris_mirror(fpath, pad_orientations, therm, mech, other)
             self.number_all_modes = self.luvoir.harris_sm.num_actuators
 
         elif self.which_dm == 'zernike_mirror':

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -278,7 +278,7 @@ def _luvoir_matrix_single_mode(number_all_modes, wfe_aber, luvoir_sim, resDir, s
     elif which_dm == 'harris_seg_mirror':
         luvoir_sim.harris_sm.actuators = all_modes
     elif which_dm == 'zernike_mirror':
-        luvoir_sim.harris_sm.actuators = all_modes
+        luvoir_sim.zernike_mirror.actuators = all_modes
     else:
         raise ValueError(f'DM with name "{which_dm}" not recognized.')
 

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -99,8 +99,8 @@ class PastisMatrixEfields(PastisMatrix):
 
 def pastis_matrix_from_efields(electric_fields, efield_ref, direct_norm, dh_mask, wfe_aber):
     """ Calculate the semi-analytical PASTIS matrix from the individual E-fields
-    :param electric_fields: list of individually poked mode E-fields
-    :param efield_ref: array, reference E-field of an unaberrated system
+    :param electric_fields: list, items of same type as "efield_ref", individually poked mode E-fields
+    :param efield_ref: same type as items in "electric_fields", reference E-field of an unaberrated system
     :param direct_norm: float, normalization factor - peak pixel of a direct PSF
     :param dh_mask: array, dark hole mask
     :param wfe_aber: float, calibration aberration in meters
@@ -126,8 +126,8 @@ def calculate_semi_analytic_pastis_from_efields(efields, efield_ref, direct_norm
     This function calculates the elements of the (half !) PASTIS matrix from the E-field responses of the individually
     poked modes, in which the reference E-field has not been subtracted yet. The calculation is only performed on the
     half-PASTIS matrix, so it will need to be symmetrized after this step.
-    :param efields: list of individually poked mode E-fields
-    :param efield_ref: array, reference E-field of an unaberrated system
+    :param efields: list, items of same type as "efield_ref", individually poked mode E-fields
+    :param efield_ref: same type as items in "efields", reference E-field of an unaberrated system
     :param direct_norm: float, normalization factor - peak pixel of a direct PSF
     :param dh_mask: array, dark hole mask
     :return: half-PASTIS matrix, where one of its matrix triangles will be all zeros

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -7,13 +7,13 @@ import pastis.matrix_generation.matrix_building_numerical as matrix_calc
 from pastis import util
 
 
-# Read the LUVOIR-A small APLC PASTIS matrix
+# Read the LUVOIR-A small APLC PASTIS matrix created from intensities
 # From data dir: 2021-03-21T19-15-50_luvoir-small
 # Created on commit: 33edfa9265a4a07844927402cbde97761c413fcd
 test_data_dir = os.path.join(util.find_package_location(), 'tests')
 matrix_path = os.path.join(test_data_dir, 'data', 'pastis_matrices', 'LUVOIR_small_matrix_piston-only.fits')
-LUVOIR_MATRIX_SMALL = fits.getdata(matrix_path)
-NSEG = LUVOIR_MATRIX_SMALL.shape[0]
+LUVOIR_INTENSITY_MATRIX_SMALL = fits.getdata(matrix_path)
+NSEG = LUVOIR_INTENSITY_MATRIX_SMALL.shape[0]
 
 # Read the LUVOIR-A small APLC contrast matrix
 # From data dir: 2021-03-21T19-15-50_luvoir-small
@@ -38,7 +38,7 @@ def test_semi_analytic_matrix_from_contrast_matrix():
     # Calculate the PASTIS matrix under assumption of a CONSTANT coronagraph floor
     pastis_matrix_constant = matrix_calc.pastis_from_contrast_matrix(CONTRAST_MATRIX, seglist, wfe_aber, coro_floor)
     # Compare to PASTIS matrix in the tests folder
-    assert np.allclose(pastis_matrix_constant, LUVOIR_MATRIX_SMALL, rtol=1e-8, atol=1e-24), 'Calculated LUVOIR small PASTIS matrix is wrong.'
+    assert np.allclose(pastis_matrix_constant, LUVOIR_INTENSITY_MATRIX_SMALL, rtol=1e-8, atol=1e-24), 'Calculated LUVOIR small PASTIS matrix is wrong.'
 
     ### Test the case in which the coronagraph floor is drifting across matrix measurements
 
@@ -57,7 +57,7 @@ def test_semi_analytic_matrix_from_contrast_matrix():
     # Calculate the PASTIS matrix under assumption of a DRIFTING coronagraph floor
     pastis_matrix_drift = matrix_calc.pastis_from_contrast_matrix(contrast_matrix_random_c0, seglist, wfe_aber, random_coro_floor_matrix)
     # Compare to PASTIS matrix in the tests folder
-    assert np.allclose(pastis_matrix_drift, LUVOIR_MATRIX_SMALL, rtol=1e-8, atol=1e-24), 'Calculated LUVOIR small PASTIS matrix is wrong.'
+    assert np.allclose(pastis_matrix_drift, LUVOIR_INTENSITY_MATRIX_SMALL, rtol=1e-8, atol=1e-24), 'Calculated LUVOIR small PASTIS matrix is wrong.'
 
 
 def test_pastis_forward_model():
@@ -77,7 +77,7 @@ def test_pastis_forward_model():
         aber = util.create_random_rms_values(NSEG, rms)
 
         # Contrast from PASTIS propagation
-        contrasts_matrix = (util.pastis_contrast(aber, LUVOIR_MATRIX_SMALL) + contrast_floor)
+        contrasts_matrix = (util.pastis_contrast(aber, LUVOIR_INTENSITY_MATRIX_SMALL) + contrast_floor)
 
         # Contrast from E2E propagator
         for nb_seg in range(NSEG):
@@ -89,7 +89,7 @@ def test_pastis_forward_model():
         assert np.isclose(contrasts_matrix, contrasts_e2e, rtol=rel_tol, atol=abs_tol), f'Calculated contrasts from PASTIS and E2E are not the same for rms={rms} and rtol={rel_tol}.'
 
 
-def test_luvoir_matrix_regression():
+def test_luvoir_intensity_matrix_regression():
     """ Check multiprocessed matrix calculation against previously calculated matrix """
 
     # Calculate new LUVOIR small PASTIS matrix
@@ -102,4 +102,4 @@ def test_luvoir_matrix_regression():
 
     # Check that new matrix is equal to previously computed matrix that is known to be correct, down to numerical noise
     # on the order of 1e-23
-    assert np.allclose(new_matrix, LUVOIR_MATRIX_SMALL, rtol=1e-8, atol=1e-24), 'Calculated LUVOIR small PASTIS matrix is wrong.'
+    assert np.allclose(new_matrix, LUVOIR_INTENSITY_MATRIX_SMALL, rtol=1e-8, atol=1e-24), 'Calculated LUVOIR small PASTIS matrix is wrong.'


### PR DESCRIPTION
- add a bunch of docstrings to recently added classes and functions
- enable Efield matrix generation for multi-Zernike segmented mirror on LUVOIR A, as well as Harris segmented mirror and global Zernike mirror

FOLLOW-UP:
- deal with attributes like `self.seglist`, `self.nb_seg`
- add tests for matrix generation from E-fields, for now for multi-Zernike segmented mirror on LUVOIR A, and global Zernike mirror on LUVOIR A