### PR TITLE
Fix typo in __init__() methods.

### DIFF
--- a/pastis/matrix_generation/matrix_building_numerical.py
+++ b/pastis/matrix_generation/matrix_building_numerical.py
@@ -806,7 +806,7 @@ class MatrixIntensityLuvoirA(PastisMatrixIntensities):
     """ Calculate a PASTIS matrix for LUVOIR-A, using intensity images. """
 
     def __init__(self, design='small', initial_path='', savepsfs=True, saveopds=True):
-        super().__init__(design=design, savepsfs=savepsfs, saveopds=saveopds)
+        super().__init__(design=design, initial_path=initial_path, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
         """ Create the partial function that returns the PSF of a single aberrated segment pair. """
@@ -830,7 +830,7 @@ class MatrixIntensityHicat(PastisMatrixIntensities):
     """ Calculate a PASTIS matrix for HiCAT, using intensity images. """
 
     def __init__(self, initial_path='', savepsfs=True, saveopds=True):
-        super().__init__(design=None, savepsfs=savepsfs, saveopds=saveopds)
+        super().__init__(design=None, initial_path=initial_path, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
         """ Create the partial function that returns the PSF of a single aberrated segment pair. """
@@ -856,7 +856,7 @@ class MatrixIntensityJWST(PastisMatrixIntensities):
     """ Calculate a PASTIS matrix for JWST, using intensity images. """
 
     def __init__(self, initial_path='', savepsfs=True, saveopds=True):
-        super().__init__(design=None, savepsfs=savepsfs, saveopds=saveopds)
+        super().__init__(design=None, initial_path=initial_path, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
         """ Create the partial function that returns the PSF of a single aberrated segment pair. """
@@ -879,7 +879,7 @@ class MatrixIntensityRST(PastisMatrixIntensities):
     """ Calculate a PASTIS matrix for the pupil-plane continuous DM on RST/CGI, using intensity images. """
 
     def __init__(self, initial_path='', savepsfs=True, saveopds=True):
-        super().__init__(design=None, savepsfs=savepsfs, saveopds=saveopds)
+        super().__init__(design=None, initial_path=initial_path, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
         """ Create the partial function that returns the PSF of a single aberrated actuator pair. """

--- a/pastis/matrix_generation/matrix_building_numerical.py
+++ b/pastis/matrix_generation/matrix_building_numerical.py
@@ -805,7 +805,7 @@ class MatrixIntensityLuvoirA(PastisMatrixIntensities):
     instrument = 'LUVOIR'
     """ Calculate a PASTIS matrix for LUVOIR-A, using intensity images. """
 
-    def __int__(self, design='small', initial_path='', savepsfs=True, saveopds=True):
+    def __init__(self, design='small', initial_path='', savepsfs=True, saveopds=True):
         super().__init__(design=design, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
@@ -829,7 +829,7 @@ class MatrixIntensityHicat(PastisMatrixIntensities):
     instrument = 'HiCAT'
     """ Calculate a PASTIS matrix for HiCAT, using intensity images. """
 
-    def __int__(self, initial_path='', savepsfs=True, saveopds=True):
+    def __init__(self, initial_path='', savepsfs=True, saveopds=True):
         super().__init__(design=None, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
@@ -855,7 +855,7 @@ class MatrixIntensityJWST(PastisMatrixIntensities):
     instrument = 'JWST'
     """ Calculate a PASTIS matrix for JWST, using intensity images. """
 
-    def __int__(self, initial_path='', savepsfs=True, saveopds=True):
+    def __init__(self, initial_path='', savepsfs=True, saveopds=True):
         super().__init__(design=None, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):
@@ -878,7 +878,7 @@ class MatrixIntensityRST(PastisMatrixIntensities):
     instrument = 'RST'
     """ Calculate a PASTIS matrix for the pupil-plane continuous DM on RST/CGI, using intensity images. """
 
-    def __int__(self, initial_path='', savepsfs=True, saveopds=True):
+    def __init__(self, initial_path='', savepsfs=True, saveopds=True):
         super().__init__(design=None, savepsfs=savepsfs, saveopds=saveopds)
 
     def setup_one_pair_function(self):


### PR DESCRIPTION
Somehow a bug made its way into the classes that calculate the sensitivity matrices from intensities. This PR fixes that.
It also fixes the bug where it wouldn't pass the inital output path variable through to the respective superclass.