### PR TITLE
Allow for creation of Harris segmented mirror with subset of local modes

### DIFF
--- a/pastis/e2e_simulators/generic_segmented_telescopes.py
+++ b/pastis/e2e_simulators/generic_segmented_telescopes.py
@@ -434,12 +434,15 @@ class SegmentedTelescope:
         new_command[self.seg_n_zernikes * segid + zernike_number] = amplitude
         self.sm.actuators = new_command
 
-    def create_segmented_harris_mirror(self, filepath, pad_orientation):
+    def create_segmented_harris_mirror(self, filepath, pad_orientation, thermal=True, mechanical=True, other=True):
         """ Create an actuated segmented mirror with a modal basis made of the thermal modes provided by Harris.
 
         Thermal modes: a, h, i, j, k
         Mechanical modes: e, f, g
         Other modes: b, c, d
+
+        If all modes are created, they will be ordered as:
+        a, h, i, j, k, e, f, g, b, c, d
 
         Parameters:
         ----------
@@ -500,19 +503,24 @@ class SegmentedTelescope:
             y_rotation = -x_line_grid * np.sin(phi) + y_line_grid * np.cos(phi)
 
             # Transform all needed Harris modes from data to modes on our segmented aperture
-            ZA = _transform_harris_mode(valuesA, x_rotation, y_rotation, points, seg_evaluated, seg_num)
-            ZB = _transform_harris_mode(valuesB, x_rotation, y_rotation, points, seg_evaluated, seg_num)
-            ZC = _transform_harris_mode(valuesC, x_rotation, y_rotation, points, seg_evaluated, seg_num)
-            ZD = _transform_harris_mode(valuesD, x_rotation, y_rotation, points, seg_evaluated, seg_num)
-            ZE = _transform_harris_mode(valuesE, x_rotation, y_rotation, points, seg_evaluated, seg_num)
-            ZF = _transform_harris_mode(valuesF, x_rotation, y_rotation, points, seg_evaluated, seg_num)
-            ZG = _transform_harris_mode(valuesG, x_rotation, y_rotation, points, seg_evaluated, seg_num)
-            ZH = _transform_harris_mode(valuesH, x_rotation, y_rotation, points, seg_evaluated, seg_num)
-            ZI = _transform_harris_mode(valuesI, x_rotation, y_rotation, points, seg_evaluated, seg_num)
-            ZJ = _transform_harris_mode(valuesJ, x_rotation, y_rotation, points, seg_evaluated, seg_num)
-            ZK = _transform_harris_mode(valuesK, x_rotation, y_rotation, points, seg_evaluated, seg_num)
-
-            harris_base_thermal.append([ZA, ZB, ZC, ZD, ZE, ZF, ZG, ZH, ZI, ZJ, ZK])
+            # Use only the sets of modes that have been specified in the input parameters
+            if thermal:
+                ZA = _transform_harris_mode(valuesA, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+                ZH = _transform_harris_mode(valuesH, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+                ZI = _transform_harris_mode(valuesI, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+                ZJ = _transform_harris_mode(valuesJ, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+                ZK = _transform_harris_mode(valuesK, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+                harris_base_thermal.append([ZA, ZH, ZI, ZJ, ZK])
+            if mechanical:
+                ZE = _transform_harris_mode(valuesE, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+                ZF = _transform_harris_mode(valuesF, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+                ZG = _transform_harris_mode(valuesG, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+                harris_base_thermal.append([ZE, ZF, ZG])
+            if other:
+                ZB = _transform_harris_mode(valuesB, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+                ZC = _transform_harris_mode(valuesC, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+                ZD = _transform_harris_mode(valuesD, x_rotation, y_rotation, points, seg_evaluated, seg_num)
+                harris_base_thermal.append([ZB, ZC, ZD])
 
         # Create full mode basis of all Harris modes on all segments
         harris_base_thermal = np.asarray(harris_base_thermal)

--- a/pastis/e2e_simulators/generic_segmented_telescopes.py
+++ b/pastis/e2e_simulators/generic_segmented_telescopes.py
@@ -443,6 +443,7 @@ class SegmentedTelescope:
 
         If all modes are created, they will be ordered as:
         a, h, i, j, k, e, f, g, b, c, d
+        If only a subset is created, the ordering will be retained but the non-chosen modes dropped.
 
         Parameters:
         ----------


### PR DESCRIPTION
This PR implements simple switches that allow you to create a Harris segmented mirror with only a subset of the modes. As shown in the docstring of  `create_segmented_harris_mirror()`:
https://github.com/spacetelescope/PASTIS/blob/acb6bcafda605b80cdda37fcadfef9d5000e6458/pastis/e2e_simulators/generic_segmented_telescopes.py#L437

There are three different types of local Harris modes: thermal, mechanical, and other modes. This PR adds boolean parameters to the creation method that allow you to pick which of these sets the Harris segmented mirror should be created with. E.g.:
```py
create_segmented_harris_mirror(self, filepath, pad_orientation, thermal=False, mechanical=True, other=False)
```
will create a Harris SM with only the mechanical local modes. The default will create a mirror with all 11 local modes.