### PR TITLE
Fix segment size in SCDA Hex telescope simulator

### DIFF
--- a/pastis/e2e_simulators/scda_telescopes.py
+++ b/pastis/e2e_simulators/scda_telescopes.py
@@ -107,7 +107,7 @@ class HexRingAPLC(ScdaAPLC):
         else:
             raise ValueError(f"An apodizer design with robustness to a LS misalignment of {robustness_px} pixels does not exist for this aperture.")
         apod_fname = f'solutions/{robust}_SCDA_N1024_FPM350M0150_IWA0340_OWA01200_C10_BW10_Nlam3_LS_IDex_ID_OD0_OD_ls_982_no_strut.fits'
-        apod_hdr = fits.getheader(apod_fname)
+        apod_hdr = fits.getheader(os.path.join(data_in_repo, apod_fname))
         imlamD = 1.2 * apod_hdr['OWA']
 
         # Find correct Lyot stop file


### PR DESCRIPTION
The new simulator introduced in #123 was using the wrong flat-to-flat diameter for its segments, which was visible in the multi-mode local Zernike segmented DM as well as in the Harris segmented DM.

This PR changes the code so that all required telescopes and coronagraph parameters are read from the respective fits headers.

Before bugfix:
<img width="221" alt="Screen Shot 2022-06-20 at 17 10 30" src="https://user-images.githubusercontent.com/29508965/174641601-ba7d4a50-d230-482f-90f9-1db1c9565373.png">

After bugfix:
<img width="218" alt="Screen Shot 2022-06-20 at 17 25 05" src="https://user-images.githubusercontent.com/29508965/174641646-e0bda828-9c9c-4a7b-906b-dc832a651ad7.png">

