### PR TITLE
Adjust aberration amplitudes in test after fixing simulator

### DIFF
--- a/pastis/tests/test_internal_simulators.py
+++ b/pastis/tests/test_internal_simulators.py
@@ -49,9 +49,9 @@ def test_simple_segmented_dm():
     tel = HexRingAPLC(OPTICS_DIR, num_rings=1, sampling=SAMPLING)
     coro_perfect, ref = tel.calc_psf(ref=True)
 
-    tel.set_segment(2, 1e-2, 0, 0)
-    tel.set_segment(4, 0, 1e-2, 0)
-    tel.set_segment(7, 0, 0, 1e-2)
+    tel.set_segment(2, 1e-9, 0, 0)
+    tel.set_segment(4, 0, 1e-9, 0)
+    tel.set_segment(7, 0, 0, 1e-9)
     coro_aberrated = tel.calc_psf()
     assert np.sum(coro_perfect/ref.max()) < np.sum(coro_aberrated/ref.max())
 
@@ -62,9 +62,9 @@ def test_multi_mode_segmented_dm():
     coro_perfect, ref = tel.calc_psf(ref=True)
 
     tel.create_segmented_mirror(n_zernikes)
-    tel.set_sm_segment(segid=2, zernike_number=2, amplitude=1e-2)
-    tel.set_sm_segment(segid=4, zernike_number=4, amplitude=1e-2)
-    tel.set_sm_segment(segid=7, zernike_number=5, amplitude=1e-2)
+    tel.set_sm_segment(segid=2, zernike_number=2, amplitude=1e-9)
+    tel.set_sm_segment(segid=4, zernike_number=4, amplitude=1e-9)
+    tel.set_sm_segment(segid=7, zernike_number=5, amplitude=1e-9)
     coro_aberrated = tel.calc_psf()
     assert np.sum(coro_perfect/ref.max()) < np.sum(coro_aberrated/ref.max())
 
@@ -78,8 +78,8 @@ def test_global_zernike_dm():
     num_act = tel.zernike_mirror.num_actuators
     dm_command = np.zeros(num_act)
 
-    dm_command[2] = 1e-4
-    dm_command[7] = 1e-4
+    dm_command[2] = 1e-8
+    dm_command[7] = 1e-8
     tel.zernike_mirror.actuators = dm_command
     coro_aberrated = tel.calc_psf()
     assert np.sum(coro_perfect/ref.max()) < np.sum(coro_aberrated/ref.max())
@@ -94,8 +94,8 @@ def test_ripple_mirror():
     num_act = tel.ripple_mirror.num_actuators
     dm_command = np.zeros(num_act)
 
-    dm_command[2] = 1e-4
-    dm_command[7] = 1e-4
+    dm_command[2] = 1e-9
+    dm_command[7] = 1e-9
     tel.ripple_mirror.actuators = dm_command
     coro_aberrated = tel.calc_psf()
     assert np.sum(coro_perfect/ref.max()) < np.sum(coro_aberrated/ref.max())
@@ -110,10 +110,10 @@ def test_continuous_dm():
     num_act = tel.dm.num_actuators
     dm_command = np.zeros(num_act)
 
-    dm_command[3] = 1e-4
-    dm_command[11] = 1e-4
-    dm_command[19] = 1e-4
-    dm_command[23] = 1e-4
+    dm_command[3] = 1e-9
+    dm_command[11] = 1e-9
+    dm_command[19] = 1e-9
+    dm_command[23] = 1e-9
     tel.dm.actuators = dm_command
     coro_aberrated = tel.calc_psf()
     assert np.sum(coro_perfect/ref.max()) < np.sum(coro_aberrated/ref.max())


### PR DESCRIPTION
Some tests were failing after fixing a simulator bug over in #134. Didn't have the time to fix it there so doing that now.
Since PR #134 makes the SCDA simulator read the correct wavelength, we now have appropriate contrast sensitivity to aberrations. In this PR here, I adjust some pytests to reflect that.