### PR TITLE
Add analysis scripts for scda telescope

### DIFF
--- a/pastis/multimode_tolerance_plots.py
+++ b/pastis/multimode_tolerance_plots.py
@@ -4,6 +4,31 @@ import matplotlib.pyplot as plt
 
 
 def plot_mus_all_hexrings(mu1, mu2, mu3, mu4, mu5, c0, out_dir, save=False):
+    """
+    Parameters
+    ----------
+    mu1 : numpy.ndarray
+        Each element represents tolerance (in units of nm) for segment per a segment level aberration mode
+        for the 1-HexRingTelescope.
+    mu2 : numpy.ndarray
+        Each element represents tolerance (in units of nm) for segment per a segment level aberration mode
+        for the 2-HexRingTelescope.
+    mu3 : numpy.ndarray
+        Each element  represents tolerance (in units of nm) for segment per a segment level aberration mode
+        for the 3-HexRingTelescope.
+    mu4 : numpy.ndarray
+        Each element represents tolerance (in units of nm) for segment per a segment level aberration mode
+        for the 4-HexRingTelescope.
+    mu5 : numpy.ndarray
+        Each element represents tolerance (in units of nm) for segment per a segment level aberration mode
+        for the 5-HexRingTelescope.
+    c0 : float
+        The set-target contrast for which the above tolerances were calculated.
+    out_dir : str
+        path where the plot will be saved
+    save : bool
+        whether to save the plot
+    """
     plt.figure(figsize=(10, 10))
     plt.title("Modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=20)
     plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
@@ -22,6 +47,37 @@ def plot_mus_all_hexrings(mu1, mu2, mu3, mu4, mu5, c0, out_dir, save=False):
 
 
 def plot_single_thermal_mode_all_hex(mu1, mu2, mu3, mu4, mu5, c0, mode, out_dir, save=False, inner_segments=False):
+    """
+    Parameters
+    ----------
+    mu1 : numpy.ndarray
+        Each element represents tolerance (in units of nm) for segment per a segment level aberration mode
+        for the 1-HexRingTelescope.
+    mu2 : numpy.ndarray
+        Each element represents tolerance (in units of nm) for segment per a segment level aberration mode
+        for the 2-HexRingTelescope.
+    mu3 : numpy.ndarray
+        Each element  represents tolerance (in units of nm) for segment per a segment level aberration mode
+        for the 3-HexRingTelescope.
+    mu4 : numpy.ndarray
+        Each element represents tolerance (in units of nm) for segment per a segment level aberration mode
+        for the 4-HexRingTelescope.
+    mu5 : numpy.ndarray
+        Each element represents tolerance (in units of nm) for segment per a segment level aberration mode
+        for the 5-HexRingTelescope.
+    c0 : float
+        The set-target contrast for which the above tolerances were calculated.
+    mode : str
+        name of the segment level zernike/harris thermal aberration
+        "Faceplates Silvered" or "Piston", "Bulk" or "Tip", "Gradiant Radial" or "Tilt",
+        "Gradiant X lateral" or "Defocus", or "Gradiant Z axial" or "Astig"
+    out_dir : str
+        path where the plot will be saved
+    save : bool
+        whether to save the plot
+    inner_segments : bool
+        whether to plot tolerances for the inner segments only
+    """
 
     # for 1-HexRingTelescope
     mus1_table = np.zeros([5, 7])
@@ -53,7 +109,7 @@ def plot_single_thermal_mode_all_hex(mu1, mu2, mu3, mu4, mu5, c0, mode, out_dir,
         for kk in range(85):
             mus5_table[qq, kk] = mu5[qq + kk * 5]
 
-    if mode == "Faceplates Silvered" or mode =="Piston":
+    if mode == "Faceplates Silvered" or mode == "Piston":
         num = 0
     elif mode == "Bulk" or mode == "Tip":
         num = 1
@@ -74,11 +130,10 @@ def plot_single_thermal_mode_all_hex(mu1, mu2, mu3, mu4, mu5, c0, mode, out_dir,
     plt.plot(mus3_table[num] * 1e3, label="3-HexRingTelescope", marker="p")
     plt.plot(mus4_table[num] * 1e3, label="4-HexRingTelescope", marker="P")
     plt.plot(mus5_table[num] * 1e3, label="5-HexRingTelescope", marker="H")
-    #plt.yticks(np.arange(np.min(mus2_table[1] * 1e3), np.max(mus5_table[1] * 1e3), 0.5))
     if inner_segments:
         plt.xlabel("Inner Segment Number", fontsize=20)
-        plt.yticks(np.arange(np.min(mus5_table[0] * 1e3), np.max(mus5_table[0] * 1e3), 0.1))
-        plt.ylim(0, 2)
+        plt.yticks(np.arange(np.min(mus3_table[num] * 1e3), np.max(mus4_table[num] * 1e3), 0.5))
+        plt.ylim(1, 5)
         plt.xlim(0, 15)
     plt.grid()
     plt.legend(fontsize=15)
@@ -105,5 +160,5 @@ if __name__ == '__main__':
 
     resdir = '/Users/asahoo/Desktop/data_repos/plots_mid_zernike'
     # plot_mus_all_hexrings(mus1, mus2, mus3, mus4, mus5, 1e-11, resdir, save=False)
-    plot_single_thermal_mode_all_hex(mus1, mus2, mus3, mus4, mus5, 1e-11,
-                                     mode="Gradiant Z axial", out_dir=resdir, save=True, inner_segments=False)
+    plot_single_thermal_mode_all_hex(z1, z2, z3, z4, z5, 1e-11,
+                                     mode="Astig", out_dir=resdir, save=True, inner_segments=True)

--- a/pastis/multimode_tolerance_plots.py
+++ b/pastis/multimode_tolerance_plots.py
@@ -53,130 +53,57 @@ def plot_single_thermal_mode_all_hex(mu1, mu2, mu3, mu4, mu5, c0, mode, out_dir,
         for kk in range(85):
             mus5_table[qq, kk] = mu5[qq + kk * 5]
 
-    if mode == "Faceplates Silvered":
-        plt.figure(figsize=(10, 10))
-        plt.title("Faceplates Silvered Modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=10)
-        plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
-        plt.xlabel("Segment Number", fontsize=20)
-        plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
-        plt.plot(mus1_table[0] * 1e3, label="1-HexRingTelescope")
-        plt.plot(mus2_table[0] * 1e3, label="2-HexRingTelescope")
-        plt.plot(mus3_table[0] * 1e3, label="3-HexRingTelescope")
-        plt.plot(mus4_table[0] * 1e3, label="4-HexRingTelescope")
-        plt.plot(mus5_table[0] * 1e3, label="5-HexRingTelescope")
-        plt.yticks(np.arange(np.min(mus5_table[0]*1e3), np.max(mus5_table[0]*1e3), 0.1))
-        if inner_segments:
-            plt.xlabel("Inner Segment Number", fontsize=20)
-            plt.ylim(0, 2)
-            plt.xlim(0, 15)
-        plt.grid()
-        plt.legend(fontsize=15)
-        plt.tight_layout()
-        if save:
-            plt.savefig(os.path.join(out_dir, 'mus_faceplate_%s.png' % c0))
+    if mode == "Faceplates Silvered" or mode =="Piston":
+        num = 0
+    elif mode == "Bulk" or mode == "Tip":
+        num = 1
+    elif mode == "Gradiant Radial" or mode == "Tilt":
+        num = 2
+    elif mode == "Gradiant X lateral" or mode == "Defocus":
+        num = 3
+    elif mode == "Gradiant Z axial" or mode == "Astig":
+        num = 4
 
-    if mode == "Bulk":
-        plt.figure(figsize=(10, 10))
-        plt.title("Bulk Modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=10)
-        plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
-        plt.xlabel("Segment Number", fontsize=20)
-        plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
-        plt.plot(mus1_table[1] * 1e3, label="1-HexRingTelescope")
-        plt.plot(mus2_table[1] * 1e3, label="2-HexRingTelescope")
-        plt.plot(mus3_table[1] * 1e3, label="3-HexRingTelescope")
-        plt.plot(mus4_table[1] * 1e3, label="4-HexRingTelescope")
-        plt.plot(mus5_table[1] * 1e3, label="5-HexRingTelescope")
-        plt.yticks(np.arange(np.min(mus2_table[1] * 1e3), np.max(mus5_table[1] * 1e3), 2))
-        if inner_segments:
-            plt.xlabel("Inner Segment Number", fontsize=20)
-            plt.yticks(np.arange(np.min(mus2_table[1] * 1e3), np.max(mus5_table[1] * 1e3), 0.5))
-            plt.ylim(1, 10)
-            plt.xlim(0, 15)
-        plt.grid()
-        plt.legend(fontsize=15)
-        plt.tight_layout()
-        if save:
-            plt.savefig(os.path.join(out_dir, 'mus_bulk_%s.png' % c0))
-
-    if mode == "Gradiant Radial":
-        plt.figure(figsize=(10, 10))
-        plt.title("Gradiant Radial constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=10)
-        plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
-        plt.xlabel("Segment Number", fontsize=20)
-        plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
-        plt.plot(mus1_table[2] * 1e3, label="1-HexRingTelescope")
-        plt.plot(mus2_table[2] * 1e3, label="2-HexRingTelescope")
-        plt.plot(mus3_table[2] * 1e3, label="3-HexRingTelescope")
-        plt.plot(mus4_table[2] * 1e3, label="4-HexRingTelescope")
-        plt.plot(mus5_table[2] * 1e3, label="5-HexRingTelescope")
-        plt.yticks(np.arange(np.min(mus2_table[2] * 1e3), np.max(mus5_table[2] * 1e3), 5))
-        if inner_segments:
-            plt.xlabel("Inner Segment Number", fontsize=20)
-            plt.yticks(np.arange(np.min(mus2_table[1] * 1e3), np.max(mus5_table[1] * 1e3), 0.5))
-            plt.ylim(1, 13.5)
-            plt.xlim(0, 15)
-        plt.grid()
-        plt.legend(fontsize=15)
-        plt.tight_layout()
-        if save:
-            plt.savefig(os.path.join(out_dir, 'mus_gradient_radial_%s.png' % c0))
-
-    if mode == "Gradiant X lateral":
-        plt.figure(figsize=(10, 10))
-        plt.title("Gradiant X lateral constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=10)
-        plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
-        plt.xlabel("Segment Number", fontsize=20)
-        plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
-        plt.plot(mus1_table[3] * 1e3, label="1-HexRingTelescope")
-        plt.plot(mus2_table[3] * 1e3, label="2-HexRingTelescope")
-        plt.plot(mus3_table[3] * 1e3, label="3-HexRingTelescope")
-        plt.plot(mus4_table[3] * 1e3, label="4-HexRingTelescope")
-        plt.plot(mus5_table[3] * 1e3, label="5-HexRingTelescope")
-        plt.yticks(np.arange(np.min(mus3_table[3] * 1e3), np.max(mus5_table[3] * 1e3), 0.5))
-        if inner_segments:
-            plt.xlabel("Inner Segment Number", fontsize=20)
-            plt.yticks(np.arange(np.min(mus3_table[3] * 1e3), np.max(mus5_table[3] * 1e3), 0.1))
-            plt.ylim(0.8, 2.5)
-            plt.xlim(0, 15)
-        plt.grid()
-        plt.legend(fontsize=15)
-        plt.tight_layout()
-        if save:
-            plt.savefig(os.path.join(out_dir, 'mus_gradient_xlateral_%s.png' % c0))
-
-    if mode == "Gradiant Y lateral":
-        plt.figure(figsize=(10, 10))
-        plt.title("Gradiant Y lateral constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=10)
-        plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
-        plt.xlabel("Segment Number", fontsize=20)
-        plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
-        plt.plot(mus1_table[4] * 1e3, label="1-HexRingTelescope")
-        plt.plot(mus2_table[4] * 1e3, label="2-HexRingTelescope")
-        plt.plot(mus3_table[4] * 1e3, label="3-HexRingTelescope")
-        plt.plot(mus4_table[4] * 1e3, label="4-HexRingTelescope")
-        plt.plot(mus5_table[4] * 1e3, label="5-HexRingTelescope")
-        plt.yticks(np.arange(np.min(mus3_table[4] * 1e3), np.max(mus5_table[4] * 1e3), 1))
-        if inner_segments:
-            plt.xlabel("Inner Segment Number", fontsize=20)
-            plt.yticks(np.arange(np.min(mus3_table[4] * 1e3), np.max(mus5_table[4] * 1e3), 0.1))
-            plt.ylim(0.7, 3.0)
-            plt.xlim(0, 15)
-        plt.grid()
-        plt.legend(fontsize=15)
-        plt.tight_layout()
-        if save:
-            plt.savefig(os.path.join(out_dir, 'mus_gradient_inner_%s.png' % c0))
+    plt.figure(figsize=(10, 10))
+    plt.title(str(mode)+" modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=10)
+    plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
+    plt.xlabel("Segment Number", fontsize=20)
+    plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
+    plt.plot(mus1_table[num] * 1e3, label="1-HexRingTelescope", marker="o")
+    plt.plot(mus2_table[num] * 1e3, label="2-HexRingTelescope", marker="s")
+    plt.plot(mus3_table[num] * 1e3, label="3-HexRingTelescope", marker="p")
+    plt.plot(mus4_table[num] * 1e3, label="4-HexRingTelescope", marker="P")
+    plt.plot(mus5_table[num] * 1e3, label="5-HexRingTelescope", marker="H")
+    #plt.yticks(np.arange(np.min(mus2_table[1] * 1e3), np.max(mus5_table[1] * 1e3), 0.5))
+    if inner_segments:
+        plt.xlabel("Inner Segment Number", fontsize=20)
+        plt.yticks(np.arange(np.min(mus5_table[0] * 1e3), np.max(mus5_table[0] * 1e3), 0.1))
+        plt.ylim(0, 2)
+        plt.xlim(0, 15)
+    plt.grid()
+    plt.legend(fontsize=15)
+    plt.tight_layout()
+    if save:
+        plt.savefig(os.path.join(out_dir, str(mode) + '_mus_%s.png' % c0))
 
 
 if __name__ == '__main__':
 
-    mus5 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots/mus_1e-11_5.csv', delimiter=',')
-    mus4 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots/mus_1e-11_4.csv', delimiter=',')
-    mus3 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots/mus_1e-11_3.csv', delimiter=',')
-    mus2 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots/mus_1e-11_2.csv', delimiter=',')
-    mus1 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots/mus_1e-11_1.csv', delimiter=',')
+    # Thermal tolerance coefficients
+    mus5 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots_thermal/mus_1e-11_5.csv', delimiter=',')
+    mus4 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots_thermal/mus_1e-11_4.csv', delimiter=',')
+    mus3 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots_thermal/mus_1e-11_3.csv', delimiter=',')
+    mus2 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots_thermal/mus_1e-11_2.csv', delimiter=',')
+    mus1 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots_thermal/mus_1e-11_1.csv', delimiter=',')
 
-    resdir = '/Users/asahoo/Desktop/data_repos/plots'
-    plot_mus_all_hexrings(mus1, mus2, mus3, mus4, mus5, 1e-11, resdir, save=False)
+    # Segment level zernike coefficients
+    z5 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots_mid_zernike/mus_1e-11_5.csv', delimiter=',')
+    z4 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots_mid_zernike/mus_1e-11_4.csv', delimiter=',')
+    z3 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots_mid_zernike/mus_1e-11_3.csv', delimiter=',')
+    z2 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots_mid_zernike/mus_1e-11_2.csv', delimiter=',')
+    z1 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots_mid_zernike/mus_1e-11_1.csv', delimiter=',')
+
+    resdir = '/Users/asahoo/Desktop/data_repos/plots_mid_zernike'
+    # plot_mus_all_hexrings(mus1, mus2, mus3, mus4, mus5, 1e-11, resdir, save=False)
     plot_single_thermal_mode_all_hex(mus1, mus2, mus3, mus4, mus5, 1e-11,
-                                     mode="Gradiant Y lateral", out_dir=resdir, save=False, inner_segments=False)
+                                     mode="Gradiant Z axial", out_dir=resdir, save=True, inner_segments=False)

--- a/pastis/multimode_tolerance_plots.py
+++ b/pastis/multimode_tolerance_plots.py
@@ -1,0 +1,182 @@
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def plot_mus_all_hexrings(mu1, mu2, mu3, mu4, mu5, c0, out_dir, save=False):
+    plt.figure(figsize=(10, 10))
+    plt.title("Modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=20)
+    plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
+    plt.xlabel("Mode Index", fontsize=20)
+    plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
+    plt.plot(mu1*1e3, label="1-HexRingTelescope")
+    plt.plot(mu2*1e3, label="2-HexRingTelescope")
+    plt.plot(mu3*1e3, label="3-HexRingTelescope")
+    plt.plot(mu4*1e3, label="4-HexRingTelescope")
+    plt.plot(mu5*1e3, label="5-HexRingTelescope")
+    plt.grid()
+    plt.legend(fontsize=15)
+    plt.tight_layout()
+    if save:
+        plt.savefig(os.path.join(out_dir, 'mus_1d_multi_modes_%s.png' % c0))
+
+
+def plot_single_thermal_mode_all_hex(mu1, mu2, mu3, mu4, mu5, c0, mode, out_dir, save=False, inner_segments=False):
+
+    # for 1-HexRingTelescope
+    mus1_table = np.zeros([5, 7])
+    for qq in range(5):
+        for kk in range(7):
+            mus1_table[qq, kk] = mu1[qq + kk * 5]
+
+    # for 2-HexRingTelescope
+    mus2_table = np.zeros([5, 19])
+    for qq in range(5):
+        for kk in range(19):
+            mus2_table[qq, kk] = mu2[qq + kk * 5]
+
+    # for 3-HexRingTelescope
+    mus3_table = np.zeros([5, 31])
+    for qq in range(5):
+        for kk in range(31):
+            mus3_table[qq, kk] = mu3[qq + kk * 5]
+
+    # for 4-HexRingTelescope
+    mus4_table = np.zeros([5, 55])
+    for qq in range(5):
+        for kk in range(55):
+            mus4_table[qq, kk] = mu4[qq + kk * 5]
+
+    # for 5-HexRingTelescope
+    mus5_table = np.zeros([5, 85])
+    for qq in range(5):
+        for kk in range(85):
+            mus5_table[qq, kk] = mu5[qq + kk * 5]
+
+    if mode == "Faceplates Silvered":
+        plt.figure(figsize=(10, 10))
+        plt.title("Faceplates Silvered Modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=10)
+        plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
+        plt.xlabel("Segment Number", fontsize=20)
+        plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
+        plt.plot(mus1_table[0] * 1e3, label="1-HexRingTelescope")
+        plt.plot(mus2_table[0] * 1e3, label="2-HexRingTelescope")
+        plt.plot(mus3_table[0] * 1e3, label="3-HexRingTelescope")
+        plt.plot(mus4_table[0] * 1e3, label="4-HexRingTelescope")
+        plt.plot(mus5_table[0] * 1e3, label="5-HexRingTelescope")
+        plt.yticks(np.arange(np.min(mus5_table[0]*1e3), np.max(mus5_table[0]*1e3), 0.1))
+        if inner_segments:
+            plt.xlabel("Inner Segment Number", fontsize=20)
+            plt.ylim(0, 2)
+            plt.xlim(0, 15)
+        plt.grid()
+        plt.legend(fontsize=15)
+        plt.tight_layout()
+        if save:
+            plt.savefig(os.path.join(out_dir, 'mus_faceplate_%s.png' % c0))
+
+    if mode == "Bulk":
+        plt.figure(figsize=(10, 10))
+        plt.title("Bulk Modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=10)
+        plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
+        plt.xlabel("Segment Number", fontsize=20)
+        plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
+        plt.plot(mus1_table[1] * 1e3, label="1-HexRingTelescope")
+        plt.plot(mus2_table[1] * 1e3, label="2-HexRingTelescope")
+        plt.plot(mus3_table[1] * 1e3, label="3-HexRingTelescope")
+        plt.plot(mus4_table[1] * 1e3, label="4-HexRingTelescope")
+        plt.plot(mus5_table[1] * 1e3, label="5-HexRingTelescope")
+        plt.yticks(np.arange(np.min(mus2_table[1] * 1e3), np.max(mus5_table[1] * 1e3), 2))
+        if inner_segments:
+            plt.xlabel("Inner Segment Number", fontsize=20)
+            plt.yticks(np.arange(np.min(mus2_table[1] * 1e3), np.max(mus5_table[1] * 1e3), 0.5))
+            plt.ylim(1, 10)
+            plt.xlim(0, 15)
+        plt.grid()
+        plt.legend(fontsize=15)
+        plt.tight_layout()
+        if save:
+            plt.savefig(os.path.join(out_dir, 'mus_bulk_%s.png' % c0))
+
+    if mode == "Gradiant Radial":
+        plt.figure(figsize=(10, 10))
+        plt.title("Gradiant Radial constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=10)
+        plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
+        plt.xlabel("Segment Number", fontsize=20)
+        plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
+        plt.plot(mus1_table[2] * 1e3, label="1-HexRingTelescope")
+        plt.plot(mus2_table[2] * 1e3, label="2-HexRingTelescope")
+        plt.plot(mus3_table[2] * 1e3, label="3-HexRingTelescope")
+        plt.plot(mus4_table[2] * 1e3, label="4-HexRingTelescope")
+        plt.plot(mus5_table[2] * 1e3, label="5-HexRingTelescope")
+        plt.yticks(np.arange(np.min(mus2_table[2] * 1e3), np.max(mus5_table[2] * 1e3), 5))
+        if inner_segments:
+            plt.xlabel("Inner Segment Number", fontsize=20)
+            plt.yticks(np.arange(np.min(mus2_table[1] * 1e3), np.max(mus5_table[1] * 1e3), 0.5))
+            plt.ylim(1, 13.5)
+            plt.xlim(0, 15)
+        plt.grid()
+        plt.legend(fontsize=15)
+        plt.tight_layout()
+        if save:
+            plt.savefig(os.path.join(out_dir, 'mus_gradient_radial_%s.png' % c0))
+
+    if mode == "Gradiant X lateral":
+        plt.figure(figsize=(10, 10))
+        plt.title("Gradiant X lateral constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=10)
+        plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
+        plt.xlabel("Segment Number", fontsize=20)
+        plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
+        plt.plot(mus1_table[3] * 1e3, label="1-HexRingTelescope")
+        plt.plot(mus2_table[3] * 1e3, label="2-HexRingTelescope")
+        plt.plot(mus3_table[3] * 1e3, label="3-HexRingTelescope")
+        plt.plot(mus4_table[3] * 1e3, label="4-HexRingTelescope")
+        plt.plot(mus5_table[3] * 1e3, label="5-HexRingTelescope")
+        plt.yticks(np.arange(np.min(mus3_table[3] * 1e3), np.max(mus5_table[3] * 1e3), 0.5))
+        if inner_segments:
+            plt.xlabel("Inner Segment Number", fontsize=20)
+            plt.yticks(np.arange(np.min(mus3_table[3] * 1e3), np.max(mus5_table[3] * 1e3), 0.1))
+            plt.ylim(0.8, 2.5)
+            plt.xlim(0, 15)
+        plt.grid()
+        plt.legend(fontsize=15)
+        plt.tight_layout()
+        if save:
+            plt.savefig(os.path.join(out_dir, 'mus_gradient_xlateral_%s.png' % c0))
+
+    if mode == "Gradiant Y lateral":
+        plt.figure(figsize=(10, 10))
+        plt.title("Gradiant Y lateral constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=10)
+        plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
+        plt.xlabel("Segment Number", fontsize=20)
+        plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
+        plt.plot(mus1_table[4] * 1e3, label="1-HexRingTelescope")
+        plt.plot(mus2_table[4] * 1e3, label="2-HexRingTelescope")
+        plt.plot(mus3_table[4] * 1e3, label="3-HexRingTelescope")
+        plt.plot(mus4_table[4] * 1e3, label="4-HexRingTelescope")
+        plt.plot(mus5_table[4] * 1e3, label="5-HexRingTelescope")
+        plt.yticks(np.arange(np.min(mus3_table[4] * 1e3), np.max(mus5_table[4] * 1e3), 1))
+        if inner_segments:
+            plt.xlabel("Inner Segment Number", fontsize=20)
+            plt.yticks(np.arange(np.min(mus3_table[4] * 1e3), np.max(mus5_table[4] * 1e3), 0.1))
+            plt.ylim(0.7, 3.0)
+            plt.xlim(0, 15)
+        plt.grid()
+        plt.legend(fontsize=15)
+        plt.tight_layout()
+        if save:
+            plt.savefig(os.path.join(out_dir, 'mus_gradient_inner_%s.png' % c0))
+
+
+if __name__ == '__main__':
+
+    mus5 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots/mus_1e-11_5.csv', delimiter=',')
+    mus4 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots/mus_1e-11_4.csv', delimiter=',')
+    mus3 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots/mus_1e-11_3.csv', delimiter=',')
+    mus2 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots/mus_1e-11_2.csv', delimiter=',')
+    mus1 = np.genfromtxt('/Users/asahoo/Desktop/data_repos/plots/mus_1e-11_1.csv', delimiter=',')
+
+    resdir = '/Users/asahoo/Desktop/data_repos/plots'
+    plot_mus_all_hexrings(mus1, mus2, mus3, mus4, mus5, 1e-11, resdir, save=False)
+    plot_single_thermal_mode_all_hex(mus1, mus2, mus3, mus4, mus5, 1e-11,
+                                     mode="Gradiant Y lateral", out_dir=resdir, save=False, inner_segments=False)

--- a/pastis/temporal_analysis/run_luvoir_analysis.py
+++ b/pastis/temporal_analysis/run_luvoir_analysis.py
@@ -340,3 +340,9 @@ c5 = c_contrast5['averaged_hist']
 n_tmp1 = len(c5)
 result_c5.append(c5[n_tmp1-1])
 print(result_c5[0]-contrast_floor)
+
+print(np.sqrt(np.mean((result_c5[0]-contrast_floor)**2 +
+                      (result_c4[0]-contrast_floor)**2 +
+                      (result_c3[0]-contrast_floor)**2 +
+                      (result_c2[0]-contrast_floor)**2 +
+                      (result_c1[0]-contrast_floor)**2)))

--- a/pastis/temporal_analysis/run_luvoir_analysis.py
+++ b/pastis/temporal_analysis/run_luvoir_analysis.py
@@ -1,0 +1,66 @@
+import os
+from astropy.io import fits
+import numpy as np
+from pastis.matrix_generation.matrix_from_efields import MatrixEfieldLuvoirA
+from pastis.config import CONFIG_PASTIS
+from pastis.simulators.luvoir_imaging import LuvoirA_APLC
+import pastis.util as util
+
+
+# Create necessary directories if they don't exist yet
+data_dir = CONFIG_PASTIS.get('local', 'local_data_path')
+
+# Instantiate the LUVOIR telescope
+optics_input = os.path.join(util.find_repo_location(), CONFIG_PASTIS.get('LUVOIR', 'optics_path_in_repo'))
+coronagraph_design = CONFIG_PASTIS.get('LUVOIR', 'coronagraph_design')
+sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')
+tel = LuvoirA_APLC(optics_input, coronagraph_design, sampling)
+
+# Create harris deformable mirror
+pad_orientation = np.pi/2*np.ones(tel.nseg)
+filepath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')
+tel.create_segmented_harris_mirror(filepath, pad_orientation, thermal=True, mechanical=False, other=False)
+tel.harris_sm
+
+# get number of poking modes
+num_actuators = tel.harris_sm.num_actuators
+num_modes = 5
+
+# calculate dark hole contrast
+tel.harris_sm.flatten()
+unaberrated_coro_psf, ref = tel.calc_psf(ref=True, display_intermediate=False, norm_one_photon=True)
+norm = np.max(ref)
+dh_intensity = (unaberrated_coro_psf / norm) * tel.dh_mask
+contrast_floor = np.mean(dh_intensity[np.where(tel.dh_mask != 0)])
+print(f'contrast floor: {contrast_floor}')
+
+
+# Calculate pastis matrix
+DM = 'harris_seg_mirror'
+DM_SPEC = (filepath, pad_orientation, True, False, False)
+
+
+run_matrix = MatrixEfieldLuvoirA(which_dm=DM, dm_spec=DM_SPEC, design='small',
+                                 calc_science=True, calc_wfs=True,
+                                 initial_path=CONFIG_PASTIS.get('local', 'local_data_path'),
+                                 norm_one_photon=True)
+run_matrix.calc()
+data_dir = run_matrix.overall_dir
+print(f'Matrix and Efields saved to {data_dir}.')
+
+pastis_matrix = fits.getdata(os.path.join(data_dir, 'matrix_numerical', 'pastis_matrix.fits'))
+
+# Define target contrast
+c_target_log = -11
+c_target = 10**(c_target_log)
+mu_map_harris = np.sqrt(((c_target) / (num_actuators)) / (np.diag(pastis_matrix)))
+np.savetxt(os.path.join(data_dir, 'mu_map_harris_%s.csv' % c_target), mu_map_harris, delimiter=',')
+
+# Temporal Analysis
+efield_coron_real = fits.getdata(os.path.join(data_dir, 'efield_coron_real.fits'))
+efield_coron_imag = fits.getdata(os.path.join(data_dir, 'efield_coron_imag.fits'))
+efield_obwfs_real = fits.getdata(os.path.join(data_dir, 'efield_obwfs_real.fits'))
+efield_obwfs_imag = fits.getdata(os.path.join(data_dir, 'efield_obwfs_imag.fits'))
+e0_coron = fits.getdata(os.path.join(data_dir, 'e0_coron.fits'))
+e0_obwfs = fits.getdata(os.path.join(data_dir, 'e0_wfs.fits'))
+

--- a/pastis/temporal_analysis/run_luvoir_analysis.py
+++ b/pastis/temporal_analysis/run_luvoir_analysis.py
@@ -52,9 +52,9 @@ def calculate_sensitivity_matrices(e0_coron, e0_obwfs, efield_coron_real,
     ref_coron[:, 0, 0] = ref_coron_real
     ref_coron[:, 0, 1] = ref_coron_imag
 
-    n_sub_pix = np.sqrt(total_pupil_pix) // subsample_factor
-    ref_wfs_real_sub = np.reshape(matrix_subsample(e0_obwfs[0], n_sub_pix, n_sub_pix), np.square(n_sub_pix))
-    ref_wfs_imag_sub = np.reshape(matrix_subsample(e0_obwfs[1], n_sub_pix, n_sub_pix), np.square(n_sub_pix))
+    n_sub_pix = int(np.sqrt(total_pupil_pix) // subsample_factor)
+    ref_wfs_real_sub = np.reshape(matrix_subsample(e0_obwfs[0], n_sub_pix, n_sub_pix), int(np.square(n_sub_pix)))
+    ref_wfs_imag_sub = np.reshape(matrix_subsample(e0_obwfs[1], n_sub_pix, n_sub_pix), int(np.square(n_sub_pix)))
     ref_wfs_sub = (ref_wfs_real_sub + 1j * ref_wfs_imag_sub)
 
     ref_obwfs_downsampled = np.zeros([int(np.square(n_sub_pix)), 1, 2])
@@ -72,12 +72,12 @@ def calculate_sensitivity_matrices(e0_coron, e0_obwfs, efield_coron_real,
         g_obwfs[:, 0, i] = np.reshape(efield_obwfs_real[i], total_pupil_pix) - ref_obwfs_real
         g_obwfs[:, 1, i] = np.reshape(efield_obwfs_real[i], total_pupil_pix) - ref_obwfs_imag
 
-    g_obwfs_downsampled = np.empty([int(np.square(n_sub_pix)), 2, num_all_modes])
+    g_obwfs_downsampled = np.zeros([int(np.square(n_sub_pix)), 2, num_all_modes])
     for i in range(num_all_modes):
         efields_per_mode_wfs_real_sub = np.reshape(matrix_subsample(efield_obwfs_real[i],
-                                                                    n_sub_pix, n_sub_pix), np.square(n_sub_pix))
+                                                                    n_sub_pix, n_sub_pix), int(np.square(n_sub_pix)))
         efields_per_mode_wfs_imag_sub = np.reshape(matrix_subsample(efield_obwfs_imag[i],
-                                                                    n_sub_pix, n_sub_pix), np.square(n_sub_pix) )
+                                                                    n_sub_pix, n_sub_pix), int(np.square(n_sub_pix)))
         g_obwfs_downsampled[:, 0, i] = efields_per_mode_wfs_real_sub - ref_wfs_real_sub
         g_obwfs_downsampled[:, 1, i] = efields_per_mode_wfs_imag_sub - ref_wfs_imag_sub
 
@@ -134,7 +134,7 @@ pastis_matrix = fits.getdata(os.path.join(data_dir, 'matrix_numerical', 'pastis_
 
 # Define target contrast
 c_target_log = -11
-c_target = 10**(c_target_log)
+c_target = 4*10**(c_target_log)
 mu_map_harris = np.sqrt(((c_target) / (num_actuators)) / (np.diag(pastis_matrix)))
 np.savetxt(os.path.join(data_dir, 'mu_map_harris_%s.csv' % c_target), mu_map_harris, delimiter=',')
 
@@ -153,8 +153,7 @@ sensitivity_matrices = calculate_sensitivity_matrices(ref_coron, ref_obwfs, efie
 g_coron = sensitivity_matrices['senitivity_image_plane']
 g_wfs = sensitivity_matrices['sensitvity_wfs_plane']
 e0_coron = sensitivity_matrices['ref_image_plane']
-e0_wfs = sensitivity_matrices['sensitvity_wfs_plane']
-
+e0_wfs = sensitivity_matrices['ref_wfs_plane']
 
 npup = int(np.sqrt(tel.pupil_grid.x.shape[0]))
 sptype = 'A0V'

--- a/pastis/temporal_analysis/run_luvoir_analysis.py
+++ b/pastis/temporal_analysis/run_luvoir_analysis.py
@@ -55,7 +55,8 @@ def calculate_sensitivity_matrices(e0_coron, e0_obwfs, efield_coron_real,
     n_sub_pix = int(np.sqrt(total_pupil_pix) // subsample_factor)
     ref_wfs_real_sub = np.reshape(matrix_subsample(e0_obwfs[0], n_sub_pix, n_sub_pix), int(np.square(n_sub_pix)))
     ref_wfs_imag_sub = np.reshape(matrix_subsample(e0_obwfs[1], n_sub_pix, n_sub_pix), int(np.square(n_sub_pix)))
-    ref_wfs_sub = (ref_wfs_real_sub + 1j * ref_wfs_imag_sub)
+    ref_wfs_sub = (ref_wfs_real_sub + 1j * ref_wfs_imag_sub) / subsample_factor
+    # subsample_factor**2 is multiplied here to preserve total intensity, same goes for g_obwfs_downsampled
 
     ref_obwfs_downsampled = np.zeros([int(np.square(n_sub_pix)), 1, 2])
     ref_obwfs_downsampled[:, 0, 0] = ref_wfs_sub.real
@@ -75,11 +76,13 @@ def calculate_sensitivity_matrices(e0_coron, e0_obwfs, efield_coron_real,
     g_obwfs_downsampled = np.zeros([int(np.square(n_sub_pix)), 2, num_all_modes])
     for i in range(num_all_modes):
         efields_per_mode_wfs_real_sub = np.reshape(matrix_subsample(efield_obwfs_real[i],
-                                                                    n_sub_pix, n_sub_pix), int(np.square(n_sub_pix)))
+                                                                    n_sub_pix, n_sub_pix),
+                                                   int(np.square(n_sub_pix))) / subsample_factor
         efields_per_mode_wfs_imag_sub = np.reshape(matrix_subsample(efield_obwfs_imag[i],
-                                                                    n_sub_pix, n_sub_pix), int(np.square(n_sub_pix)))
-        g_obwfs_downsampled[:, 0, i] = efields_per_mode_wfs_real_sub - ref_wfs_real_sub
-        g_obwfs_downsampled[:, 1, i] = efields_per_mode_wfs_imag_sub - ref_wfs_imag_sub
+                                                                    n_sub_pix, n_sub_pix),
+                                                   int(np.square(n_sub_pix))) / subsample_factor
+        g_obwfs_downsampled[:, 0, i] = efields_per_mode_wfs_real_sub - ref_wfs_sub.real
+        g_obwfs_downsampled[:, 1, i] = efields_per_mode_wfs_imag_sub - ref_wfs_sub.imag
 
     matrix = {"ref_image_plane": ref_coron,
               "ref_wfs_plane": ref_obwfs_downsampled,
@@ -87,6 +90,9 @@ def calculate_sensitivity_matrices(e0_coron, e0_obwfs, efield_coron_real,
               "sensitvity_wfs_plane": g_obwfs_downsampled}
 
     return matrix
+
+#def sort_tolerance_maps():
+
 
 
 # Create necessary directories if they don't exist yet
@@ -97,6 +103,7 @@ optics_input = os.path.join(util.find_repo_location(), CONFIG_PASTIS.get('LUVOIR
 coronagraph_design = CONFIG_PASTIS.get('LUVOIR', 'coronagraph_design')
 sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')
 tel = LuvoirA_APLC(optics_input, coronagraph_design, sampling)
+nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
 
 # Create harris deformable mirror
 pad_orientation = np.pi/2*np.ones(tel.nseg)
@@ -134,18 +141,19 @@ pastis_matrix = fits.getdata(os.path.join(data_dir, 'matrix_numerical', 'pastis_
 
 # Define target contrast
 c_target_log = -11
-c_target = 4*10**(c_target_log)
+c_target = 1*10**(c_target_log)
 mu_map_harris = np.sqrt(((c_target) / (num_actuators)) / (np.diag(pastis_matrix)))
 np.savetxt(os.path.join(data_dir, 'mu_map_harris_%s.csv' % c_target), mu_map_harris, delimiter=',')
 
 
 # Temporal Analysis
-efield_science_real = fits.getdata(os.path.join(data_dir, 'efield_coron_real.fits'))
-efield_science_imag = fits.getdata(os.path.join(data_dir, 'efield_coron_imag.fits'))
-efield_wfs_real = fits.getdata(os.path.join(data_dir, 'efield_obwfs_real.fits'))
-efield_wfs_imag = fits.getdata(os.path.join(data_dir, 'efield_obwfs_imag.fits'))
-ref_coron = fits.getdata(os.path.join(data_dir, 'e0_coron.fits'))
-ref_obwfs = fits.getdata(os.path.join(data_dir, 'e0_wfs.fits'))
+#data_dir = '/Users/asahoo/Desktop/data_repos/harris_data/2022-09-19T16-28-34_luvoir'
+efield_science_real = fits.getdata(os.path.join(data_dir,'matrix_numerical', 'efield_coron_real.fits'))
+efield_science_imag = fits.getdata(os.path.join(data_dir,'matrix_numerical','efield_coron_imag.fits'))
+efield_wfs_real = fits.getdata(os.path.join(data_dir,'matrix_numerical', 'efield_obwfs_real.fits'))
+efield_wfs_imag = fits.getdata(os.path.join(data_dir,'matrix_numerical','efield_obwfs_imag.fits'))
+ref_coron = fits.getdata(os.path.join(data_dir, 'ref_e0_coron.fits'))
+ref_obwfs = fits.getdata(os.path.join(data_dir, 'ref_e0_wfs.fits'))
 
 # Get the total pupil and imaging camera pixels
 sensitivity_matrices = calculate_sensitivity_matrices(ref_coron, ref_obwfs, efield_science_real, efield_science_imag,
@@ -193,7 +201,7 @@ for wavescale in range (1, 15, 2):
 
 delta_wf = []
 for wavescale in range(1, 15, 2):
-    wf = 1e3*np.sqrt(0.0001*wavescale**2*np.sqrt(np.mean(np.square(np.diag(Qharris)))))
+    wf = np.sqrt(np.mean(np.diag(0.0001*wavescale**2*Qharris)))*1e3
     delta_wf.append(wf)
 
 texp = np.logspace(TimeMinus, TimePlus, Ntimes)
@@ -202,13 +210,13 @@ contrast_floor = 4.237636070056418e-11
 result_wf_test = np.asarray(result_wf_test)
 plt.figure(figsize=(15, 10))
 plt.title('Target contrast = %s, Vmag= %s' % (c_target, Vmag), fontdict=font)
-plt.plot(texp, result_wf_test[0:20] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[0]))
-plt.plot(texp, result_wf_test[20:40] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[1]))
-plt.plot(texp, result_wf_test[40:60] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[2]))
-plt.plot(texp, result_wf_test[60:80] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[3]))
-plt.plot(texp, result_wf_test[80:100] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[4]))
-plt.plot(texp, result_wf_test[100:120] - contrast_floor, label=r'$\Delta_{wf}= %.2f\ pm$' % (delta_wf[5]))
-plt.plot(texp, result_wf_test[120:140] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[6]))
+plt.plot(texp, result_wf_test[0:20] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm/s$' % (delta_wf[0]))
+plt.plot(texp, result_wf_test[20:40] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm/s$' % (delta_wf[1]))
+plt.plot(texp, result_wf_test[40:60] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm/s$' % (delta_wf[2]))
+plt.plot(texp, result_wf_test[60:80] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm/s$' % (delta_wf[3]))
+plt.plot(texp, result_wf_test[80:100] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm/s$' % (delta_wf[4]))
+plt.plot(texp, result_wf_test[100:120] - contrast_floor, label=r'$\Delta_{wf}= %.2f\ pm/s$' % (delta_wf[5]))
+plt.plot(texp, result_wf_test[120:140] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm/s$' % (delta_wf[6]))
 plt.xlabel("$t_{WFS}$ in secs", fontsize=20)
 plt.ylabel("$\Delta$ contrast", fontsize=20)
 plt.yscale('log')
@@ -221,3 +229,114 @@ plt.tick_params(axis='both', which='major', length=10, width=2)
 plt.tick_params(axis='both', which='minor', length=6, width=2)
 plt.grid()
 plt.savefig(os.path.join(data_dir, 'cont_wf_%s.png' % c_target))
+
+# Sort to individual modes
+harris_coeffs_numaps = np.zeros([num_modes, num_actuators])
+for qq in range(num_modes):
+    harris_coeffs_tmp = np.zeros([num_actuators])
+    for kk in range(tel.nseg):
+        harris_coeffs_tmp[qq+(kk)*num_modes] = mu_map_harris[qq+(kk)*num_modes] # arranged per modal basis
+    harris_coeffs_numaps[qq] = harris_coeffs_tmp # arranged into 5 groups of 600 elements and in units of nm
+
+nu_maps = []
+for qq in range(num_modes):
+    harris_coeffs = harris_coeffs_numaps[qq] # in units of nm
+    tel.harris_sm.actuators = harris_coeffs*nm_aber/2 # in units of m
+    nu_maps.append(tel.harris_sm.surface) # in units of m, each nu_map is now of the order of 1e-9 m
+
+coeffs_table = np.zeros([num_modes, tel.nseg])
+for qq in range(num_modes):
+    for kk in range(tel.nseg):
+        coeffs_table[qq, kk] = mu_map_harris[qq + (kk) * num_modes]
+
+# Final Individual Tolerance allocation across 5 modes in units of pm
+opt_wavescale = 13 # This is wavescale value corresponding to lowest contrast
+Q_total = 1e3*np.sqrt(0.0001*opt_wavescale**2*np.sqrt(np.mean(np.square(mu_map_harris**2))))
+Q_1 = 1e3*np.sqrt(0.0001*opt_wavescale**2*np.sqrt(np.mean(np.square(coeffs_table[0]**2))))
+Q_2 = 1e3*np.sqrt(0.0001*opt_wavescale**2*np.sqrt(np.mean(np.square(coeffs_table[1]**2))))
+Q_3 = 1e3*np.sqrt(0.0001*opt_wavescale**2*np.sqrt(np.mean(np.square(coeffs_table[2]**2))))
+Q_4 = 1e3*np.sqrt(0.0001*opt_wavescale**2*np.sqrt(np.mean(np.square(coeffs_table[3]**2))))
+Q_5 = 1e3*np.sqrt(0.0001*opt_wavescale**2*np.sqrt(np.mean(np.square(coeffs_table[4]**2))))
+print(Q_1, Q_2, Q_3, Q_4, Q_5)
+print(Q_total, np.sqrt((Q_1**2 + Q_2**2 + Q_3**2 + Q_4**2 + Q_5**2)/5))
+
+
+# check temporal maps for individual modes
+q0 = np.diag(0.0001*opt_wavescale**2*Qharris)
+q1 = 0.0001*opt_wavescale**2*(coeffs_table[0]**2)
+q2 = 0.0001*opt_wavescale**2*(coeffs_table[1]**2)
+q3 = 0.0001*opt_wavescale**2*(coeffs_table[2]**2)
+q4 = 0.0001*opt_wavescale**2*(coeffs_table[3]**2)
+q5 = 0.0001*opt_wavescale**2*(coeffs_table[4]**2)
+
+tscale = 1000
+print(np.sqrt(np.mean(q0))*1e3*tscale, '\n', np.sqrt(np.mean(q1))*1e3*tscale, '\n', np.sqrt(np.mean(q2))*1e3*tscale, '\n',
+      np.sqrt(np.mean(q3))*1e3*tscale, '\n', np.sqrt(np.mean(q4))*1e3*tscale, '\n', np.sqrt(np.mean(q5))*1e3*tscale, '\n')
+
+Qharris = np.diag(np.asarray(mu_map_harris**2)) # 19.4/1e3
+Qharris0 = np.diag(np.asarray(harris_coeffs_numaps[0]**2))
+Qharris1 = np.diag(np.asarray(harris_coeffs_numaps[1]**2))
+Qharris2 = np.diag(np.asarray(harris_coeffs_numaps[2]**2))
+Qharris3 = np.diag(np.asarray(harris_coeffs_numaps[3]**2))
+Qharris4 = np.diag(np.asarray(harris_coeffs_numaps[4]**2))
+
+opt_tscale = 30
+c_contrast0 = req_closedloop_calc_batch(g_coron, g_wfs, e0_coron, e0_wfs, detector_noise,
+                                         detector_noise, opt_tscale, flux*Starfactor, 0.0001*opt_wavescale**2*Qharris,
+                                         niter, tel.dh_mask, norm)
+
+c_contrast1 = req_closedloop_calc_batch(g_coron, g_wfs, e0_coron, e0_wfs, detector_noise,
+                                         detector_noise, opt_tscale, flux*Starfactor, 0.0001*opt_wavescale**2*Qharris0,
+                                         niter, tel.dh_mask, norm)
+
+c_contrast2 = req_closedloop_calc_batch(g_coron, g_wfs, e0_coron, e0_wfs, detector_noise,
+                                         detector_noise, opt_tscale, flux*Starfactor, 0.0001*opt_wavescale**2*Qharris1,
+                                         niter, tel.dh_mask, norm)
+
+c_contrast3 = req_closedloop_calc_batch(g_coron, g_wfs, e0_coron, e0_wfs, detector_noise,
+                                         detector_noise, opt_tscale, flux*Starfactor, 0.0001*opt_wavescale**2*Qharris2,
+                                         niter, tel.dh_mask, norm)
+
+c_contrast4 = req_closedloop_calc_batch(g_coron, g_wfs, e0_coron, e0_wfs, detector_noise,
+                                         detector_noise, opt_tscale, flux*Starfactor, 0.0001*opt_wavescale**2*Qharris3,
+                                         niter, tel.dh_mask, norm)
+
+c_contrast5 = req_closedloop_calc_batch(g_coron, g_wfs, e0_coron, e0_wfs, detector_noise,
+                                         detector_noise, opt_tscale, flux*Starfactor, 0.0001*opt_wavescale**2*Qharris4,
+                                         niter, tel.dh_mask, norm)
+
+result_c0 = []
+c0 = c_contrast0['averaged_hist']
+n_tmp1 = len(c0)
+result_c0.append(c0[n_tmp1-1])
+print(result_c0[0]-contrast_floor)
+
+result_c1 = []
+c1 = c_contrast1['averaged_hist']
+n_tmp1 = len(c1)
+result_c1.append(c1[n_tmp1-1])
+print(result_c1[0]-contrast_floor)
+
+result_c2 = []
+c2 = c_contrast2['averaged_hist']
+n_tmp1 = len(c2)
+result_c2.append(c2[n_tmp1-1])
+print(result_c2[0]-contrast_floor)
+
+result_c3 = []
+c3 = c_contrast3['averaged_hist']
+n_tmp1 = len(c3)
+result_c3.append(c3[n_tmp1-1])
+print(result_c3[0]-contrast_floor)
+
+result_c4 = []
+c4 = c_contrast4['averaged_hist']
+n_tmp1 = len(c4)
+result_c4.append(c4[n_tmp1-1])
+print(result_c4[0]-contrast_floor)
+
+result_c5 = []
+c5 = c_contrast5['averaged_hist']
+n_tmp1 = len(c5)
+result_c5.append(c5[n_tmp1-1])
+print(result_c5[0]-contrast_floor)

--- a/pastis/temporal_analysis/run_luvoir_analysis.py
+++ b/pastis/temporal_analysis/run_luvoir_analysis.py
@@ -2,10 +2,15 @@ import os
 import hcipy
 from astropy.io import fits
 import numpy as np
+import time
+import exoscene.star
+import astropy.units as u
+import matplotlib.pyplot as plt
 from pastis.matrix_generation.matrix_from_efields import MatrixEfieldLuvoirA
 from pastis.config import CONFIG_PASTIS
 from pastis.simulators.luvoir_imaging import LuvoirA_APLC
 import pastis.util as util
+from pastis.temporal_analysis.close_loop_analysis import req_closedloop_calc_batch
 
 
 def matrix_subsample(matrix, n, m):
@@ -28,6 +33,7 @@ def matrix_subsample_fast(matrix, n, m):
     reshaped_array = matrix.reshape(new_shape)
     data_reduced = np.sum(reshaped_array, axis=(1, 3))
     return data_reduced
+
 
 # Create necessary directories if they don't exist yet
 data_dir = CONFIG_PASTIS.get('local', 'local_data_path')
@@ -79,7 +85,6 @@ mu_map_harris = np.sqrt(((c_target) / (num_actuators)) / (np.diag(pastis_matrix)
 np.savetxt(os.path.join(data_dir, 'mu_map_harris_%s.csv' % c_target), mu_map_harris, delimiter=',')
 
 
-
 # Temporal Analysis
 efield_coron_real = fits.getdata(os.path.join(data_dir, 'efield_coron_real.fits'))
 efield_coron_imag = fits.getdata(os.path.join(data_dir, 'efield_coron_imag.fits'))
@@ -123,15 +128,78 @@ for i in range(num_all_modes):
     G_OBWFS[:, 0, i] = np.reshape(efield_obwfs_real[i], total_pupil_pix) - e0_obwfs_real
     G_OBWFS[:, 1, i] = np.reshape(efield_obwfs_real[i], total_pupil_pix) - e0_obwfs_imag
 
-G_OBWFS = np.empty([2, num_all_modes, total_pupil_pix])
-for i in range(num_all_modes):
-    G_OBWFS[0, i, :] = np.reshape(efield_obwfs_real[i], total_pupil_pix) - e0_obwfs_real
-    G_OBWFS[1, i, :] = np.reshape(efield_obwfs_real[i], total_pupil_pix) - e0_obwfs_imag
-G_OBWFS = np.transpose(G_OBWFS, axes=(2, 0, 1))
-
 G_OBWFS_downsampled = np.empty([int(N_pup_z), 2, num_all_modes])
 for i in range(num_all_modes):
     efields_per_mode_wfs_real_sub = np.reshape(matrix_subsample(efield_obwfs_real[i], 125, 125), int(N_pup_z))
     efields_per_mode_wfs_imag_sub = np.reshape(matrix_subsample(efield_obwfs_imag[i], 125, 125), int(N_pup_z))
     G_OBWFS_downsampled[:, 0, i] = efields_per_mode_wfs_real_sub - e0_wfs_sub_real
     G_OBWFS_downsampled[:, 1, i] = efields_per_mode_wfs_imag_sub - e0_wfs_sub_imag
+
+
+npup = int(np.sqrt(tel.pupil_grid.x.shape[0]))
+sptype = 'A0V'
+Vmag = 5.0
+minlam = 500 * u.nanometer
+maxlam = 600 * u.nanometer
+dark_current = 0
+CIC = 0
+star_flux = exoscene.star.bpgs_spectype_to_photonrate(spectype=sptype, Vmag=Vmag, minlam=minlam.value, maxlam=maxlam.value)
+Nph = star_flux.value*15**2*np.sum(tel.apodizer**2) / npup**2
+flux = Nph
+Qharris = np.diag(np.asarray(mu_map_harris**2))
+detector_noise = 0.0
+niter = 10
+TimeMinus = -2
+TimePlus = 5.5
+Ntimes = 20
+Nwavescale = 8
+Nflux = 3
+
+res = np.zeros([Ntimes, Nwavescale, Nflux, 1])
+result_wf_test =[]
+norm = 0.010242195657579547
+for wavescale in range (1, 15, 2):
+    print('recurssive close loop batch estimation and wavescale %f'% wavescale)
+    niter = 10
+    timer1 = time.time()
+    StarMag = 0.0
+    for tscale in np.logspace(TimeMinus, TimePlus, Ntimes):
+        Starfactor = 10**(-StarMag/2.5)
+        print(tscale)
+        tmp0 = req_closedloop_calc_batch(G_coron, G_OBWFS_downsampled, E0_coron, E0_OBWFS_downsampled, detector_noise,
+                                         detector_noise, tscale, flux*Starfactor, 0.0001*wavescale**2*Qharris,
+                                         niter, tel.dh_mask, norm)
+        tmp1 = tmp0['averaged_hist']
+        n_tmp1 = len(tmp1)
+        result_wf_test.append(tmp1[n_tmp1-1])
+
+delta_wf = []
+for wavescale in range(1, 15, 2):
+    wf = 1e3*np.sqrt(0.0001*wavescale**2*np.sqrt(np.mean(np.square(np.diag(Qharris)))))
+    delta_wf.append(wf)
+
+texp = np.logspace(TimeMinus, TimePlus, Ntimes)
+font = {'family': 'serif', 'color': 'black', 'weight': 'normal', 'size': 20}
+contrast_floor = 4.237636070056418e-11
+result_wf_test = np.asarray(result_wf_test)
+plt.figure(figsize=(15, 10))
+plt.title('Target contrast = %s, Vmag= %s' % (c_target, Vmag), fontdict=font)
+plt.plot(texp, result_wf_test[0:20] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[0]))
+plt.plot(texp, result_wf_test[20:40] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[1]))
+plt.plot(texp, result_wf_test[40:60] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[2]))
+plt.plot(texp, result_wf_test[60:80] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[3]))
+plt.plot(texp, result_wf_test[80:100] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[4]))
+plt.plot(texp, result_wf_test[100:120] - contrast_floor, label=r'$\Delta_{wf}= %.2f\ pm$' % (delta_wf[5]))
+plt.plot(texp, result_wf_test[120:140] - contrast_floor, label=r'$\Delta_{wf}= % .2f\ pm$' % (delta_wf[6]))
+plt.xlabel("$t_{WFS}$ in secs", fontsize=20)
+plt.ylabel("$\Delta$ contrast", fontsize=20)
+plt.yscale('log')
+plt.xscale('log')
+plt.legend(loc='upper center', fontsize=20)
+plt.tick_params(top=True, bottom=True, left=True,
+                    right=True, labelleft=True, labelbottom=True,
+                    labelsize=20)
+plt.tick_params(axis='both', which='major', length=10, width=2)
+plt.tick_params(axis='both', which='minor', length=6, width=2)
+plt.grid()
+plt.savefig(os.path.join(data_dir, 'cont_wf_%s.png' % c_target))

--- a/pastis/temporal_analysis/run_scda_analysis.py
+++ b/pastis/temporal_analysis/run_scda_analysis.py
@@ -1,0 +1,26 @@
+import numpy as np
+from pastis.config import CONFIG_PASTIS
+from pastis.matrix_generation.matrix_from_efields import MatrixEfieldHex
+
+if __name__ == '__main__':
+
+    # Set the number of rings
+    num_rings = 1
+    ini_path = CONFIG_PASTIS.get('local', 'local_data_path')
+
+    # Needed for Harris mirror
+    DM = 'harris_seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
+    fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
+    pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
+    DM_SPEC = (fpath, pad_orientations, True, False, False)
+
+    # First generate a PASTIS matrix
+    run_matrix = MatrixEfieldHex(which_dm=DM, dm_spec=DM_SPEC, num_rings=num_rings,
+                                 calc_science=True, calc_wfs=True,
+                                 initial_path=ini_path,
+                                 saveefields=True, saveopds=True,
+                                 norm_one_photon=True)
+
+    run_matrix.calc()
+    data_dir = run_matrix.overall_dir
+    print(f'Matrix and Efields saved to {data_dir}.')

--- a/pastis/temporal_analysis/run_scda_analysis.py
+++ b/pastis/temporal_analysis/run_scda_analysis.py
@@ -108,5 +108,5 @@ if __name__ == '__main__':
     np.savetxt(os.path.join(data_dir, 'mus_%s_%d.csv' % (c_target, num_rings)), mus_1d, delimiter=',')
 
     # plot_thermal_mus(mus_1d, num_modes, tel.nseg, c_target, data_dir, save=True)
-    plot_zernike_mus(mus_1d, num_modes, tel.nseg, c_target, data_dir, save=True)
+    # plot_zernike_mus(mus_1d, num_modes, tel.nseg, c_target, data_dir, save=True)
 

--- a/pastis/temporal_analysis/run_scda_analysis.py
+++ b/pastis/temporal_analysis/run_scda_analysis.py
@@ -32,6 +32,29 @@ def plot_thermal_mus(mus, nmodes, nsegments, c0, out_dir, save=False):
         plt.savefig(os.path.join(out_dir, 'mus_1d_multi_modes_%s.png' % c0))
 
 
+def plot_zernike_mus(mus, nmodes, nsegments, c0, out_dir, save=False):
+    mid_zernike_table = np.zeros([nmodes, nsegments])
+    for qq in range(nmodes):
+        for kk in range(nsegments):
+            mid_zernike_table[qq, kk] = mus[qq + (kk) * nmodes]
+
+    plt.figure(figsize=(10, 10))
+    plt.title("Modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=20)
+    plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
+    plt.xlabel("Segment Number", fontsize=20)
+    plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
+    plt.plot(mid_zernike_table[0]*1e3, label="Piston")
+    plt.plot(mid_zernike_table[1]*1e3, label="Tip")
+    plt.plot(mid_zernike_table[2]*1e3, label="Tilt")
+    plt.plot(mid_zernike_table[3]*1e3, label="Defocus")
+    plt.plot(mid_zernike_table[4]*1e3, label="Astigmatism45")
+    plt.grid()
+    plt.legend(fontsize=15)
+    plt.tight_layout()
+    if save:
+        plt.savefig(os.path.join(out_dir, 'mus_1d_mid_modes_%s.png' % c0))
+
+
 if __name__ == '__main__':
 
     # Instantiate the HeXRingAPLC telescope
@@ -42,22 +65,29 @@ if __name__ == '__main__':
     sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')
     tel = HexRingAPLC(optics_dir, num_rings, sampling, robustness_px=robust)
 
-    # Needed for Harris mirror
-    DM = 'harris_seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
-    pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
-    DM_SPEC = (fpath, pad_orientations, True, False, False)
+    # Define the mirror
 
-    # Create harris deformable mirror
-    pad_orientation = np.pi / 2 * np.ones(tel.nseg)
-    filepath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')
-    tel.create_segmented_harris_mirror(filepath, pad_orientation, thermal=True, mechanical=False, other=False)
+    # If harris deformable mirror, uncomment following lines
+    # ---------------------------------------------------------------------------------------------------------------
+    # DM = 'harris_seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
+    # fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
+    # pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
+    # DM_SPEC = (fpath, pad_orientations, True, False, False)
+    # pad_orientation = np.pi / 2 * np.ones(tel.nseg)
+    # filepath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')
+    # tel.create_segmented_harris_mirror(filepath, pad_orientation, thermal=True, mechanical=False, other=False)
+    # num_actuators = tel.harris_sm.num_actuators
+    # num_modes = 5
 
-    # get number of poking modes
-    num_actuators = tel.harris_sm.num_actuators
-    num_modes = 5
+    # If Segmented Zernike Mirror, uncomment following lines
+    # --------------------------------------------------------------------------------------------------------------
+    DM = 'seg_mirror'
+    DM_SPEC = 5
+    tel.create_segmented_mirror(DM_SPEC)
+    num_modes = DM_SPEC
 
-    # First generate a PASTIS matrix
+    # --------------------------------------------------------------------------------------------------------------
+    # Generate a PASTIS matrix
     run_matrix = MatrixEfieldHex(which_dm=DM, dm_spec=DM_SPEC, num_rings=num_rings,
                                  calc_science=True, calc_wfs=True,
                                  initial_path=ini_path,
@@ -68,6 +98,7 @@ if __name__ == '__main__':
     data_dir = run_matrix.overall_dir
     print(f'Matrix and Efields saved to {data_dir}.')
 
+    # --------------------------------------------------------------------------------------------------------------
     pastis_matrix = fits.getdata(os.path.join(data_dir, 'matrix_numerical', 'pastis_matrix.fits'))
 
     # Calculate the static tolerances
@@ -76,5 +107,6 @@ if __name__ == '__main__':
     mus_1d = calculate_segment_constraints(pastis_matrix, c_target=1e-11, coronagraph_floor=0)
     np.savetxt(os.path.join(data_dir, 'mus_%s_%d.csv' % (c_target, num_rings)), mus_1d, delimiter=',')
 
-    plot_thermal_mus(mus_1d, num_modes, tel.nseg, c_target, data_dir, save=True)
+    # plot_thermal_mus(mus_1d, num_modes, tel.nseg, c_target, data_dir, save=True)
+    plot_zernike_mus(mus_1d, num_modes, tel.nseg, c_target, data_dir, save=True)
 

--- a/pastis/temporal_analysis/run_scda_analysis.py
+++ b/pastis/temporal_analysis/run_scda_analysis.py
@@ -1,18 +1,61 @@
+import os
 import numpy as np
+from astropy.io import fits
+import pastis.util as util
+import matplotlib.pyplot as plt
 from pastis.config import CONFIG_PASTIS
+from pastis.simulators.scda_telescopes import HexRingAPLC
+from pastis.pastis_analysis import calculate_segment_constraints
 from pastis.matrix_generation.matrix_from_efields import MatrixEfieldHex
+
+
+def plot_thermal_mus(mus, nmodes, nsegments, c0, out_dir, save=False):
+    harris_coeffs_table = np.zeros([nmodes, nsegments])
+    for qq in range(nmodes):
+        for kk in range(nsegments):
+            harris_coeffs_table[qq, kk] = mus[qq + (kk) * nmodes]
+
+    plt.figure(figsize=(10, 10))
+    plt.title("Modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=20)
+    plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
+    plt.xlabel("Segment Number", fontsize=20)
+    plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
+    plt.plot(harris_coeffs_table[0]*1e3, label="Faceplates Silvered")
+    plt.plot(harris_coeffs_table[1]*1e3, label="Bulk")
+    plt.plot(harris_coeffs_table[2]*1e3, label="Gradiant Radial")
+    plt.plot(harris_coeffs_table[3]*1e3, label="Gradiant X lateral")
+    plt.plot(harris_coeffs_table[4]*1e3, label="Gradient Z axial")
+    plt.grid()
+    plt.legend(fontsize=15)
+    plt.tight_layout()
+    if save:
+        plt.savefig(os.path.join(out_dir, 'mus_1d_multi_modes_%s.png' % c0))
+
 
 if __name__ == '__main__':
 
-    # Set the number of rings
-    num_rings = 1
+    # Instantiate the HeXRingAPLC telescope
     ini_path = CONFIG_PASTIS.get('local', 'local_data_path')
+    optics_dir = os.path.join(util.find_repo_location(), 'data', 'SCDA')
+    num_rings = 5
+    robust = 4
+    sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')
+    tel = HexRingAPLC(optics_dir, num_rings, sampling, robustness_px=robust)
 
     # Needed for Harris mirror
     DM = 'harris_seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
     fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
     pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
     DM_SPEC = (fpath, pad_orientations, True, False, False)
+
+    # Create harris deformable mirror
+    pad_orientation = np.pi / 2 * np.ones(tel.nseg)
+    filepath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')
+    tel.create_segmented_harris_mirror(filepath, pad_orientation, thermal=True, mechanical=False, other=False)
+
+    # get number of poking modes
+    num_actuators = tel.harris_sm.num_actuators
+    num_modes = 5
 
     # First generate a PASTIS matrix
     run_matrix = MatrixEfieldHex(which_dm=DM, dm_spec=DM_SPEC, num_rings=num_rings,
@@ -24,3 +67,14 @@ if __name__ == '__main__':
     run_matrix.calc()
     data_dir = run_matrix.overall_dir
     print(f'Matrix and Efields saved to {data_dir}.')
+
+    pastis_matrix = fits.getdata(os.path.join(data_dir, 'matrix_numerical', 'pastis_matrix.fits'))
+
+    # Calculate the static tolerances
+    c_target_log = -11
+    c_target = 10 ** (c_target_log)
+    mus_1d = calculate_segment_constraints(pastis_matrix, c_target=1e-11, coronagraph_floor=0)
+    np.savetxt(os.path.join(data_dir, 'mus_%s_%d.csv' % (c_target, num_rings)), mus_1d, delimiter=',')
+
+    plot_thermal_mus(mus_1d, num_modes, tel.nseg, c_target, data_dir, save=True)
+


### PR DESCRIPTION
This PR needs to be merged after PR #130. 
This adds the following features to the existing repo.

- [x] Create PASTIS matrix for scda telescopes with segment level multimode mode aberration.
- [ ] Generate static tolerance plots and maps
- [ ] mcmc simulation to validate the static tolerances
- [ ] call the focal plane and wfs plane efields generated while pastis matrix, and reshape them to feed them into temporal analysis funcs
- [ ] generate contrast vs t_wfs curves
- [ ] and use the optimal t_wfs found from the curve to fill error budget table.
- [ ] validate the temporal tolerance quantites using close loop function

Currently, most of this step is calculated only in a single big scrips. Therefore, breaking this PR into several mini PRs. 