### PR TITLE
Pin hcipy to 0.4.0.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,8 +16,8 @@ dependencies:
   - pytest
   - python=3.10
   - scipy
+  - conda-forge::hcipy<=0.4
+  - conda-forge::progressbar2
   - pip:
     - fpdf
     - poppy
-    - hcipy
-    - progressbar2


### PR DESCRIPTION
Pins hcipy to 0.4.0, due to regression test failure found in #130. This should be unpinned when the reason for the regression has been found and fixed (or when a new PASTIS matrix is uploaded for the regression test).

An initial investigation showed that the regression was primarily numerical in nature, and than no physics changes were made. I could not tell you for sure what actually changed between 0.5.0 and 0.4.0. There were a lot of aperture changes so that would be my first choice.

This PR also moves both hcipy and progressbar2 to conda (conda-forge) installations rather than pip.