### PR TITLE
Create functions for calculation of sensitivity matrices at the wfs plane

### DIFF
--- a/pastis/matrix_generation/matrix_building_numerical.py
+++ b/pastis/matrix_generation/matrix_building_numerical.py
@@ -52,6 +52,8 @@ class PastisMatrix:
         ----------
         nb_seg : int
             Number of segments in the segmented aperture.
+        seglist : list or array
+            List of all segment indices, as given in the indexed aperture file.
         save_path : string
             Path to top-level directory where result folder should be saved to.
         """

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -43,6 +43,7 @@ class PastisMatrixEfields(PastisMatrix):
         self.saveopds = saveopds
         self.calculate_one_mode = None
         self.efields_per_mode = []
+        self.efields_per_mode_wfs = []
 
         os.makedirs(os.path.join(self.resDir, 'efields'), exist_ok=True)
 
@@ -68,6 +69,13 @@ class PastisMatrixEfields(PastisMatrix):
         for i in range(self.number_all_modes):
             self.efields_per_mode.append(self.calculate_one_mode(i))
         self.efields_per_mode = np.array(self.efields_per_mode)
+
+    def calculate_efields_wfs(self):
+        """ Poke each mode individually and calculate the resulting focal plane E-field. """
+
+        for i in range(self.number_all_modes):
+            self.efields_per_mode_wfs.append(self.calculate_one_mode(i)) #TODO: does this function needs to be changed?
+        self.efields_per_mode_wfs = np.array(self.efields_per_mode_wfs)
 
     def calculate_pastis_matrix_from_efields(self):
         """ Use the individual-mode E-fields to calculate the PASTIS matrix from it. """
@@ -195,6 +203,15 @@ class MatrixEfieldInternalSimulator(PastisMatrixEfields):
         # Calculate reference E-field in focal plane, without any aberrations applied
         unaberrated_ref_efield, _inter = self.simulator.calc_psf(return_intermediate='efield')
         self.efield_ref = unaberrated_ref_efield.electric_field
+
+    def calculate_ref_efield_wfs(self, norm_one_photon=False):
+        """Calculate the reference E-field at the wavefront sensor plane."""
+        if norm_one_photon:
+            unaberrated_ref_efield_wfs = self.simulator.calc_out_of_band_wfs(norm_one_photon=True)
+        else:
+            unaberrated_ref_efield_wfs = self.simulator.calc_out_of_band_wfs(norm_one_photon=False)
+
+        self.efield_ref_wfs = unaberrated_ref_efield_wfs
 
     def setup_deformable_mirror(self):
         """ Set up the deformable mirror for the modes you're using and define the total number of mode actuators. """

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -75,7 +75,7 @@ class PastisMatrixEfields(PastisMatrix):
         self.efields_per_mode = np.array(self.efields_per_mode)
 
     def calculate_efields_wfs(self):
-        """ Poke each mode individually and calculate the resulting focal plane E-field. """
+        """ Poke each mode individually and calculate the resulting Wavefront Sensor plane E-field. """
         for i in range(self.number_all_modes):
             self.efields_per_mode_wfs.append(self.calculate_one_mode(i)[1])
         self.efields_per_mode_wfs = np.array(self.efields_per_mode_wfs)

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -194,8 +194,8 @@ class MatrixEfieldInternalSimulator(PastisMatrixEfields):
         im_lamd = npx/2 /self.simulator.sampling
         plt.figure(figsize=(10, 10))
         plt.imshow(np.log10(unaberrated_coro_psf.shaped/self.norm), cmap='inferno', extent=[-im_lamd, im_lamd, -im_lamd, im_lamd])
-        plt.xlabel('$\lambda/D_{LS}$', size=30)
-        plt.ylabel('$\lambda/D_{LS}$', size=30)
+        plt.xlabel('$\lambda/D$', size=30)
+        plt.ylabel('$\lambda/D$', size=30)
         plt.tick_params(axis='both', length=6, width=2, labelsize=30)
         cbar = plt.colorbar(fraction=0.046, pad=0.04)
         cbar.ax.tick_params(labelsize=30)

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -303,6 +303,7 @@ class MatrixEfieldHex(MatrixEfieldInternalSimulator):
         sampling = CONFIG_PASTIS.getfloat('HexRingTelescope', 'sampling')
         self.simulator = HexRingAPLC(optics_input, self.num_rings, sampling)
 
+
 class MatrixEfieldRST(PastisMatrixEfields):
     """
     Class to calculate the PASTIS matrix from E-fields of RST CGI.
@@ -397,6 +398,7 @@ def _simulator_matrix_single_mode(which_dm, number_all_modes, wfe_aber, simulato
         plt.savefig(os.path.join(resDir, 'OTE_images', opd_name + '.pdf'))
 
     return efield_focal_plane.electric_field, efield_wfs_plane
+
 
 def _rst_matrix_single_mode(wfe_aber, rst_sim, resDir, saveefields, saveopds, mode_no):
     """

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -46,6 +46,7 @@ class PastisMatrixEfields(PastisMatrix):
         self.efields_per_mode_wfs = []
 
         os.makedirs(os.path.join(self.resDir, 'efields'), exist_ok=True)
+        os.makedirs(os.path.join(self.resDir, 'efields_wfs'), exist_ok=True)
 
     def calc(self):
         """ Main method that calculates the PASTIS matrix """
@@ -377,15 +378,15 @@ def _simulator_matrix_single_mode(which_dm, number_all_modes, wfe_aber, simulato
 
     if saveefields:
         #Save focal plane Efields
-        fname_real_focal = f'efield_real_mode{mode_no}'
-        hcipy.write_fits(efield_focal_plane.real, os.path.join(resDir, 'efields_focal', fname_real_focal + '.fits'))
-        fname_imag_focal = f'efield_imag_mode{mode_no}'
-        hcipy.write_fits(efield_focal_plane.imag, os.path.join(resDir, 'efields_focal', fname_imag_focal + '.fits'))
+        fname_real_focal = f'focal_real_mode{mode_no}'
+        hcipy.write_fits(efield_focal_plane.real, os.path.join(resDir, 'efields', fname_real_focal + '.fits'))
+        fname_imag_focal = f'focal_imag_mode{mode_no}'
+        hcipy.write_fits(efield_focal_plane.imag, os.path.join(resDir, 'efields', fname_imag_focal + '.fits'))
 
         #Save wfs plane Efields
-        fname_real_wfs = f'real_mode{mode_no}'
+        fname_real_wfs = f'wfs_real_mode{mode_no}'
         hcipy.write_fits(efield_wfs_plane.real, os.path.join(resDir, 'efields_wfs', fname_real_wfs + '.fits'))
-        fname_imag_wfs = f'imag_mode{mode_no}'
+        fname_imag_wfs = f'wfs_imag_mode{mode_no}'
         hcipy.write_fits(efield_wfs_plane.imag, os.path.join(resDir, 'efields_wfs', fname_imag_wfs + '.fits'))
 
     if saveopds:

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -69,10 +69,7 @@ class PastisMatrixEfields(PastisMatrix):
         self.calculate_ref_efield_wfs()
         self.setup_deformable_mirror()
         self.setup_single_mode_function()
-        if self.calc_science:
-            self.calculate_efields()
-        if self.calc_wfs:
-            self.calculate_efields_wfs()
+        self.calculate_efields()
         self.calculate_pastis_matrix_from_efields()
 
         end_time = time.time()
@@ -84,13 +81,12 @@ class PastisMatrixEfields(PastisMatrix):
         """ Poke each mode individually and calculate the resulting focal plane E-field. """
 
         for i in range(self.number_all_modes):
-            self.efields_per_mode.append(self.calculate_one_mode(i)['efield_science_plane'])
+            efields = self.calculate_one_mode(i)
+            if self.calc_science:
+                self.efields_per_mode.append(efields['efield_science_plane'])
+            if self.calc_wfs:
+                self.efields_per_mode_wfs.append(efields['efield_wfs_plane'])
         self.efields_per_mode = np.array(self.efields_per_mode)
-
-    def calculate_efields_wfs(self):
-        """ Poke each mode individually and calculate the resulting Wavefront Sensor plane E-field. """
-        for i in range(self.number_all_modes):
-            self.efields_per_mode_wfs.append(self.calculate_one_mode(i)['efield_wfs_plane'])
         self.efields_per_mode_wfs = np.array(self.efields_per_mode_wfs)
 
     def calculate_pastis_matrix_from_efields(self):

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -71,13 +71,13 @@ class PastisMatrixEfields(PastisMatrix):
         """ Poke each mode individually and calculate the resulting focal plane E-field. """
 
         for i in range(self.number_all_modes):
-            self.efields_per_mode.append(self.calculate_one_mode(i)[0])
+            self.efields_per_mode.append(self.calculate_one_mode(i)['efield_science_plane'])
         self.efields_per_mode = np.array(self.efields_per_mode)
 
     def calculate_efields_wfs(self):
         """ Poke each mode individually and calculate the resulting Wavefront Sensor plane E-field. """
         for i in range(self.number_all_modes):
-            self.efields_per_mode_wfs.append(self.calculate_one_mode(i)[1])
+            self.efields_per_mode_wfs.append(self.calculate_one_mode(i)['efield_wfs_plane'])
         self.efields_per_mode_wfs = np.array(self.efields_per_mode_wfs)
 
     def calculate_pastis_matrix_from_efields(self):
@@ -401,7 +401,11 @@ def _simulator_matrix_single_mode(which_dm, number_all_modes, wfe_aber, simulato
         hcipy.imshow_field(opd_map, grid=simulator.aperture.grid, mask=simulator.aperture, cmap='RdBu')
         plt.savefig(os.path.join(resDir, 'OTE_images', opd_name + '.pdf'))
 
-    return efield_focal_plane.electric_field, efield_wfs_plane
+    # Format returned Efields
+    efields = {'efield_science_plane': efield_focal_plane.electric_field,
+               'efield_wfs_plane': efield_wfs_plane}
+
+    return efields
 
 
 def _rst_matrix_single_mode(wfe_aber, rst_sim, resDir, saveefields, saveopds, mode_no):
@@ -444,4 +448,7 @@ def _rst_matrix_single_mode(wfe_aber, rst_sim, resDir, saveefields, saveopds, mo
                             title='Aberrated actuator pair')
         plt.savefig(os.path.join(resDir, 'OTE_images', opd_name + '.pdf'))
 
-    return efield_focal_plane.wavefront
+    # Format returned Efields
+    efields = {'efield_science_plane': efield_focal_plane.wavefront}
+
+    return efields

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -84,6 +84,10 @@ class PastisMatrixEfields(PastisMatrix):
         """ Create the attributes self.norm, self.dh_mask, self.coro_simulator and self.efield_ref. """
         raise NotImplementedError()
 
+    def calculate_ref_efield_wfs(self):
+        """ Create the attributes self.norm, self.dh_mask, self.coro_simulator and self.efield_ref. """
+        raise NotImplementedError()
+
     def setup_deformable_mirror(self):
         """ Set up the deformable mirror for the modes you're using, if necessary, and define the total number of mode actuators. """
         raise NotImplementedError()

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -303,7 +303,6 @@ class MatrixEfieldHex(MatrixEfieldInternalSimulator):
         sampling = CONFIG_PASTIS.getfloat('HexRingTelescope', 'sampling')
         self.simulator = HexRingAPLC(optics_input, self.num_rings, sampling)
 
-#TODO: add norm_one_photon?
 class MatrixEfieldRST(PastisMatrixEfields):
     """
     Class to calculate the PASTIS matrix from E-fields of RST CGI.
@@ -399,7 +398,6 @@ def _simulator_matrix_single_mode(which_dm, number_all_modes, wfe_aber, simulato
 
     return efield_focal_plane.electric_field, efield_wfs_plane
 
-#TODO: add norm_one_photon?
 def _rst_matrix_single_mode(wfe_aber, rst_sim, resDir, saveefields, saveopds, mode_no):
     """
     Function to calculate RST Electrical field (E_field) of one DM actuator in CGI.

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -375,7 +375,11 @@ def _simulator_matrix_single_mode(which_dm, number_all_modes, wfe_aber, simulato
     efield_focal_plane, inter = simulator.calc_psf(return_intermediate='efield', norm_one_photon=norm_one_photon)
 
     # Calculate WFS plane E-field
-    efield_wfs_plane = simulator.calc_out_of_band_wfs(norm_one_photon=norm_one_photon)
+    # Purposefully do not use `simulator.calc_out_of_band_wfs()` because it would recalculate all intermediate planes,
+    # as is already done with `simulator.calc_psf()`, so we can use the output from there.
+    if simulator.zwfs is None:
+        simulator.create_zernike_wfs()
+    efield_wfs_plane = simulator.zwfs(inter['active_pupil'])
 
     if saveefields:
         # Save focal plane Efields

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -377,13 +377,13 @@ def _simulator_matrix_single_mode(which_dm, number_all_modes, wfe_aber, simulato
     efield_wfs_plane = simulator.calc_out_of_band_wfs(norm_one_photon=norm_one_photon)
 
     if saveefields:
-        #Save focal plane Efields
+        # Save focal plane Efields
         fname_real_focal = f'focal_real_mode{mode_no}'
         hcipy.write_fits(efield_focal_plane.real, os.path.join(resDir, 'efields', fname_real_focal + '.fits'))
         fname_imag_focal = f'focal_imag_mode{mode_no}'
         hcipy.write_fits(efield_focal_plane.imag, os.path.join(resDir, 'efields', fname_imag_focal + '.fits'))
 
-        #Save wfs plane Efields
+        # Save wfs plane Efields
         fname_real_wfs = f'wfs_real_mode{mode_no}'
         hcipy.write_fits(efield_wfs_plane.real, os.path.join(resDir, 'efields_wfs', fname_real_wfs + '.fits'))
         fname_imag_wfs = f'wfs_imag_mode{mode_no}'

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -54,8 +54,8 @@ class PastisMatrixEfields(PastisMatrix):
 
         start_time = time.time()
 
-        self.calculate_ref_efield(self.norm_one_photon)
-        self.calculate_ref_efield_wfs(self.norm_one_photon)
+        self.calculate_ref_efield()
+        self.calculate_ref_efield_wfs()
         self.setup_deformable_mirror()
         self.setup_single_mode_function()
         self.calculate_efields()
@@ -91,11 +91,11 @@ class PastisMatrixEfields(PastisMatrix):
         ppl.plot_pastis_matrix(self.matrix_pastis, self.wvln * 1e9, out_dir=self.resDir, save=True)  # convert wavelength to nm
         log.info(f'PASTIS matrix saved to: {os.path.join(self.resDir, filename_matrix + ".fits")}')
 
-    def calculate_ref_efield(self, norm_one_photon):
+    def calculate_ref_efield(self):
         """ Create the attributes self.norm, self.dh_mask, self.coro_simulator and self.efield_ref. """
         raise NotImplementedError()
 
-    def calculate_ref_efield_wfs(self, norm_one_photon):
+    def calculate_ref_efield_wfs(self):
         """ Create the attributes self.norm, self.dh_mask, self.coro_simulator and self.efield_ref. """
         raise NotImplementedError()
 
@@ -181,7 +181,7 @@ class MatrixEfieldInternalSimulator(PastisMatrixEfields):
         """ Create a simulator object and save to self.simulator """
         raise NotImplementedError()
 
-    def calculate_ref_efield(self, norm_one_photon):
+    def calculate_ref_efield(self):
         """Calculate the reference E-field, DH mask, and direct PSF norm factor."""
         self.dh_mask = self.simulator.dh_mask
 
@@ -207,7 +207,7 @@ class MatrixEfieldInternalSimulator(PastisMatrixEfields):
         unaberrated_ref_efield, _inter = self.simulator.calc_psf(return_intermediate='efield', norm_one_photon=self.norm_one_photon)
         self.efield_ref = unaberrated_ref_efield.electric_field
 
-    def calculate_ref_efield_wfs(self, norm_one_photon):
+    def calculate_ref_efield_wfs(self):
         """Calculate the reference E-field at the wavefront sensor plane."""
         unaberrated_ref_efield_wfs = self.simulator.calc_out_of_band_wfs(norm_one_photon=self.norm_one_photon)
         self.efield_ref_wfs = unaberrated_ref_efield_wfs

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -53,6 +53,7 @@ class PastisMatrixEfields(PastisMatrix):
         start_time = time.time()
 
         self.calculate_ref_efield()
+        self.calculate_ref_efield_wfs()
         self.setup_deformable_mirror()
         self.setup_single_mode_function()
         self.calculate_efields()
@@ -72,10 +73,7 @@ class PastisMatrixEfields(PastisMatrix):
 
     def calculate_efields_wfs(self):
         """ Poke each mode individually and calculate the resulting focal plane E-field. """
-
-        for i in range(self.number_all_modes):
-            self.efields_per_mode_wfs.append(self.calculate_one_mode(i)) #TODO: does this function needs to be changed?
-        self.efields_per_mode_wfs = np.array(self.efields_per_mode_wfs)
+        raise NotImplementedError()
 
     def calculate_pastis_matrix_from_efields(self):
         """ Use the individual-mode E-fields to calculate the PASTIS matrix from it. """
@@ -204,13 +202,9 @@ class MatrixEfieldInternalSimulator(PastisMatrixEfields):
         unaberrated_ref_efield, _inter = self.simulator.calc_psf(return_intermediate='efield')
         self.efield_ref = unaberrated_ref_efield.electric_field
 
-    def calculate_ref_efield_wfs(self, norm_one_photon=False):
+    def calculate_ref_efield_wfs(self):
         """Calculate the reference E-field at the wavefront sensor plane."""
-        if norm_one_photon:
-            unaberrated_ref_efield_wfs = self.simulator.calc_out_of_band_wfs(norm_one_photon=True)
-        else:
-            unaberrated_ref_efield_wfs = self.simulator.calc_out_of_band_wfs(norm_one_photon=False)
-
+        unaberrated_ref_efield_wfs = self.simulator.calc_out_of_band_wfs()
         self.efield_ref_wfs = unaberrated_ref_efield_wfs
 
     def setup_deformable_mirror(self):

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -186,7 +186,7 @@ class MatrixEfieldInternalSimulator(PastisMatrixEfields):
         self.dh_mask = self.simulator.dh_mask
 
         # Calculate contrast normalization factor from direct PSF (intensity)
-        _unaberrated_coro_psf, direct = self.simulator.calc_psf(ref=True, norm_one_photon=self.norm_one_photon)
+        unaberrated_coro_psf, direct = self.simulator.calc_psf(ref=True, norm_one_photon=self.norm_one_photon)
         self.norm = np.max(direct)
         hcipy.write_fits(unaberrated_coro_psf/self.norm, os.path.join(self.overall_dir, 'unaberrated_coro_psf.fits'))
 

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -31,12 +31,20 @@ class PastisMatrixEfields(PastisMatrix):
         ----------
         nb_seg : int
             Number of segments in the segmented aperture.
+        seglist : list or array
+            List of all segment indices, as given in the indexed aperture file.
+        calc_science : bool
+            Whether to calculate the Efields in the science focal plane.
+        calc_wfs : bool
+            Whether to calculate the Efields in the out-of-band Zernike WFS plane.
         initial_path: string
             Path to top-level directory where result folder should be saved to.
         saveefields: bool
             Whether to save E-fields both at focal and wfs plane as fits file to disk or not
-        saveopds: bool
+        saveopds : bool
             Whether to save images of pair-wise aberrated pupils to disk or not
+        norm_one_photon : bool
+            Whether to normalize the returned E-fields and intensities to one photon in the entrance pupil.
         """
         super().__init__(nb_seg=nb_seg, seglist=seglist, save_path=initial_path)
         self.calc_science = calc_science
@@ -173,9 +181,14 @@ class MatrixEfieldInternalSimulator(PastisMatrixEfields):
                         for seg_mirror: int, number of local Zernike modes on each segment
                         for harris_seg_mirror: tuple (string, array, bool, bool, bool), absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets
                         for zernike_mirror: int, number of global Zernikes
+        :param nb_seg: int, Number of segments in the segmented aperture.
+        :param seglist: list or array, list of all segment indices, as given in the indexed aperture file.
+        :param calc_science: bool, whether to calculate the Efields in the science focal plane.
+        :param calc_wfs: bool, whether to calculate the Efields in the out-of-band Zernike WFS plane.
         :param initial_path: string, path to top-level directory where result folder should be saved to.
         :param saveefields: bool, whether to save E-fields as fits file to disk or not
         :param saveopds: bool, whether to save images of pair-wise aberrated pupils to disk or not
+        :param norm_one_photon: bool, whether to normalize the returned E-fields and intensities to one photon in the entrance pupil.
         """
         super().__init__(nb_seg=nb_seg, seglist=seglist, calc_science=calc_science, calc_wfs=calc_wfs,
                          initial_path=initial_path, saveefields=saveefields, saveopds=saveopds, norm_one_photon=norm_one_photon)
@@ -198,7 +211,7 @@ class MatrixEfieldInternalSimulator(PastisMatrixEfields):
         hcipy.write_fits(unaberrated_coro_psf/self.norm, os.path.join(self.overall_dir, 'unaberrated_coro_psf.fits'))
 
         npx = unaberrated_coro_psf.shaped.shape[0]
-        im_lamd = npx/2 /self.simulator.sampling
+        im_lamd = npx/2 / self.simulator.sampling
         plt.figure(figsize=(10, 10))
         plt.imshow(np.log10(unaberrated_coro_psf.shaped/self.norm), cmap='inferno', extent=[-im_lamd, im_lamd, -im_lamd, im_lamd])
         plt.xlabel('$\lambda/D$', size=30)
@@ -268,9 +281,12 @@ class MatrixEfieldLuvoirA(MatrixEfieldInternalSimulator):
                         for harris_seg_mirror: tuple (string, array, bool, bool, bool), absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets
                         for zernike_mirror: int, number of global Zernikes
         :param design: str, what coronagraph design to use - 'small', 'medium' or 'large'
+        :param calc_science: bool, whether to calculate the Efields in the science focal plane.
+        :param calc_wfs: bool, whether to calculate the Efields in the out-of-band Zernike WFS plane.
         :param initial_path: string, path to top-level directory where result folder should be saved to.
         :param saveefields: bool, whether to save E-fields as fits file to disk or not
         :param saveopds: bool, whether to save images of pair-wise aberrated pupils to disk or not
+        :param norm_one_photon: bool, whether to normalize the returned E-fields and intensities to one photon in the entrance pupil.
         """
         nb_seg = CONFIG_PASTIS.getint(self.instrument, 'nb_subapertures')
         seglist = util.get_segment_list(self.instrument)
@@ -297,9 +313,12 @@ class MatrixEfieldHex(MatrixEfieldInternalSimulator):
                         for harris_seg_mirror: tuple (string, array, bool, bool, bool), absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets
                         for zernike_mirror: int, number of global Zernikes
         :param num_rings: int, number of hexagonal segment rings
+        :param calc_science: bool, whether to calculate the Efields in the science focal plane.
+        :param calc_wfs: bool, whether to calculate the Efields in the out-of-band Zernike WFS plane.
         :param initial_path: string, path to top-level directory where result folder should be saved to.
         :param saveefields: bool, whether to save E-fields as fits file to disk or not
         :param saveopds: bool, whether to save images of pair-wise aberrated pupils to disk or not
+        :param norm_one_photon: bool, whether to normalize the returned E-fields and intensities to one photon in the entrance pupil.
         """
         nb_seg = 3 * num_rings * (num_rings + 1) + 1
         seglist = np.arange(nb_seg) + 1

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -70,7 +70,8 @@ class PastisMatrixEfields(PastisMatrix):
         self.setup_deformable_mirror()
         self.setup_single_mode_function()
         self.calculate_efields()
-        self.calculate_pastis_matrix_from_efields()
+        if self.calc_science:
+            self.calculate_pastis_matrix_from_efields()
 
         end_time = time.time()
         log.info(

--- a/pastis/matrix_generation/matrix_from_efields.py
+++ b/pastis/matrix_generation/matrix_from_efields.py
@@ -33,7 +33,7 @@ class PastisMatrixEfields(PastisMatrix):
         initial_path: string
             Path to top-level directory where result folder should be saved to.
         saveefields: bool
-            Whether to save E-fields as fits file to disk or not
+            Whether to save E-fields both at focal and wfs plane as fits file to disk or not
         saveopds: bool
             Whether to save images of pair-wise aberrated pupils to disk or not
         """
@@ -376,10 +376,17 @@ def _simulator_matrix_single_mode(which_dm, number_all_modes, wfe_aber, simulato
     efield_wfs_plane = simulator.calc_out_of_band_wfs()
 
     if saveefields:
-        fname_real = f'efield_real_mode{mode_no}'
-        hcipy.write_fits(efield_focal_plane.real, os.path.join(resDir, 'efields', fname_real + '.fits'))
-        fname_imag = f'efield_imag_mode{mode_no}'
-        hcipy.write_fits(efield_focal_plane.imag, os.path.join(resDir, 'efields', fname_imag + '.fits'))
+        #Save focal plane Efields
+        fname_real_focal = f'efield_real_mode{mode_no}'
+        hcipy.write_fits(efield_focal_plane.real, os.path.join(resDir, 'efields_focal', fname_real_focal + '.fits'))
+        fname_imag_focal = f'efield_imag_mode{mode_no}'
+        hcipy.write_fits(efield_focal_plane.imag, os.path.join(resDir, 'efields_focal', fname_imag_focal + '.fits'))
+
+        #Save wfs plane Efields
+        fname_real_wfs = f'real_mode{mode_no}'
+        hcipy.write_fits(efield_wfs_plane.real, os.path.join(resDir, 'efields_wfs', fname_real_wfs + '.fits'))
+        fname_imag_wfs = f'imag_mode{mode_no}'
+        hcipy.write_fits(efield_wfs_plane.imag, os.path.join(resDir, 'efields_wfs', fname_imag_wfs + '.fits'))
 
     if saveopds:
         opd_map = inter[which_dm].phase


### PR DESCRIPTION
This PR adds function to calculate electric field (can be ideal_reference or poked efields) at the wavefront sensor plane.  These fields are further used to generate sensitivity matrices at the wavefront sensor plane. 

1. Add calculate_ref_efield_wfs(): This function generates an electric field as seen by the wavefront sensor when there is no aberration at the pupil plane.
2. Add calculate_efields_wfs(): This function generates a list of electric fields at the wavefront sensor plane by poking the deformable mirror with individual aberration modes
3. save the real and imaginary part of the efields_wfs
4. add norm_one_photon parameter to the all the efields/matrices calculated. 
5. norm_one_photon to be kept same across all efields/matrices computation
