### PR TITLE
Simplify matrix calculation classes

### DIFF
--- a/pastis/matrix_generation/matrix_building_numerical.py
+++ b/pastis/matrix_generation/matrix_building_numerical.py
@@ -132,7 +132,7 @@ class PastisMatrixIntensities(PastisMatrix):
 
         end_time = time.time()
         log.info(
-            f'Runtime for PastisMatrixIntensities().calc(): {end_time - start_time}sec = {(end_time - start_time) / 60}min')
+            f'Runtime for {self.__class__.__name__}.calc(): {end_time - start_time}sec = {(end_time - start_time) / 60}min')
         log.info(f'Data saved to {self.resDir}')
 
     def calculate_contrast_matrix(self):

--- a/pastis/matrix_generation/matrix_building_numerical.py
+++ b/pastis/matrix_generation/matrix_building_numerical.py
@@ -46,16 +46,18 @@ class PastisMatrix:
 
     instrument = None
 
-    def __init__(self, save_path=''):
+    def __init__(self, nb_seg, save_path=''):
         """
         Parameters:
         ----------
+        nb_seg : int
+            Number of segments in the segmented aperture.
         save_path : string
             Path to top-level directory where result folder should be saved to.
         """
 
         # General telescope parameters
-        self.nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
+        self.nb_seg = nb_seg
         self.seglist = util.get_segment_list(self.instrument)
         self.wvln = CONFIG_PASTIS.getfloat(self.instrument, 'lambda') * 1e-9  # m
         self.wfe_aber = CONFIG_PASTIS.getfloat(self.instrument, 'calibration_aberration') * 1e-9  # m
@@ -95,10 +97,12 @@ class PastisMatrixIntensities(PastisMatrix):
     """
     instrument = None
 
-    def __init__(self, initial_path='', savepsfs=True, saveopds=True):
+    def __init__(self, nb_seg, initial_path='', savepsfs=True, saveopds=True):
         """
         Parameters:
         ----------
+        nb_seg : int
+            Number of segments in the segmented aperture.
         initial_path: string
             Path to top-level directory where result folder should be saved to.
         savepsfs: bool
@@ -106,8 +110,7 @@ class PastisMatrixIntensities(PastisMatrix):
         saveopds: bool
             Whether to save images of pair-wise aberrated pupils to disk or not
         """
-        super().__init__(save_path=initial_path)
-
+        super().__init__(nb_seg=nb_seg, save_path=initial_path)
         self.savepsfs = savepsfs
         self.saveopds = saveopds
         self.calculate_matrix_pair = None
@@ -795,7 +798,8 @@ class MatrixIntensityLuvoirA(PastisMatrixIntensities):
     """ Calculate a PASTIS matrix for LUVOIR-A, using intensity images. """
 
     def __init__(self, design='small', initial_path='', savepsfs=True, saveopds=True):
-        super().__init__(savepsfs=savepsfs, saveopds=saveopds)
+        nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
+        super().__init__(nb_seg=nb_seg, savepsfs=savepsfs, saveopds=saveopds)
         self.design = design
 
     def setup_one_pair_function(self):
@@ -820,7 +824,8 @@ class MatrixIntensityHicat(PastisMatrixIntensities):
     """ Calculate a PASTIS matrix for HiCAT, using intensity images. """
 
     def __init__(self, initial_path='', savepsfs=True, saveopds=True):
-        super().__init__(savepsfs=savepsfs, saveopds=saveopds)
+        nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
+        super().__init__(nb_seg=nb_seg, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
         """ Create the partial function that returns the PSF of a single aberrated segment pair. """
@@ -846,7 +851,8 @@ class MatrixIntensityJWST(PastisMatrixIntensities):
     """ Calculate a PASTIS matrix for JWST, using intensity images. """
 
     def __init__(self, initial_path='', savepsfs=True, saveopds=True):
-        super().__init__(savepsfs=savepsfs, saveopds=saveopds)
+        nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
+        super().__init__(nb_seg=nb_seg, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
         """ Create the partial function that returns the PSF of a single aberrated segment pair. """
@@ -869,7 +875,8 @@ class MatrixIntensityRST(PastisMatrixIntensities):
     """ Calculate a PASTIS matrix for the pupil-plane continuous DM on RST/CGI, using intensity images. """
 
     def __init__(self, initial_path='', savepsfs=True, saveopds=True):
-        super().__init__(savepsfs=savepsfs, saveopds=saveopds)
+        nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
+        super().__init__(nb_seg=nb_seg, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
         """ Create the partial function that returns the PSF of a single aberrated actuator pair. """

--- a/pastis/matrix_generation/matrix_building_numerical.py
+++ b/pastis/matrix_generation/matrix_building_numerical.py
@@ -63,8 +63,8 @@ class PastisMatrix:
         self.wfe_aber = CONFIG_PASTIS.getfloat(self.instrument, 'calibration_aberration') * 1e-9  # m
 
         # Create directory names
-        tel_suffix = f'{self.instrument.lower()}'
-        self.overall_dir = util.create_data_path(save_path, telescope=tel_suffix)
+        tel_name = f'{self.instrument.lower()}'
+        self.overall_dir = util.create_data_path(save_path, telescope=tel_name)
         os.makedirs(self.overall_dir, exist_ok=True)
         self.resDir = os.path.join(self.overall_dir, 'matrix_numerical')
 
@@ -73,11 +73,11 @@ class PastisMatrix:
         os.makedirs(os.path.join(self.resDir, 'OTE_images'), exist_ok=True)
 
         # Set up logger
-        util.setup_pastis_logging(self.resDir, f'pastis_matrix_{tel_suffix}')
-        log.info(f'Building numerical matrix for {tel_suffix}\n')
+        util.setup_pastis_logging(self.resDir, f'pastis_matrix_{tel_name}')
+        log.info(f'Building numerical matrix for {tel_name}\n')
 
         # Record some of the defined parameters
-        log.info(f'Instrument: {tel_suffix}')
+        log.info(f'Instrument: {tel_name}')
         log.info(f'Wavelength: {self.wvln} m')
         log.info(f'Number of segments: {self.nb_seg}')
         log.info(f'Segment list: {self.seglist}')

--- a/pastis/matrix_generation/matrix_building_numerical.py
+++ b/pastis/matrix_generation/matrix_building_numerical.py
@@ -799,7 +799,7 @@ class MatrixIntensityLuvoirA(PastisMatrixIntensities):
 
     def __init__(self, design='small', initial_path='', savepsfs=True, saveopds=True):
         nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
-        super().__init__(nb_seg=nb_seg, savepsfs=savepsfs, saveopds=saveopds)
+        super().__init__(nb_seg=nb_seg, initial_path=initial_path, savepsfs=savepsfs, saveopds=saveopds)
         self.design = design
 
     def setup_one_pair_function(self):
@@ -825,7 +825,7 @@ class MatrixIntensityHicat(PastisMatrixIntensities):
 
     def __init__(self, initial_path='', savepsfs=True, saveopds=True):
         nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
-        super().__init__(nb_seg=nb_seg, savepsfs=savepsfs, saveopds=saveopds)
+        super().__init__(nb_seg=nb_seg, initial_path=initial_path, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
         """ Create the partial function that returns the PSF of a single aberrated segment pair. """
@@ -852,7 +852,7 @@ class MatrixIntensityJWST(PastisMatrixIntensities):
 
     def __init__(self, initial_path='', savepsfs=True, saveopds=True):
         nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
-        super().__init__(nb_seg=nb_seg, savepsfs=savepsfs, saveopds=saveopds)
+        super().__init__(nb_seg=nb_seg, initial_path=initial_path, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
         """ Create the partial function that returns the PSF of a single aberrated segment pair. """
@@ -876,7 +876,7 @@ class MatrixIntensityRST(PastisMatrixIntensities):
 
     def __init__(self, initial_path='', savepsfs=True, saveopds=True):
         nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
-        super().__init__(nb_seg=nb_seg, savepsfs=savepsfs, saveopds=saveopds)
+        super().__init__(nb_seg=nb_seg, initial_path=initial_path, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
         """ Create the partial function that returns the PSF of a single aberrated actuator pair. """

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -23,10 +23,12 @@ class PastisMatrixEfields(PastisMatrix):
     instrument = None
     """ Main class for PASTIS matrix calculations from individually 'poked' modes. """
 
-    def __init__(self, initial_path='', saveefields=True, saveopds=True):
+    def __init__(self, nb_seg, initial_path='', saveefields=True, saveopds=True):
         """
         Parameters:
         ----------
+        nb_seg : int
+            Number of segments in the segmented aperture.
         initial_path: string
             Path to top-level directory where result folder should be saved to.
         saveefields: bool
@@ -34,7 +36,7 @@ class PastisMatrixEfields(PastisMatrix):
         saveopds: bool
             Whether to save images of pair-wise aberrated pupils to disk or not
         """
-        super().__init__(save_path=initial_path)
+        super().__init__(nb_seg=nb_seg, save_path=initial_path)
 
         self.save_efields = saveefields
         self.saveopds = saveopds
@@ -156,7 +158,8 @@ class MatrixEfieldLuvoirA(PastisMatrixEfields):
         :param saveefields: bool, whether to save E-fields as fits file to disk or not
         :param saveopds: bool, whether to save images of pair-wise aberrated pupils to disk or not
         """
-        super().__init__(initial_path=initial_path, saveefields=saveefields, saveopds=saveopds)
+        nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
+        super().__init__(nb_seg=nb_seg, initial_path=initial_path, saveefields=saveefields, saveopds=saveopds)
         self.which_dm = which_dm
         self.dm_spec = dm_spec
         self.design = design
@@ -220,7 +223,8 @@ class MatrixEfieldRST(PastisMatrixEfields):
     instrument = 'RST'
 
     def __init__(self, initial_path='', saveefields=True, saveopds=True):
-        super().__init__(initial_path=initial_path, saveefields=saveefields, saveopds=saveopds)
+        nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
+        super().__init__(nb_seg=nb_seg, initial_path=initial_path, saveefields=saveefields, saveopds=saveopds)
 
     def calculate_ref_efield(self):
         iwa = CONFIG_PASTIS.getfloat('RST', 'IWA')

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 import os
 import time
 import functools
@@ -24,12 +23,10 @@ class PastisMatrixEfields(PastisMatrix):
     instrument = None
     """ Main class for PASTIS matrix calculations from individually 'poked' modes. """
 
-    def __init__(self, design=None, initial_path='', saveefields=True, saveopds=True):
+    def __init__(self, initial_path='', saveefields=True, saveopds=True):
         """
         Parameters:
         ----------
-        design: string
-            Default None; if instrument=='LUVOIR', need to pass "small", "medium" or "large"
         initial_path: string
             Path to top-level directory where result folder should be saved to.
         saveefields: bool
@@ -37,7 +34,7 @@ class PastisMatrixEfields(PastisMatrix):
         saveopds: bool
             Whether to save images of pair-wise aberrated pupils to disk or not
         """
-        super().__init__(design=design, initial_path=initial_path)
+        super().__init__(save_path=initial_path)
 
         self.save_efields = saveefields
         self.saveopds = saveopds
@@ -80,17 +77,14 @@ class PastisMatrixEfields(PastisMatrix):
         ppl.plot_pastis_matrix(self.matrix_pastis, self.wvln * 1e9, out_dir=self.resDir, save=True)  # convert wavelength to nm
         log.info(f'PASTIS matrix saved to: {os.path.join(self.resDir, filename_matrix + ".fits")}')
 
-    @abstractmethod
     def calculate_ref_efield(self):
         """ Create the attributes self.norm, self.dh_mask, self.coro_simulator and self.efield_ref. """
         pass
 
-    @abstractmethod
     def setup_deformable_mirror(self):
         """ Set up the deformable mirror for the modes you're using, if necessary, and define the total number of mode actuators. """
         pass
 
-    @abstractmethod
     def setup_single_mode_function(self):
         """ Create an attribute that is the partial function that can calculate the focal plane E-field from one
         aberrated mode. This needs to create self.calculate_one_mode. """
@@ -162,9 +156,10 @@ class MatrixEfieldLuvoirA(PastisMatrixEfields):
         :param saveefields: bool, whether to save E-fields as fits file to disk or not
         :param saveopds: bool, whether to save images of pair-wise aberrated pupils to disk or not
         """
-        super().__init__(design=design, initial_path=initial_path, saveefields=saveefields, saveopds=saveopds)
+        super().__init__(initial_path=initial_path, saveefields=saveefields, saveopds=saveopds)
         self.which_dm = which_dm
         self.dm_spec = dm_spec
+        self.design = design
 
     def calculate_ref_efield(self):
         """Instantiate the simulator object and calculate the reference E-field, DH mask, and direct PSF norm factor."""

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -58,7 +58,7 @@ class PastisMatrixEfields(PastisMatrix):
 
         end_time = time.time()
         log.info(
-            f'Runtime for PastisMatrixEfields().calc(): {end_time - start_time}sec = {(end_time - start_time) / 60}min')
+            f'Runtime for {self.__class__.__name__}.calc(): {end_time - start_time}sec = {(end_time - start_time) / 60}min')
         log.info(f'Data saved to {self.resDir}')
 
     def calculate_efields(self):


### PR DESCRIPTION
Some general changes to the top-level classes for sensitivity matrix calculation.

- removed `design` from input parameters to `PastisMatrix`, this attribute is now set only in the Luvoir classes
- remove inheritance from `ABC`
- rename output path variable in `PastisMatrix`
- change variable `nb_seg` such that it is now passed into `PastisMatrix` upon instantiation instead of reading it from the configfile directly there.