### PR TITLE
Fix poor contrast performance of Luvex simulator

### DIFF
--- a/notebooks/SCDA/1_test-scda-simulator.ipynb
+++ b/notebooks/SCDA/1_test-scda-simulator.ipynb
@@ -34,8 +34,8 @@
     "# Define input parameters\n",
     "optics_dir = os.path.join(find_repo_location(), 'data', 'SCDA')\n",
     "sampling = 4\n",
-    "num_rings = 1\n",
-    "robust = 4"
+    "num_rings = 3\n",
+    "robust = 0"
    ]
   },
   {
@@ -89,9 +89,9 @@
    "outputs": [],
    "source": [
     "tel.flatten()\n",
-    "tel.set_segment(2, 1e-4, 0, 0)\n",
-    "tel.set_segment(4, 0, 1e-4, 0)\n",
-    "tel.set_segment(7, 0, 0, 1e-4)"
+    "tel.set_segment(1, 1e-8, 0, 0)\n",
+    "tel.set_segment(4, 0, 1e-8, 0)\n",
+    "tel.set_segment(7, 0, 0, 1e-8)"
    ]
   },
   {
@@ -113,8 +113,8 @@
    "outputs": [],
    "source": [
     "tel.flatten()\n",
-    "tel.set_sm_segment(segid=2, zernike_number=2, amplitude=1e-3)\n",
-    "tel.set_sm_segment(segid=4, zernike_number=3, amplitude=1e-3)"
+    "tel.set_sm_segment(segid=2, zernike_number=2, amplitude=1e-8)\n",
+    "tel.set_sm_segment(segid=4, zernike_number=3, amplitude=1e-8)"
    ]
   },
   {
@@ -151,8 +151,8 @@
    "outputs": [],
    "source": [
     "# Chose mask\n",
-    "num = 3\n",
-    "new_val = 1.09816"
+    "num = 5\n",
+    "new_val = 6.844452477"
    ]
   },
   {
@@ -173,9 +173,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# For aperture file\n",
+    "hdulist = fits.open(path + '.fits')\n",
+    "header = hdulist[0].header\n",
+    "\n",
     "# Also for indexed file\n",
     "hdulist_ind = fits.open(path + '_indexed' + '.fits')\n",
     "header_ind = hdulist_ind[0].header"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4419db55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header"
    ]
   },
   {
@@ -195,7 +209,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "header_ind['SEG_F2F'] = new_val"
+    "#header['SEG_F2F'] = new_val\n",
+    "#header_ind['SEG_F2F'] = new_val\n",
+    "\n",
+    "header['D_CIRC'] = new_val\n",
+    "header_ind['D_CIRC'] = new_val"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d7529b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header"
    ]
   },
   {
@@ -215,13 +243,137 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "hdulist.writeto(path + '.fits', overwrite=True)\n",
     "hdulist_ind.writeto(path + '_indexed' + '.fits', overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc057b63",
+   "metadata": {},
+   "source": [
+    "## Array cutting and extending"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f224021a",
+   "id": "38cd9465",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c31c720c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path_to_all = '/Users/ilaginja/repos/PASTIS/data/SCDA'\n",
+    "path = os.path.join(path_to_all, f'{num}-Hex', 'solutions', f'3-Hex_robust_0px_N1024')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00dc2417",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read header\n",
+    "hdulist = fits.open(path + '.fits')\n",
+    "header = hdulist[0].header\n",
+    "array = hdulist[0].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adbf4da3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f37e840c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(array)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1dcec5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_array_sizes_px = [1044, 1031, 940, 948, 955]\n",
+    "array_size_px = all_array_sizes_px[num-1]\n",
+    "print(array_size_px)\n",
+    "\n",
+    "array_size_px_old = 1024\n",
+    "#diam_meter = header['D_CIRC']\n",
+    "#print(diam_meter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a2edeec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "total_cut = array_size_px_old - array_size_px\n",
+    "print(total_cut)\n",
+    "half_cut = int(total_cut/2)\n",
+    "print(half_cut)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78ec29b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_array = array[half_cut:-half_cut, half_cut:-half_cut]\n",
+    "print(new_array.shape[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ea64a4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(new_array)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac522d12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdulist[0].data = new_array\n",
+    "hdulist.writeto(path + '.fits', overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6098aeb",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -243,7 +395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/notebooks/SCDA/2_check_LS_sizes.ipynb
+++ b/notebooks/SCDA/2_check_LS_sizes.ipynb
@@ -1,0 +1,114 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cd830bec",
+   "metadata": {},
+   "source": [
+    "# Check LS diameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8325dae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.io import fits\n",
+    "import hcipy\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9a48ab1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_rings = 5\n",
+    "robustness_px = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20d32986",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path_to_all = '/Users/ilaginja/repos/PASTIS/data/SCDA'\n",
+    "aper_path = os.path.join(path_to_all, f'{num_rings}-Hex', 'masks', f'TelAp_LUVex_0{num_rings}-Hex_gy_clipped_ovsamp04_N1024')\n",
+    "aper_ind_path = os.path.join(path_to_all, f'{num_rings}-Hex', 'masks', f'TelAp_LUVex_0{num_rings}-Hex_gy_clipped_ovsamp04_N1024_indexed')\n",
+    "ls_path = os.path.join(path_to_all, f'{num_rings}-Hex', 'masks', f'LS_LUVex_{num_rings:02d}-Hex_ID0000_OD0982_no_struts_gy_ovsamp4_N{1024:04d}')\n",
+    "apod_path = os.path.join(path_to_all, f'{num_rings}-Hex', 'solutions', f'{num_rings:01d}-Hex_robust_{robustness_px}px_N{1024:04d}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e54b186",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdu_aper = fits.open(aper_path + '.fits')\n",
+    "aper_header = hdu_aper[0].header\n",
+    "\n",
+    "hdu_ind_aper = fits.open(aper_ind_path + '.fits')\n",
+    "aper_ind_header = hdu_ind_aper[0].header\n",
+    "\n",
+    "hdu_ls = fits.open(ls_path + '.fits')\n",
+    "ls_header = hdu_ls[0].header\n",
+    "\n",
+    "hdu_apod = fits.open(apod_path + '.fits')\n",
+    "apod_header = hdu_apod[0].header"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d585a33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'{num_rings}-Hex:')\n",
+    "print(aper_header['D_CIRC'])\n",
+    "print(aper_ind_header['D_CIRC'])\n",
+    "print(ls_header['D_CIRC'])\n",
+    "#print(apod_header['D_CIRC'])    # does not exist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7ca2f6c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pastis/simulators/scda_telescopes.py
+++ b/pastis/simulators/scda_telescopes.py
@@ -48,6 +48,12 @@ class ScdaAPLC(SegmentedAPLC):
         ls_read = hcipy.read_fits(os.path.join(input_dir, ls_fname))
         lyot_stop = hcipy.Field(ls_read.ravel(), pupil_grid)
 
+        # For the 3-Hex, 4-Hex and 5-Hex Luvex designs, actually create the LS #TODO: get to the bottom of this problem
+        if hasattr(self, 'num_rings') and self.num_rings in [3, 4, 5]:
+            all_ls_diams = [5.417565656565657, 5.4495959595959595, 5.4981407035175875]
+            ls_diam = all_ls_diams[self.num_rings-3]
+            lyot_stop = hcipy.evaluate_supersampled(hcipy.circular_aperture(diameter=ls_diam), pupil_grid, 4)
+
         # Create a focal plane mask
         samp_foc = fpm_px / (fpm_rad * 2)
         focal_grid_fpm = hcipy.make_focal_grid_from_pupil_grid(pupil_grid=pupil_grid, q=samp_foc, num_airy=fpm_rad, wavelength=wvln)

--- a/pastis/simulators/scda_telescopes.py
+++ b/pastis/simulators/scda_telescopes.py
@@ -96,7 +96,9 @@ class HexRingAPLC(ScdaAPLC):
         aper_ind_fname = aper_fname.split('.')[0] + '_indexed.fits'
 
         aper_hdr = fits.getheader(os.path.join(data_in_repo, aper_fname))
-        diameter_circumscribed = aper_hdr['D_CIRC']
+        #diameter_circumscribed = aper_hdr['D_CIRC']
+        all_diameters_outer = [7.952780833, 7.258823341, 7.72593506, 7.136856303, 6.844452477]
+        diameter_circumscribed = all_diameters_outer[num_rings-1]
         seg_flat_to_flat = aper_hdr['SEG_F2F']
         wvln = CONFIG_PASTIS.getfloat('HexRingTelescope', 'lambda') * 1e-9    # m
 


### PR DESCRIPTION
The 5 SCDA telescopes designs with their APLCs were all designed to reach an average DH mean contrast below 1e-10. We noticed that this performance was not reached in the current implementation of the simulator, except for the 1-Hex and the 2-Hex design.

The reasons for this are:
- The circumscribed diameters encoded in the fits file headers of the SCDA telescope designs were scrambled and not entirely correct. @brynickson remeasured them in DS9 under the assumption that the *inscribed* diameter is exactly 6m for all five designs, and calculated the *circumscribed* (point to point) diameters from that, resulting in the following five numbers for the five designs: `[7.952780833, 7.258823341, 7.72593506, 7.136856303, 6.844452477]`
- The Lyot stops, which all have a relative size of 98.2% of the respective inscribed diameter, also had slightly scrambled sizes.

This PR provides a temporary fix for this issue although the goal is to come back to this and understand what really caused this. The fixes that are implemented here are:
- Instead of reading the circumscribed diameters of the apertures from the fits files, they are now taken from the above list.
- The Lyot stops for the 3-, 4- and 5-Hex designs are now created with HCIPy on the same pupil grid like the apertures get sampled on, with diameters that were found by means of a parameter sweep, where we picked the value that gave the best contrast.

The problem that remains is that the DH morphologies are still slightly off from the design process of the APLC designs. The only design that is perfectly fine (by reading both the aperture and the LS from file) is the 2-Hex design - both the contrast performance as well as the DH morphology are what we expect from the design process. Meanwhile, the 1-hex design meets the contrast spec but does not match the DH morphology out of the box. Both of these designs are not touched in this PR.

Below a comparison between the expected DHs and DHs produced by the fixed simulator in this PR:

1-Hex expected:
<img width="464" alt="Screen Shot 2022-07-18 at 15 57 57" src="https://user-images.githubusercontent.com/29508965/179527792-1fca16b3-1837-4963-b1c2-9f55dd834643.png">

1-Hex current:
<img width="316" alt="Screen Shot 2022-07-18 at 15 58 43" src="https://user-images.githubusercontent.com/29508965/179527915-11fe1708-bf80-4d1e-a9d0-a3a97c08fdce.png">

2-Hex expected:
<img width="466" alt="Screen Shot 2022-07-18 at 15 59 07" src="https://user-images.githubusercontent.com/29508965/179527982-ea08cc05-6e3c-4223-9fae-90811016bd56.png">

2-Hex current:
<img width="321" alt="Screen Shot 2022-07-18 at 15 59 36" src="https://user-images.githubusercontent.com/29508965/179528111-ef1b62c3-3c51-4a5c-b582-8b41e9ea753e.png">

3-Hex expected (left) and current (right):
<img width="721" alt="Screen Shot 2022-07-18 at 16 00 52" src="https://user-images.githubusercontent.com/29508965/179528482-12a60fa9-cabc-44a0-a082-89b1d14401f2.png">

4-Hex expected (left) and current (right):
<img width="719" alt="Screen Shot 2022-07-18 at 16 01 00" src="https://user-images.githubusercontent.com/29508965/179528523-a5084ed8-7d5d-4c6b-b40d-cc676b18fe5a.png">

5-Hex expected (left) and current (right):
<img width="722" alt="Screen Shot 2022-07-18 at 16 01 12" src="https://user-images.githubusercontent.com/29508965/179528582-72fca5cf-77db-40e9-bbaf-a4d2043fb7e0.png">

Incidentally, all the changes in this PR keep the segment size in the modal basis used for the segmented aberrations correct; there are potentially a handful of blank pixels now showing up on the edges of the segment modes, but this should not impact the performance of the simulator.