### PR TITLE
Write out files to temporary directory.

### DIFF
--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -89,11 +89,11 @@ def test_pastis_forward_model():
         assert np.isclose(contrasts_matrix, contrasts_e2e, rtol=rel_tol, atol=abs_tol), f'Calculated contrasts from PASTIS and E2E are not the same for rms={rms} and rtol={rel_tol}.'
 
 
-def test_luvoir_intensity_matrix_regression():
+def test_luvoir_intensity_matrix_regression(tmpdir):
     """ Check multiprocessed matrix calculation against previously calculated matrix """
 
     # Calculate new LUVOIR small PASTIS matrix
-    new_matrix_calc = matrix_calc.MatrixIntensityLuvoirA(design='small', savepsfs=False, saveopds=False)
+    new_matrix_calc = matrix_calc.MatrixIntensityLuvoirA(design='small', savepsfs=False, saveopds=False, initial_path=tmpdir)
     new_matrix_calc.calc()
     new_matrix = new_matrix_calc.matrix_pastis
 


### PR DESCRIPTION
This PR changes the output path of the pytests from a local directory to a temporary directory. This avoids clogging up the current working directory when running the pytests locally.

I'm not sure if writing to the CWD is intentional or not, since it might help with diagnosis in some cases. Feel free to close this PR if this is the case.

Tests will fail until #137 is merged, so I'm keeping this in draft until that happened and this is rebased.