### PR TITLE
Add multimode static tolerance plot.

### DIFF
--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -56,5 +56,4 @@ if __name__ == '__main__':
     ppl.plot_zernike_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
     # ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
     tel = run_matrix.simulator
-    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, tel.sm.num_actuators,
-                                       c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     # If Segmented Zernike Mirror, uncomment the following two lines
     DM = 'seg_mirror' # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    DM_SPEC = 10
+    DM_SPEC = 3
 
     NUM_RINGS = 1
 
@@ -48,12 +48,19 @@ if __name__ == '__main__':
     # Calculate the static tolerances
     c_target = 6.3*1e-11
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
-    np.savetxt(os.path.join(dir_run, 'mus_%.2e_%d.csv' % (c_target, NUM_RINGS)), mus, delimiter=',')
+    np.savetxt(os.path.join(dir_run, f'mus_{c_target:.2e}_{NUM_RINGS:d}.csv'), mus, delimiter=',')
 
-    num_modes = 10 # for harris thermal map or number of localized zernike modes = "DM_SPEC"
+    num_modes = DM_SPEC   # for harris thermal map or number of localized zernike modes = "DM_SPEC"
     nseg = run_matrix.simulator.nseg
 
-    ppl.plot_zernike_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
+    coeffs_table = util.sort_1d_mus_per_segment(mus, num_modes, nseg)
+    mu_list = []
+    label_list = []
+    for i in range(coeffs_table.shape[0]):
+        mu_list.append(coeffs_table[i])
+        label_list.append(f'Zernike mode {i}')
+
+    ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     # ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
     tel = run_matrix.simulator
     ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -23,9 +23,10 @@ if __name__ == '__main__':
     # pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
     # DM_SPEC = (fpath, pad_orientations, True, False, False)
 
-    # If Segmented Zernike Mirror, uncomment the following lines
+    # If Segmented Zernike Mirror, uncomment the following two lines
     DM = 'seg_mirror' # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    DM_SPEC = 5
+    DM_SPEC = 10
+
     NUM_RINGS = 1
 
     # First generate a couple of matrices
@@ -47,13 +48,13 @@ if __name__ == '__main__':
     # Calculate the static tolerances
     c_target = 6.3*1e-11
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
-    np.savetxt(os.path.join(dir_run, 'mus_%s_%d.csv' % (c_target, NUM_RINGS)), mus, delimiter=',')
+    np.savetxt(os.path.join(dir_run, 'mus_%.2e_%d.csv' % (c_target, NUM_RINGS)), mus, delimiter=',')
 
-    num_modes = 5 # for harris thermal map or number of localized zernike modes
+    num_modes = 10 # for harris thermal map or number of localized zernike modes = "DM_SPEC"
     nseg = run_matrix.simulator.nseg
 
-    # plot
-    ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
+    ppl.plot_zernike_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
+    # ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
     tel = run_matrix.simulator
     ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, tel.sm.num_actuators,
-                                       c_target, dir_run, mirror='sm', save=True)
+                                       c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -67,4 +67,4 @@ if __name__ == '__main__':
 
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
-    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    ppl.plot_multimode_surface_maps(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -1,22 +1,47 @@
+import os
 import numpy as np
+from astropy.io import fits
 from pastis.config import CONFIG_PASTIS
+import pastis.util as util
 from pastis.matrix_generation.matrix_from_efields import MatrixEfieldHex
-
+from pastis.simulators.scda_telescopes import HexRingAPLC
+from pastis.pastis_analysis import  calculate_segment_constraints
+import pastis.plotting as ppl
 
 if __name__ == '__main__':
 
-    NUM_RINGS = 1
-    DM = 'seg_mirror'   # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
+    # Instantiate the LUVEx telescope
+    NUM_RINGS = 2
+    optics_dir = os.path.join(util.find_repo_location(), 'data', 'SCDA')
+    sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')
+    robust = 4
+    tel = HexRingAPLC(optics_dir, NUM_RINGS, sampling, robustness_px=robust)
 
-    # Needed for Harris mirror
-    fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
-    #pad_orientations = np.pi / 2 * np.ones(120)    #TODO: replace 120 with actual number of segments
-
-    DM_SPEC = 3
     # DM_SPEC = tuple or int, specification for the used DM -
-    #    for seg_mirror: int, number of local Zernike modes on each segment
-    #    for harris_seg_mirror: tuple (string, array, bool, bool, bool), absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets (thermal, mechanical, other)
-    #    for zernike_mirror: int, number of global Zernikes
+    # for seg_mirror: int, number of local Zernike modes on each segment
+    # for harris_seg_mirror: tuple (string, array, bool, bool, bool),
+    # absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets (thermal, mechanical, other)
+    # for zernike_mirror: int, number of global Zernikes
+
+    # If Harris deformable mirror, uncomment the following lines
+    # --------------------------------------------------------------------------------------------#
+    # DM = 'harris_seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
+    # fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
+    # pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
+    # DM_SPEC = (fpath, pad_orientations, True, False, False)
+    # pad_orientation = np.pi / 2 * np.ones(tel.nseg)
+    # filepath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')
+    # tel.create_segmented_harris_mirror(filepath, pad_orientation, thermal=True, mechanical=False, other=False)
+    # num_actuators = tel.harris_sm.num_actuators
+    # num_modes = 5
+
+    # If Segmented Zernike Mirror, uncomment the following lines
+    # --------------------------------------------------------------------------------------------#
+    # DM = 'seg_mirror' # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
+    # DM_SPEC = 5
+    # tel.create_segmented_mirror(DM_SPEC)
+    # num_modes = DM_SPEC
+    # num_actuators = tel.sm.num_actuators
 
     # First generate a couple of matrices
     run_matrix = MatrixEfieldHex(which_dm=DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
@@ -24,3 +49,14 @@ if __name__ == '__main__':
     run_matrix.calc()
     dir_run = run_matrix.overall_dir
     print(f'All saved to {dir_run}.')
+
+    # get the automatically saved pastis_matrix
+    pastis_matrix = fits.getdata(os.path.join(dir_run, 'matrix_numerical', 'pastis_matrix.fits'))
+
+    # Calculate the static tolerances
+    c_target = 5.3*1e-11
+    mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=0)
+    np.savetxt(os.path.join(dir_run, 'mus_%s_%d.csv' % (c_target, NUM_RINGS)), mus, delimiter=',')
+
+    ppl.plot_thermal_mus(mus, num_modes, tel.nseg, c_target, dir_run, save=True)
+    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, dir_run, save=True)

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
         NUM_MODES = 5  # TODO: works only for thermal modes currently
 
     # If using Segmented Zernike Mirror
-    if WHICH_DM == 'seg_mirror':
+    if WHICH_DM in ['seg_mirror', 'zernike_mirror']:
         DM_SPEC = 3
         NUM_MODES = DM_SPEC
 

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -25,10 +25,12 @@ if __name__ == '__main__':
         fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
         pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
         DM_SPEC = (fpath, pad_orientations, True, False, False)
+        NUM_MODES = 5  # TODO: works only for thermal modes currently
 
     # If using Segmented Zernike Mirror
     if WHICH_DM == 'seg_mirror':
         DM_SPEC = 3
+        NUM_MODES = DM_SPEC
 
     # First generate a couple of matrices
     run_matrix = MatrixEfieldHex(which_dm=WHICH_DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
@@ -51,10 +53,8 @@ if __name__ == '__main__':
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
     np.savetxt(os.path.join(dir_run, f'mus_{c_target:.2e}_{NUM_RINGS:d}.csv'), mus, delimiter=',')
 
-    num_modes = 5   # for Harris thermal map or number of localized zernike modes = "DM_SPEC"
     nseg = run_matrix.simulator.nseg
-
-    coeffs_table = util.sort_1d_mus_per_segment(mus, num_modes, nseg)
+    coeffs_table = util.sort_1d_mus_per_segment(mus, NUM_MODES, nseg)
     mu_list = []
     label_list = []
     for i in range(coeffs_table.shape[0]):
@@ -67,4 +67,5 @@ if __name__ == '__main__':
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
     os.makedirs(os.path.join(dir_run, 'mu_maps'), exist_ok=True)
-    ppl.plot_multimode_surface_maps(tel, mus, num_modes, mirror=WHICH_DM, cmin=-5, cmax=5, data_dir=dir_run, fname='stat_mu_maps')
+    ppl.plot_multimode_surface_maps(tel, mus, NUM_MODES, mirror=WHICH_DM, cmin=-5, cmax=5,
+                                    data_dir=dir_run, fname='stat_mu_maps')

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -66,4 +66,5 @@ if __name__ == '__main__':
 
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
-    ppl.plot_multimode_surface_maps(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    os.makedirs(os.path.join(dir_run, 'mu_maps'), exist_ok=True)
+    ppl.plot_multimode_surface_maps(tel, mus, num_modes, mirror=WHICH_DM, cmin=-5, cmax=5, data_dir=dir_run, fname='stat_mu_maps')

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -11,26 +11,28 @@ from pastis.pastis_analysis import  calculate_segment_constraints
 import pastis.plotting as ppl
 
 if __name__ == '__main__':
+    
+    NUM_RINGS = 1
+    WHICH_DM = 'harris_seg_mirror'   # 'harris_seg_mirror' or 'seg_mirror', or (global) 'zernike_mirror'
+    
     # DM_SPEC = tuple or int, specification for the used DM -
     # for seg_mirror: int, number of local Zernike modes on each segment
     # for harris_seg_mirror: tuple (string, array, bool, bool, bool),
     # absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets (thermal, mechanical, other)
     # for zernike_mirror: int, number of global Zernikes
 
-    # If Harris deformable mirror, uncomment the following lines
-    # DM = 'harris_seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    # fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
-    # pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
-    # DM_SPEC = (fpath, pad_orientations, True, False, False)
+    # If using Harris deformable mirror
+    if WHICH_DM == 'harris_seg_mirror':
+        fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
+        pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
+        DM_SPEC = (fpath, pad_orientations, True, False, False)
 
-    # If Segmented Zernike Mirror, uncomment the following two lines
-    DM = 'seg_mirror' # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    DM_SPEC = 3
-
-    NUM_RINGS = 1
+    # If using Segmented Zernike Mirror
+    if WHICH_DM == 'seg_mirror':
+        DM_SPEC = 3
 
     # First generate a couple of matrices
-    run_matrix = MatrixEfieldHex(which_dm=DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
+    run_matrix = MatrixEfieldHex(which_dm=WHICH_DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
                                  calc_science=True, calc_wfs=True,
                                  initial_path=CONFIG_PASTIS.get('local', 'local_data_path'), norm_one_photon=True)
     run_matrix.calc()
@@ -50,7 +52,7 @@ if __name__ == '__main__':
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
     np.savetxt(os.path.join(dir_run, f'mus_{c_target:.2e}_{NUM_RINGS:d}.csv'), mus, delimiter=',')
 
-    num_modes = DM_SPEC   # for harris thermal map or number of localized zernike modes = "DM_SPEC"
+    num_modes = 5   # for Harris thermal map or number of localized zernike modes = "DM_SPEC"
     nseg = run_matrix.simulator.nseg
 
     coeffs_table = util.sort_1d_mus_per_segment(mus, num_modes, nseg)
@@ -58,9 +60,11 @@ if __name__ == '__main__':
     label_list = []
     for i in range(coeffs_table.shape[0]):
         mu_list.append(coeffs_table[i])
-        label_list.append(f'Zernike mode {i}')
+        if WHICH_DM == 'seg_mirror':
+            label_list.append(f'Zernike mode {i}')
+    if WHICH_DM == 'harris_seg_mirror':
+        label_list = ['Faceplates Silvered', 'Bulk', 'Gradient Radial', 'Gradient X lateral', 'Gradient Z axial']
 
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
-    # ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
     tel = run_matrix.simulator
     ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -11,7 +11,7 @@ import pastis.plotting as ppl
 if __name__ == '__main__':
 
     # Instantiate the LUVEx telescope
-    NUM_RINGS = 2
+    NUM_RINGS = 1
     optics_dir = os.path.join(util.find_repo_location(), 'data', 'SCDA')
     sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')
     robust = 4
@@ -47,7 +47,8 @@ if __name__ == '__main__':
 
     # First generate a couple of matrices
     run_matrix = MatrixEfieldHex(which_dm=DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
-                                 initial_path=CONFIG_PASTIS.get('local', 'local_data_path'))
+                                 calc_science=True, calc_wfs=True,
+                                 initial_path=CONFIG_PASTIS.get('local', 'local_data_path'), norm_one_photon=True)
     run_matrix.calc()
     dir_run = run_matrix.overall_dir
     print(f'All saved to {dir_run}.')

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -1,14 +1,13 @@
 import os
-import numpy as np
 from astropy.io import fits
+import numpy as np
+
 from pastis.config import CONFIG_PASTIS
 import pastis.util as util
 from pastis.matrix_generation.matrix_from_efields import MatrixEfieldHex
-from pastis.simulators.scda_telescopes import HexRingAPLC
-import hcipy
-import matplotlib.pyplot as plt
-from pastis.pastis_analysis import  calculate_segment_constraints
+from pastis.pastis_analysis import calculate_segment_constraints
 import pastis.plotting as ppl
+
 
 if __name__ == '__main__':
     

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -1,12 +1,13 @@
 import os
 from astropy.io import fits
 import numpy as np
+
 from pastis.config import CONFIG_PASTIS
 import pastis.util as util
 from pastis.matrix_generation.matrix_from_efields import MatrixEfieldLuvoirA
-from pastis.pastis_analysis import  calculate_segment_constraints
-from pastis.simulators.luvoir_imaging import LuvoirA_APLC
+from pastis.pastis_analysis import calculate_segment_constraints
 import pastis.plotting as ppl
+
 
 if __name__ == '__main__':
 

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -55,4 +55,4 @@ if __name__ == '__main__':
 
     tel = run_matrix.simulator
     ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, tel.sm.num_actuators,
-                                       c_target, dir_run, mirror='sm', save=False)
+                                       c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -54,5 +54,4 @@ if __name__ == '__main__':
     ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, out_dir=dir_run, save=True)
 
     tel = run_matrix.simulator
-    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, tel.sm.num_actuators,
-                                       c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -9,25 +9,29 @@ from pastis.simulators.luvoir_imaging import LuvoirA_APLC
 import pastis.plotting as ppl
 
 if __name__ == '__main__':
+
+    NUM_RINGS = 1
+    WHICH_DM = 'harris_seg_mirror'   # 'harris_seg_mirror' or 'seg_mirror', or (global) 'zernike_mirror'
+
     # DM_SPEC = tuple or int, specification for the used DM -
     # for seg_mirror: int, number of local Zernike modes on each segment
     # for harris_seg_mirror: tuple (string, array, bool, bool, bool),
     # absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets (thermal, mechanical, other)
     # for zernike_mirror: int, number of global Zernikes
 
-    # If Harris deformable mirror, uncomment the following lines
-    # DM = 'harris_seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    # fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
-    # pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
-    # DM_SPEC = (fpath, pad_orientations, True, False, False)
+    # If using Harris deformable mirror
+    if WHICH_DM == 'harris_seg_mirror':
+        fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
+        pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
+        DM_SPEC = (fpath, pad_orientations, True, False, False)
 
-    # If Segmented Zernike Mirror, uncomment the following lines
-    DM = 'seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    DM_SPEC = 5
+    # If using Segmented Zernike Mirror
+    if WHICH_DM == 'seg_mirror':
+        DM_SPEC = 3
 
     APLC_DESIGN = 'small'
     # First generate a couple of matrices
-    run_matrix = MatrixEfieldLuvoirA(which_dm=DM, dm_spec=DM_SPEC, design=APLC_DESIGN,
+    run_matrix = MatrixEfieldLuvoirA(which_dm=WHICH_DM, dm_spec=DM_SPEC, design=APLC_DESIGN,
                                      calc_science=True, calc_wfs=True,
                                      initial_path=CONFIG_PASTIS.get('local', 'local_data_path'),
                                      norm_one_photon=True)
@@ -35,7 +39,7 @@ if __name__ == '__main__':
     dir_run = run_matrix.overall_dir
     print(f'All saved to {dir_run}.')
 
-    # Calculate and save per segment static tolerance
+    # get the automatically saved pastis_matrix
     pastis_matrix = fits.getdata(os.path.join(dir_run, 'matrix_numerical', 'pastis_matrix.fits'))
 
     # get the unaberrated coro_psf after the matrix run
@@ -43,15 +47,24 @@ if __name__ == '__main__':
     dh_mask = np.array(run_matrix.simulator.dh_mask.shaped)
     contrast_floor = util.dh_mean(e0_psf, dh_mask)
 
-    # set the target contrast
+    # Calculate the static tolerances
     c_target = 5.3*1e-11
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
-    np.savetxt(os.path.join(dir_run, 'mu_map_%s.csv' % c_target), mus, delimiter=',')
+    np.savetxt(os.path.join(dir_run, f'mu_map_{c_target:.2e}.csv'), mus, delimiter=',')
 
     num_modes = 5  # for harris thermal map or number of localized zernike modes
     nseg = run_matrix.simulator.nseg
 
-    ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, out_dir=dir_run, save=True)
+    coeffs_table = util.sort_1d_mus_per_segment(mus, num_modes, nseg)
+    mu_list = []
+    label_list = []
+    for i in range(coeffs_table.shape[0]):
+        mu_list.append(coeffs_table[i])
+        if WHICH_DM == 'seg_mirror':
+            label_list.append(f'Zernike mode {i}')
+    if WHICH_DM == 'harris_seg_mirror':
+        label_list = ['Faceplates Silvered', 'Bulk', 'Gradient Radial', 'Gradient X lateral', 'Gradient Z axial']
 
+    ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
     ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -9,17 +9,6 @@ from pastis.simulators.luvoir_imaging import LuvoirA_APLC
 import pastis.plotting as ppl
 
 if __name__ == '__main__':
-
-    APLC_DESIGN = 'small'
-
-    # Instantiate the LUVOIR telescope
-    optics_input = os.path.join(util.find_repo_location(), CONFIG_PASTIS.get('LUVOIR', 'optics_path_in_repo'))
-    coronagraph_design = CONFIG_PASTIS.get('LUVOIR', 'coronagraph_design')
-    sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')
-    tel = LuvoirA_APLC(optics_input, coronagraph_design, sampling)
-    nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
-
-    # -----------------------------
     # DM_SPEC = tuple or int, specification for the used DM -
     # for seg_mirror: int, number of local Zernike modes on each segment
     # for harris_seg_mirror: tuple (string, array, bool, bool, bool),
@@ -27,27 +16,16 @@ if __name__ == '__main__':
     # for zernike_mirror: int, number of global Zernikes
 
     # If Harris deformable mirror, uncomment the following lines
-    # --------------------------------------------------------------------------------------------#
     # DM = 'harris_seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
     # fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
     # pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
     # DM_SPEC = (fpath, pad_orientations, True, False, False)
-    # pad_orientation = np.pi / 2 * np.ones(tel.nseg)
-    # filepath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')
-    # tel.create_segmented_harris_mirror(filepath, pad_orientation, thermal=True, mechanical=False, other=False)
-    # num_actuators = tel.harris_sm.num_actuators
-    # num_modes = 5
-    # tel.harris_sm.flatten()
 
     # If Segmented Zernike Mirror, uncomment the following lines
-    # --------------------------------------------------------------------------------------------#
     DM = 'seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
     DM_SPEC = 5
-    tel.create_segmented_mirror(DM_SPEC)
-    num_modes = DM_SPEC
-    num_actuators = tel.sm.num_actuators
-    tel.sm.flatten()
 
+    APLC_DESIGN = 'small'
     # First generate a couple of matrices
     run_matrix = MatrixEfieldLuvoirA(which_dm=DM, dm_spec=DM_SPEC, design=APLC_DESIGN,
                                      calc_science=True, calc_wfs=True,
@@ -57,19 +35,24 @@ if __name__ == '__main__':
     dir_run = run_matrix.overall_dir
     print(f'All saved to {dir_run}.')
 
-    unaberrated_coro_psf, ref = tel.calc_psf(ref=True, display_intermediate=False, norm_one_photon=True)
-    norm = np.max(ref)
-    dh_intensity = (unaberrated_coro_psf / norm) * tel.dh_mask
-    contrast_floor = np.mean(dh_intensity[np.where(tel.dh_mask != 0)])
-    print(f'contrast floor: {contrast_floor}') #TODO:  access this value from run_matrix
-
     # Calculate and save per segment static tolerance
     pastis_matrix = fits.getdata(os.path.join(dir_run, 'matrix_numerical', 'pastis_matrix.fits'))
+
+    # get the unaberrated coro_psf after the matrix run
+    e0_psf = fits.getdata(os.path.join(dir_run, 'unaberrated_coro_psf.fits'))  # already normalized to max of direct pdf
+    dh_mask = np.array(run_matrix.simulator.dh_mask.shaped)
+    contrast_floor = util.dh_mean(e0_psf, dh_mask)
 
     # set the target contrast
     c_target = 5.3*1e-11
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
     np.savetxt(os.path.join(dir_run, 'mu_map_%s.csv' % c_target), mus, delimiter=',')
 
-    ppl.plot_thermal_mus(mus, num_modes, tel.nseg, c_target, out_dir=dir_run, save=True)
-    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, dir_run, mirror='sm', save=False)
+    num_modes = 5  # for harris thermal map or number of localized zernike modes
+    nseg = run_matrix.simulator.nseg
+
+    ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, out_dir=dir_run, save=True)
+
+    tel = run_matrix.simulator
+    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, tel.sm.num_actuators,
+                                       c_target, dir_run, mirror='sm', save=False)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
     # set the target contrast
     c_target = 5.3*1e-11
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
-    np.savetxt(os.path.join(dir_run, 'mu_map_harris_%s.csv' % c_target), mus, delimiter=',')
+    np.savetxt(os.path.join(dir_run, 'mu_map_%s.csv' % c_target), mus, delimiter=',')
 
     ppl.plot_thermal_mus(mus, num_modes, tel.nseg, c0=c_target, out_dir=dir_run, save=True)
     ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, dir_run, save=False)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -67,4 +67,4 @@ if __name__ == '__main__':
 
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
-    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    ppl.plot_multimode_surface_maps(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -11,18 +11,43 @@ import pastis.plotting as ppl
 if __name__ == '__main__':
 
     APLC_DESIGN = 'small'
-    DM = 'harris_seg_mirror'   # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
 
-    # Needed for Harris mirror
-    fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
-    pad_orientations = np.pi / 2 * np.ones(120)
+    # Instantiate the LUVOIR telescope
+    optics_input = os.path.join(util.find_repo_location(), CONFIG_PASTIS.get('LUVOIR', 'optics_path_in_repo'))
+    coronagraph_design = CONFIG_PASTIS.get('LUVOIR', 'coronagraph_design')
+    sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')
+    tel = LuvoirA_APLC(optics_input, coronagraph_design, sampling)
+    nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
 
-    DM_SPEC = (fpath, pad_orientations, True, False, False)
+    # -----------------------------
     # DM_SPEC = tuple or int, specification for the used DM -
-    #    for seg_mirror: int, number of local Zernike modes on each segment
-    #    for harris_seg_mirror: tuple (string, array, bool, bool, bool),
-    #    absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets (thermal, mechanical, other)
-    #    for zernike_mirror: int, number of global Zernikes
+    # for seg_mirror: int, number of local Zernike modes on each segment
+    # for harris_seg_mirror: tuple (string, array, bool, bool, bool),
+    # absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets (thermal, mechanical, other)
+    # for zernike_mirror: int, number of global Zernikes
+
+    # If Harris deformable mirror, uncomment the following lines
+    # --------------------------------------------------------------------------------------------#
+    # DM = 'harris_seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
+    # fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
+    # pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
+    # DM_SPEC = (fpath, pad_orientations, True, False, False)
+    # pad_orientation = np.pi / 2 * np.ones(tel.nseg)
+    # filepath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')
+    # tel.create_segmented_harris_mirror(filepath, pad_orientation, thermal=True, mechanical=False, other=False)
+    # tel.harris_sm
+    # num_actuators = tel.harris_sm.num_actuators
+    # num_modes = 5
+    # tel.harris_sm.flatten()
+
+    # If Segmented Zernike Mirror, uncomment the following lines
+    # --------------------------------------------------------------------------------------------#
+    DM = 'seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
+    DM_SPEC = 5
+    tel.create_segmented_mirror(DM_SPEC)
+    num_modes = DM_SPEC
+    num_actuators = tel.sm.num_actuators
+    tel.sm.flatten()
 
     # First generate a couple of matrices
     run_matrix = MatrixEfieldLuvoirA(which_dm=DM, dm_spec=DM_SPEC, design=APLC_DESIGN,
@@ -33,23 +58,6 @@ if __name__ == '__main__':
     dir_run = run_matrix.overall_dir
     print(f'All saved to {dir_run}.')
 
-    # Instantiate the LUVOIR telescope
-    optics_input = os.path.join(util.find_repo_location(), CONFIG_PASTIS.get('LUVOIR', 'optics_path_in_repo'))
-    coronagraph_design = CONFIG_PASTIS.get('LUVOIR', 'coronagraph_design')
-    sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')
-    tel = LuvoirA_APLC(optics_input, coronagraph_design, sampling)
-    nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
-
-    # Create harris deformable mirror
-    tel.create_segmented_harris_mirror(fpath, pad_orientations, thermal=True, mechanical=False, other=False)
-    tel.harris_sm
-
-    # get number of poking modes
-    num_actuators = tel.harris_sm.num_actuators
-    num_modes = 5
-
-    # calculate dark hole contrast
-    tel.harris_sm.flatten()
     unaberrated_coro_psf, ref = tel.calc_psf(ref=True, display_intermediate=False, norm_one_photon=True)
     norm = np.max(ref)
     dh_intensity = (unaberrated_coro_psf / norm) * tel.dh_mask

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -33,7 +33,6 @@ if __name__ == '__main__':
     dir_run = run_matrix.overall_dir
     print(f'All saved to {dir_run}.')
 
-
     # Instantiate the LUVOIR telescope
     optics_input = os.path.join(util.find_repo_location(), CONFIG_PASTIS.get('LUVOIR', 'optics_path_in_repo'))
     coronagraph_design = CONFIG_PASTIS.get('LUVOIR', 'coronagraph_design')
@@ -59,6 +58,8 @@ if __name__ == '__main__':
 
     # Calculate and save per segment static tolerance
     pastis_matrix = fits.getdata(os.path.join(dir_run, 'matrix_numerical', 'pastis_matrix.fits'))
+
+    # set the target contrast
     c_target = 5.3*1e-11
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
     np.savetxt(os.path.join(dir_run, 'mu_map_harris_%s.csv' % c_target), mus, delimiter=',')

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -1,7 +1,12 @@
+import os
+from astropy.io import fits
 import numpy as np
 from pastis.config import CONFIG_PASTIS
+import pastis.util as util
 from pastis.matrix_generation.matrix_from_efields import MatrixEfieldLuvoirA
-
+from pastis.pastis_analysis import  calculate_segment_constraints
+from pastis.simulators.luvoir_imaging import LuvoirA_APLC
+import pastis.plotting as ppl
 
 if __name__ == '__main__':
 
@@ -12,15 +17,51 @@ if __name__ == '__main__':
     fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
     pad_orientations = np.pi / 2 * np.ones(120)
 
-    DM_SPEC = (fpath, pad_orientations, False, True, False)
+    DM_SPEC = (fpath, pad_orientations, True, False, False)
     # DM_SPEC = tuple or int, specification for the used DM -
     #    for seg_mirror: int, number of local Zernike modes on each segment
-    #    for harris_seg_mirror: tuple (string, array, bool, bool, bool), absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets (thermal, mechanical, other)
+    #    for harris_seg_mirror: tuple (string, array, bool, bool, bool),
+    #    absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets (thermal, mechanical, other)
     #    for zernike_mirror: int, number of global Zernikes
 
     # First generate a couple of matrices
     run_matrix = MatrixEfieldLuvoirA(which_dm=DM, dm_spec=DM_SPEC, design=APLC_DESIGN,
-                                     initial_path=CONFIG_PASTIS.get('local', 'local_data_path'))
+                                     calc_science=True, calc_wfs=True,
+                                     initial_path=CONFIG_PASTIS.get('local', 'local_data_path'),
+                                     norm_one_photon=True)
     run_matrix.calc()
     dir_run = run_matrix.overall_dir
     print(f'All saved to {dir_run}.')
+
+
+    # Instantiate the LUVOIR telescope
+    optics_input = os.path.join(util.find_repo_location(), CONFIG_PASTIS.get('LUVOIR', 'optics_path_in_repo'))
+    coronagraph_design = CONFIG_PASTIS.get('LUVOIR', 'coronagraph_design')
+    sampling = CONFIG_PASTIS.getfloat('LUVOIR', 'sampling')
+    tel = LuvoirA_APLC(optics_input, coronagraph_design, sampling)
+    nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
+
+    # Create harris deformable mirror
+    tel.create_segmented_harris_mirror(fpath, pad_orientations, thermal=True, mechanical=False, other=False)
+    tel.harris_sm
+
+    # get number of poking modes
+    num_actuators = tel.harris_sm.num_actuators
+    num_modes = 5
+
+    # calculate dark hole contrast
+    tel.harris_sm.flatten()
+    unaberrated_coro_psf, ref = tel.calc_psf(ref=True, display_intermediate=False, norm_one_photon=True)
+    norm = np.max(ref)
+    dh_intensity = (unaberrated_coro_psf / norm) * tel.dh_mask
+    contrast_floor = np.mean(dh_intensity[np.where(tel.dh_mask != 0)])
+    print(f'contrast floor: {contrast_floor}')
+
+    # Calculate and save per segment static tolerance
+    pastis_matrix = fits.getdata(os.path.join(dir_run, 'matrix_numerical', 'pastis_matrix.fits'))
+    c_target = 5.3*1e-11
+    mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
+    np.savetxt(os.path.join(dir_run, 'mu_map_harris_%s.csv' % c_target), mus, delimiter=',')
+
+    ppl.plot_thermal_mus(mus, num_modes, tel.nseg, c0=c_target, out_dir=dir_run, save=True)
+    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, dir_run, save=False)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -11,7 +11,6 @@ import pastis.plotting as ppl
 
 if __name__ == '__main__':
 
-    NUM_RINGS = 1
     WHICH_DM = 'harris_seg_mirror'   # 'harris_seg_mirror' or 'seg_mirror', or (global) 'zernike_mirror'
 
     # DM_SPEC = tuple or int, specification for the used DM -

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -67,4 +67,5 @@ if __name__ == '__main__':
 
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
-    ppl.plot_multimode_surface_maps(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    os.makedirs(os.path.join(dir_run, 'mu_maps'), exist_ok=True)
+    ppl.plot_multimode_surface_maps(tel, mus, num_modes, mirror=WHICH_DM, cmin=-5, cmax=5, data_dir=dir_run, fname='stat_mu_maps')

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -35,7 +35,6 @@ if __name__ == '__main__':
     # pad_orientation = np.pi / 2 * np.ones(tel.nseg)
     # filepath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')
     # tel.create_segmented_harris_mirror(filepath, pad_orientation, thermal=True, mechanical=False, other=False)
-    # tel.harris_sm
     # num_actuators = tel.harris_sm.num_actuators
     # num_modes = 5
     # tel.harris_sm.flatten()
@@ -62,7 +61,7 @@ if __name__ == '__main__':
     norm = np.max(ref)
     dh_intensity = (unaberrated_coro_psf / norm) * tel.dh_mask
     contrast_floor = np.mean(dh_intensity[np.where(tel.dh_mask != 0)])
-    print(f'contrast floor: {contrast_floor}')
+    print(f'contrast floor: {contrast_floor}') #TODO:  access this value from run_matrix
 
     # Calculate and save per segment static tolerance
     pastis_matrix = fits.getdata(os.path.join(dir_run, 'matrix_numerical', 'pastis_matrix.fits'))
@@ -73,4 +72,4 @@ if __name__ == '__main__':
     np.savetxt(os.path.join(dir_run, 'mu_map_%s.csv' % c_target), mus, delimiter=',')
 
     ppl.plot_thermal_mus(mus, num_modes, tel.nseg, c0=c_target, out_dir=dir_run, save=True)
-    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, dir_run, save=False)
+    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, dir_run, mirror='sm', save=False)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -71,5 +71,5 @@ if __name__ == '__main__':
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
     np.savetxt(os.path.join(dir_run, 'mu_map_%s.csv' % c_target), mus, delimiter=',')
 
-    ppl.plot_thermal_mus(mus, num_modes, tel.nseg, c0=c_target, out_dir=dir_run, save=True)
+    ppl.plot_thermal_mus(mus, num_modes, tel.nseg, c_target, out_dir=dir_run, save=True)
     ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, dir_run, mirror='sm', save=False)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -24,10 +24,12 @@ if __name__ == '__main__':
         fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
         pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
         DM_SPEC = (fpath, pad_orientations, True, False, False)
+        NUM_MODES = 5  # TODO: works only for thermal modes currently
 
     # If using Segmented Zernike Mirror
     if WHICH_DM == 'seg_mirror':
         DM_SPEC = 3
+        NUM_MODES = DM_SPEC
 
     APLC_DESIGN = 'small'
     # First generate a couple of matrices
@@ -52,10 +54,8 @@ if __name__ == '__main__':
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
     np.savetxt(os.path.join(dir_run, f'mu_map_{c_target:.2e}.csv'), mus, delimiter=',')
 
-    num_modes = 5  # for harris thermal map or number of localized zernike modes
     nseg = run_matrix.simulator.nseg
-
-    coeffs_table = util.sort_1d_mus_per_segment(mus, num_modes, nseg)
+    coeffs_table = util.sort_1d_mus_per_segment(mus, NUM_MODES, nseg)
     mu_list = []
     label_list = []
     for i in range(coeffs_table.shape[0]):
@@ -68,4 +68,4 @@ if __name__ == '__main__':
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
     os.makedirs(os.path.join(dir_run, 'mu_maps'), exist_ok=True)
-    ppl.plot_multimode_surface_maps(tel, mus, num_modes, mirror=WHICH_DM, cmin=-5, cmax=5, data_dir=dir_run, fname='stat_mu_maps')
+    ppl.plot_multimode_surface_maps(tel, mus, NUM_MODES, mirror=WHICH_DM, cmin=-5, cmax=5, data_dir=dir_run, fname='stat_mu_maps')

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
         NUM_MODES = 5  # TODO: works only for thermal modes currently
 
     # If using Segmented Zernike Mirror
-    if WHICH_DM == 'seg_mirror':
+    if WHICH_DM in ['seg_mirror', 'zernike_mirror']:
         DM_SPEC = 3
         NUM_MODES = DM_SPEC
 

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -997,7 +997,7 @@ def natural_keys(text):
     return [atoi(c) for c in re.split(r'(\d+)', text)]
 
 
-def plot_thermal_mus(mus, nmodes, nsegments, c0, out_dir, save=False):
+def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
     """
     Generates modal constraints plot for individual segment.
 
@@ -1009,20 +1009,20 @@ def plot_thermal_mus(mus, nmodes, nsegments, c0, out_dir, save=False):
         number of thermal modes
     nsegments :  int
         number of segments
-    c0 : scalar
+    c_target : scalar
         target contrast
     out_dir : str
-        path to save the plot
+        path to save the plot, if save=True
     save : bool
         whether to save the plot
     """
     harris_coeffs_table = np.zeros([nmodes, nsegments])
     for qq in range(nmodes):
         for kk in range(nsegments):
-            harris_coeffs_table[qq, kk] = mus[qq + (kk) * nmodes]
+            harris_coeffs_table[qq, kk] = mus[qq + kk * nmodes]
 
     plt.figure(figsize=(10, 10))
-    plt.title("Modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c0), fontsize=20)
+    plt.title("Modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c_target), fontsize=20)
     plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
     plt.xlabel("Segment Number", fontsize=20)
     plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
@@ -1035,14 +1035,15 @@ def plot_thermal_mus(mus, nmodes, nsegments, c0, out_dir, save=False):
     plt.legend(fontsize=15)
     plt.tight_layout()
     if save:
-        plt.savefig(os.path.join(out_dir, 'mus_1d_multi_modes_%s.png' % c0))
+        fname = f'stat_1d_mus_{c_target}'
+        plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))
     else:
         plt.show()
 
 
 def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, data_dir, mirror, save=False):
     """
-    Creates surface deformation tolerance maps for thermal aberrations.
+    Creates surface deformation tolerance maps for wavefront aberrations.
 
     Parameters:
     tel : class instance of the simulator for "instrument"
@@ -1055,7 +1056,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     c_target : float
         desired dark hole contrast for which the tolerancing is done
     data_dir :  str
-        path to save the plot
+        path to save the plot, if save=True
     save : bool
         whether to save the plot
     """
@@ -1064,8 +1065,8 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     for qq in range(num_modes):
         coeffs_tmp = np.zeros([num_actuators])
         for kk in range(tel.nseg):
-            coeffs_tmp[qq + (kk) * num_modes] = mus[qq + (kk) * num_modes]  # arranged per modal basis
-        coeffs_numaps[qq] = coeffs_tmp  # arranged into 5 groups of nseg elements and in units of nm
+            coeffs_tmp[qq + kk * num_modes] = mus[qq + kk * num_modes]  # arranged per modal basis
+        coeffs_numaps[qq] = coeffs_tmp  # arranged into 'num_modes' groups of nseg elements and in units of nm
 
     nu_maps = []
     if mirror == 'harris_sm':
@@ -1121,4 +1122,5 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     cbar.set_label("$pm$", fontsize=10)
     plt.tight_layout()
     if save:
-        plt.savefig(os.path.join(data_dir, 'stat_mu_maps_nm_%s.png' % c_target))
+        fname = f'stat_mu_maps_{c_target}'
+        plt.savefig(os.path.join(data_dir, '.'.join([fname, 'png'])))

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1020,7 +1020,7 @@ def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
     harris_coeffs_table = pastis.util.sort_1d_mus(mus, nmodes, nsegments)
 
     plt.figure(figsize=(10, 10))
-    plt.title("Modal constraints to achieve a dark hole contrast of "r"$10^{%d}$" % np.log10(c_target), fontsize=20)
+    plt.title("Modal constraints to achieve a dark hole contrast of %.2e" % c_target, fontsize=20)
     plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
     plt.xlabel("Segment Number", fontsize=20)
     plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
@@ -1042,7 +1042,7 @@ def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
 def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, data_dir,
                                    mirror, cmin, cmax, save=False):
     """
-    Creates surface deformation tolerance maps for wavefront aberrations.
+    Creates surface deformation tolerance maps for localized wavefront aberrations.
 
     Parameters:
     tel : class instance of the simulator for "instrument"
@@ -1079,47 +1079,18 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
             tel.sm.actuators = coeffs * nm_aber / 2
             mu_maps.append(tel.sm.surface)  # in units of m, each nu_map is now of the order of 1e-9 m
 
-    plt.figure(figsize=(15, 10))
-    plt.subplot2grid(shape=(2, 6), loc=(0, 0), colspan=2)
-    plot_norm1 = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)
-    hcipy.imshow_field((mu_maps[0]) * 1e12, norm=plot_norm1, cmap='RdBu')  # nu_map is already in 1e-9 m
-    plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
-    cbar = plt.colorbar()
-    cbar.ax.tick_params(labelsize=10)
-    cbar.set_label("$pm$", fontsize=10)
-
-    plt.subplot2grid((2, 6), (0, 2), colspan=2)
-    plot_norm2 = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)
-    hcipy.imshow_field((mu_maps[1]) * 1e12, norm=plot_norm2, cmap='RdBu')
-    plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
-    cbar = plt.colorbar()
-    cbar.ax.tick_params(labelsize=10)
-    cbar.set_label("$pm$", fontsize=10)
-
-    plt.subplot2grid((2, 6), (0, 4), colspan=2)
-    plot_norm3 = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)
-    hcipy.imshow_field((mu_maps[2]) * 1e12, norm=plot_norm3, cmap='RdBu')
-    plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
-    cbar = plt.colorbar()
-    cbar.ax.tick_params(labelsize=10)
-    cbar.set_label("$pm$", fontsize=10)
-
-    plt.subplot2grid((2, 6), (1, 1), colspan=2)
-    plot_norm4 = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)
-    hcipy.imshow_field((mu_maps[3]) * 1e12, norm=plot_norm4, cmap='RdBu')
-    plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
-    cbar = plt.colorbar()
-    cbar.ax.tick_params(labelsize=10)
-    cbar.set_label("$pm$", fontsize=10)
-
-    plt.subplot2grid((2, 6), (1, 3), colspan=2)
-    plot_norm5 = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)
-    hcipy.imshow_field((mu_maps[4]) * 1e12, norm=plot_norm5, cmap='RdBu')
-    plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
-    cbar = plt.colorbar()
-    cbar.ax.tick_params(labelsize=10)
-    cbar.set_label("$pm$", fontsize=10)
-    plt.tight_layout()
-    if save:
-        fname = f'stat_mu_maps_{c_target}'
-        plt.savefig(os.path.join(data_dir, '.'.join([fname, 'pdf'])))
+    for i in range(0, num_modes):
+        plt.figure(figsize=(7, 5))
+        plt.title("Modal constraints for a DH contrast of %.2e, mode number: %s" % (c_target, i), fontsize=10)
+        plot_norm = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)
+        hcipy.imshow_field((mu_maps[i]) * 1e12, norm=plot_norm, cmap='RdBu') # nu_map is already in 1e-9 m
+        plt.tick_params(top=False, bottom=True, left=True,
+                        right=False, labelleft=True, labelbottom=True)
+        cbar = plt.colorbar()
+        cbar.ax.tick_params(labelsize=10)
+        cbar.set_label("$pm$", fontsize=10)
+        plt.tight_layout()
+        if save:
+            os.makedirs(os.path.join(data_dir, 'mu_maps'), exist_ok=True)
+            fname = f'stat_mu_maps_mode_{i}'
+            plt.savefig(os.path.join(data_dir, 'mu_maps', '.'.join([fname, 'pdf'])))

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1040,7 +1040,7 @@ def plot_thermal_mus(mus, nmodes, nsegments, c0, out_dir, save=False):
         plt.show()
 
 
-def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, data_dir, save=False):
+def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, data_dir, mirror, save=False):
     """
     Creates surface deformation tolerance maps for thermal aberrations.
 
@@ -1060,23 +1060,27 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
         whether to save the plot
     """
     nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
-
-    harris_coeffs_numaps = np.zeros([num_modes, num_actuators])
+    coeffs_numaps = np.zeros([num_modes, num_actuators])
     for qq in range(num_modes):
-        harris_coeffs_tmp = np.zeros([num_actuators])
+        coeffs_tmp = np.zeros([num_actuators])
         for kk in range(tel.nseg):
-            harris_coeffs_tmp[qq + (kk) * num_modes] = mus[qq + (kk) * num_modes]  # arranged per modal basis
-        harris_coeffs_numaps[qq] = harris_coeffs_tmp  # arranged into 5 groups of nseg elements and in units of nm
+            coeffs_tmp[qq + (kk) * num_modes] = mus[qq + (kk) * num_modes]  # arranged per modal basis
+        coeffs_numaps[qq] = coeffs_tmp  # arranged into 5 groups of nseg elements and in units of nm
 
     nu_maps = []
-    for qq in range(num_modes):
-        harris_coeffs = harris_coeffs_numaps[qq]  # in units of nm
-        tel.harris_sm.actuators = harris_coeffs * nm_aber / 2  # in units of m
-        nu_maps.append(tel.harris_sm.surface)  # in units of m, each nu_map is now of the order of 1e-9 m
+    if mirror == 'harris_sm':
+        for qq in range(num_modes):
+            coeffs = coeffs_numaps[qq]  # in units of nm
+            tel.harris_sm.actuators = coeffs * nm_aber / 2  # in units of m
+            nu_maps.append(tel.harris_sm.surface)  # in units of m, each nu_map is now of the order of 1e-9 m
+    if mirror == 'sm':
+        for qq in range(num_modes):
+            coeffs = coeffs_numaps[qq]
+            tel.sm.actuators = coeffs * nm_aber / 2
+            nu_maps.append(tel.sm.surface)
 
     plt.figure(figsize=(15, 10))
     plt.subplot2grid(shape=(2, 6), loc=(0, 0), colspan=2)
-    plt.title("Faceplates Silvered", fontsize=10)
     plot_norm1 = TwoSlopeNorm(vcenter=0, vmin=-5, vmax=5)
     hcipy.imshow_field((nu_maps[0]) * 1e12, norm=plot_norm1, cmap='RdBu')  # nu_map is already in 1e-9 m
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
@@ -1085,7 +1089,6 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     cbar.set_label("$pm$", fontsize=10)
 
     plt.subplot2grid((2, 6), (0, 2), colspan=2)
-    plt.title("Bulk", fontsize=10)
     plot_norm2 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
     hcipy.imshow_field((nu_maps[1]) * 1e12, norm=plot_norm2, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
@@ -1094,7 +1097,6 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     cbar.set_label("$pm$", fontsize=10)
 
     plt.subplot2grid((2, 6), (0, 4), colspan=2)
-    plt.title("Gradiant Radial", fontsize=10)
     plot_norm3 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
     hcipy.imshow_field((nu_maps[2]) * 1e12, norm=plot_norm3, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
@@ -1103,7 +1105,6 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     cbar.set_label("$pm$", fontsize=10)
 
     plt.subplot2grid((2, 6), (1, 1), colspan=2)
-    plt.title("Gradient X lateral", fontsize=10)
     plot_norm4 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
     hcipy.imshow_field((nu_maps[3]) * 1e12, norm=plot_norm4, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
@@ -1112,7 +1113,6 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     cbar.set_label("$pm$", fontsize=10)
 
     plt.subplot2grid((2, 6), (1, 3), colspan=2)
-    plt.title("Gradient Z axial", fontsize=10)
     plot_norm5 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
     hcipy.imshow_field((nu_maps[4]) * 1e12, norm=plot_norm5, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1036,10 +1036,10 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
     for mode in range(num_modes):
         coeffs = mus_per_actuator[mode]
         if mirror == 'harris_seg_mirror':
-            tel.harris_sm.actuators = coeffs / 2
+            tel.harris_sm.actuators = coeffs * 1e-9 / 2  # in meters of surface
             mu_maps.append(tel.harris_sm.surface)  # in m
         if mirror == 'seg_mirror':
-            tel.sm.actuators = coeffs / 2
+            tel.sm.actuators = coeffs * 1e-9 / 2  # in meters of surface
             mu_maps.append(tel.sm.surface)  # in m
 
     plot_norm = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1061,29 +1061,29 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
         whether to save the plot
     """
     nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
-    coeffs_numaps = np.zeros([num_modes, num_actuators])
+    coeffs_mumaps = np.zeros([num_modes, num_actuators])
     for qq in range(num_modes):
         coeffs_tmp = np.zeros([num_actuators])
         for kk in range(tel.nseg):
             coeffs_tmp[qq + kk * num_modes] = mus[qq + kk * num_modes]  # arranged per modal basis
-        coeffs_numaps[qq] = coeffs_tmp  # arranged into 'num_modes' groups of nseg elements and in units of nm
+        coeffs_mumaps[qq] = coeffs_tmp  # arranged into 'num_modes' groups of nseg elements and in units of nm
 
-    nu_maps = []
+    mu_maps = []
     if mirror == 'harris_sm':
         for qq in range(num_modes):
-            coeffs = coeffs_numaps[qq]  # in units of nm
+            coeffs = coeffs_mumaps[qq]  # in units of nm
             tel.harris_sm.actuators = coeffs * nm_aber / 2  # in units of m
-            nu_maps.append(tel.harris_sm.surface)  # in units of m, each nu_map is now of the order of 1e-9 m
+            mu_maps.append(tel.harris_sm.surface)  # in units of m, each nu_map is now of the order of 1e-9 m
     if mirror == 'sm':
         for qq in range(num_modes):
-            coeffs = coeffs_numaps[qq]
+            coeffs = coeffs_mumaps[qq]
             tel.sm.actuators = coeffs * nm_aber / 2
-            nu_maps.append(tel.sm.surface)
+            mu_maps.append(tel.sm.surface)
 
     plt.figure(figsize=(15, 10))
     plt.subplot2grid(shape=(2, 6), loc=(0, 0), colspan=2)
     plot_norm1 = TwoSlopeNorm(vcenter=0, vmin=-5, vmax=5)
-    hcipy.imshow_field((nu_maps[0]) * 1e12, norm=plot_norm1, cmap='RdBu')  # nu_map is already in 1e-9 m
+    hcipy.imshow_field((mu_maps[0]) * 1e12, norm=plot_norm1, cmap='RdBu')  # nu_map is already in 1e-9 m
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
     cbar = plt.colorbar()
     cbar.ax.tick_params(labelsize=10)
@@ -1091,7 +1091,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
 
     plt.subplot2grid((2, 6), (0, 2), colspan=2)
     plot_norm2 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
-    hcipy.imshow_field((nu_maps[1]) * 1e12, norm=plot_norm2, cmap='RdBu')
+    hcipy.imshow_field((mu_maps[1]) * 1e12, norm=plot_norm2, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
     cbar = plt.colorbar()
     cbar.ax.tick_params(labelsize=10)
@@ -1099,7 +1099,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
 
     plt.subplot2grid((2, 6), (0, 4), colspan=2)
     plot_norm3 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
-    hcipy.imshow_field((nu_maps[2]) * 1e12, norm=plot_norm3, cmap='RdBu')
+    hcipy.imshow_field((mu_maps[2]) * 1e12, norm=plot_norm3, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
     cbar = plt.colorbar()
     cbar.ax.tick_params(labelsize=10)
@@ -1107,7 +1107,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
 
     plt.subplot2grid((2, 6), (1, 1), colspan=2)
     plot_norm4 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
-    hcipy.imshow_field((nu_maps[3]) * 1e12, norm=plot_norm4, cmap='RdBu')
+    hcipy.imshow_field((mu_maps[3]) * 1e12, norm=plot_norm4, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
     cbar = plt.colorbar()
     cbar.ax.tick_params(labelsize=10)
@@ -1115,7 +1115,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
 
     plt.subplot2grid((2, 6), (1, 3), colspan=2)
     plot_norm5 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
-    hcipy.imshow_field((nu_maps[4]) * 1e12, norm=plot_norm5, cmap='RdBu')
+    hcipy.imshow_field((mu_maps[4]) * 1e12, norm=plot_norm5, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
     cbar = plt.colorbar()
     cbar.ax.tick_params(labelsize=10)
@@ -1123,4 +1123,4 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     plt.tight_layout()
     if save:
         fname = f'stat_mu_maps_{c_target}'
-        plt.savefig(os.path.join(data_dir, '.'.join([fname, 'png'])))
+        plt.savefig(os.path.join(data_dir, '.'.join([fname, 'pdf'])))

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -997,48 +997,6 @@ def natural_keys(text):
     return [atoi(c) for c in re.split(r'(\d+)', text)]
 
 
-def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
-    """
-    Plot modal constraints plot for individual segment.
-
-    Parameters
-    ----------
-    mus : ndarray
-        list of standard deviations for each segment in nm
-    nmodes : int
-        number of thermal modes
-    nsegments :  int
-        number of segments
-    c_target : scalar
-        target contrast
-    out_dir : str
-        path to save the plot, if save=True
-    save : bool
-        whether to save the plot, if False, it shows the plot
-    """
-
-    harris_coeffs_table = pastis.util.sort_1d_mus_per_segment(mus, nmodes, nsegments)
-
-    plt.figure(figsize=(10, 10))
-    plt.title("Modal constraints to achieve a dark hole contrast of %.2e" % c_target, fontsize=20)
-    plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
-    plt.xlabel("Segment Number", fontsize=20)
-    plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
-    plt.plot(harris_coeffs_table[0]*1e3, label="Faceplates Silvered")
-    plt.plot(harris_coeffs_table[1]*1e3, label="Bulk")
-    plt.plot(harris_coeffs_table[2]*1e3, label="Gradiant Radial")
-    plt.plot(harris_coeffs_table[3]*1e3, label="Gradiant X lateral")
-    plt.plot(harris_coeffs_table[4]*1e3, label="Gradient Z axial")
-    plt.grid()
-    plt.legend(fontsize=15)
-    plt.tight_layout()
-    if save:
-        fname = f'stat_1d_mus_{c_target}'
-        plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))
-    else:
-        plt.show()
-
-
 def plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, data_dir, mirror, cmin, cmax, save=False):
     """
     Creates surface deformation tolerance maps for localized wavefront aberrations.

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -997,7 +997,7 @@ def natural_keys(text):
     return [atoi(c) for c in re.split(r'(\d+)', text)]
 
 
-def plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, data_dir, mirror, cmin, cmax, save=False):
+def plot_multimode_surface_maps(tel, mus, num_modes, c_target, data_dir, mirror, cmin, cmax, save=False):
     """
     Creates surface deformation tolerance maps for localized wavefront aberrations.
 

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -435,7 +435,7 @@ def plot_segment_weights(mus, out_dir, c_target, labels=None, fname=None, save=F
     :param mus: array or list of arrays, segment requirements in nm
     :param out_dir: str, output path to save the figure to if save=True
     :param c_target: float, target contrast for which the mode weights have been calculated
-    :param labels: tuple, optional, labels for the different lists of sigmas provided
+    :param labels: list, optional, labels for the different lists of sigmas provided
     :param fname: str, optional, file name to save plot to
     :param save: bool, whether to save to disk or not, default is False
     """
@@ -445,12 +445,15 @@ def plot_segment_weights(mus, out_dir, c_target, labels=None, fname=None, save=F
     # Figure out how many sets of mode coefficients per segment we have
     if isinstance(mus, list):
         sets = len(mus)
-        if labels is None:
-            raise AttributeError('A tuple of labels needs to be defined when more than one set of mus is provided.')
+        if sets > 1:
+            if labels is None:
+                raise AttributeError('A list of labels needs to be defined when more than one set of mus is provided.')
+        elif sets == 1:
+            mus = mus[0]
     elif isinstance(mus, np.ndarray) and mus.ndim == 1:
         sets = 1
     else:
-        raise AttributeError('Segment weights "mus" must be an array of values, or a tuple of such arrays.')
+        raise AttributeError('Segment weights "mus" must be a 1d array of values, or a list of such arrays.')
 
     plt.figure(figsize=(12, 8))
     if sets == 1:

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -999,12 +999,12 @@ def natural_keys(text):
 
 def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
     """
-    Generates modal constraints plot for individual segment.
+    Plot modal constraints plot for individual segment.
 
     Parameters
     ----------
     mus : ndarray
-        list of standard deviations for each segment
+        list of standard deviations for each segment in nm
     nmodes : int
         number of thermal modes
     nsegments :  int
@@ -1032,6 +1032,49 @@ def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
     plt.grid()
     plt.legend(fontsize=15)
     plt.tight_layout()
+    if save:
+        fname = f'stat_1d_mus_{c_target}'
+        plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))
+    else:
+        plt.show()
+
+
+def plot_zernike_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
+    """
+    Plot localized zernike modal constraints plot for individual segment.
+
+    Parameters
+    ----------
+    mus : ndarray
+        list of standard deviations for each segment in nm
+    nmodes : int
+        number of thermal modes
+    nsegments :  int
+        number of segments
+    c_target : scalar
+        target contrast
+    out_dir : str
+        path to save the plot, if save=True
+    save : bool
+        whether to save the plot, if False, it shows the plot
+    """
+
+    coeffs_table = pastis.util.sort_1d_mus(mus, nmodes, nsegments)
+
+    plt.figure(figsize=(10, 10))
+    plt.title("Modal constraints to achieve a dark hole contrast of %.2e" % c_target, fontsize=20)
+    plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
+    plt.xlabel("Segment Number", fontsize=20)
+    plt.tick_params(top=True, bottom=True, left=True, right=True,
+                    labelleft=True, labelbottom=True, labelsize=20)
+
+    for i in range(nmodes):
+        plt.plot(coeffs_table[i]*1e3, label='Zernike mode: %s' % i)
+
+    plt.grid()
+    plt.legend(fontsize=15)
+    plt.tight_layout()
+
     if save:
         fname = f'stat_1d_mus_{c_target}'
         plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1007,7 +1007,9 @@ def plot_multimode_surface_maps(tel, mus, num_modes, c_target, data_dir, mirror,
     Parameters:
     tel : class instance of the simulator for "instrument"
     mus : 1d array
-        list of tolerances for individual segments in units of nm
+        an array of segment requirements for all segment-level localized aberration modes, in units of nm.
+        each element in this array is a tolerance value per segment per mode
+        len(mus) = total number of modes * total number of segments
     num_modes : int
         the total number of local modes used to poke a segment.
         For a harris segment mirror  it is 5 (taking only thermal basis map).

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1023,7 +1023,7 @@ def plot_multimode_surface_maps(tel, mus, num_modes, c_target, data_dir, mirror,
     cmax : float
         minimum value for colorbar plot
     save : bool
-        whether to save the plot
+        whether to save the plot, default is False
     """
     nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
 

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -428,23 +428,22 @@ def plot_covariance_matrix(covariance_matrix, out_dir, c_target, segment_space=T
         plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))
 
 
-def plot_segment_weights(mus, out_dir, c_target, labels=None, fname_suffix='', save=False):
+def plot_segment_weights(mus, out_dir, c_target, labels=None, fname=None, save=False):
     """
     Plot segment weights against segment index, in units of picometers (converted from input).
-    :param mus: array or list, segment requirements in nm
+
+    :param mus: array or list of arrays, segment requirements in nm
     :param out_dir: str, output path to save the figure to if save=True
     :param c_target: float, target contrast for which the mode weights have been calculated
     :param labels: tuple, optional, labels for the different lists of sigmas provided
-    :param fname_suffix: str, optional, suffix to add to the saved file name
+    :param fname: str, optional, file name to save plot to
     :param save: bool, whether to save to disk or not, default is False
-    :return:
     """
-    fname = f'segment_requirements_{c_target}'
-    if fname_suffix != '':
-        fname += f'_{fname_suffix}'
+    if fname is None:
+        fname = f'segment_requirements_{c_target:.2e}'
 
-    # Figure out how many sets of sigmas we have
-    if isinstance(mus, tuple):
+    # Figure out how many sets of mode coefficients per segment we have
+    if isinstance(mus, list):
         sets = len(mus)
         if labels is None:
             raise AttributeError('A tuple of labels needs to be defined when more than one set of mus is provided.')
@@ -464,6 +463,7 @@ def plot_segment_weights(mus, out_dir, c_target, labels=None, fname_suffix='', s
     plt.tick_params(axis='both', which='both', length=6, width=2, labelsize=30)
     if labels is not None:
         plt.legend(prop={'size': 25}, loc=(0.15, 0.73))
+    plt.grid()
     plt.tight_layout()
 
     if save:
@@ -1032,49 +1032,6 @@ def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
     plt.grid()
     plt.legend(fontsize=15)
     plt.tight_layout()
-    if save:
-        fname = f'stat_1d_mus_{c_target}'
-        plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))
-    else:
-        plt.show()
-
-
-def plot_zernike_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
-    """
-    Plot localized zernike modal constraints plot for individual segment.
-
-    Parameters
-    ----------
-    mus : ndarray
-        list of standard deviations for each segment in nm
-    nmodes : int
-        number of thermal modes
-    nsegments :  int
-        number of segments
-    c_target : scalar
-        target contrast
-    out_dir : str
-        path to save the plot, if save=True
-    save : bool
-        whether to save the plot, if False, it shows the plot
-    """
-
-    coeffs_table = pastis.util.sort_1d_mus_per_segment(mus, nmodes, nsegments)
-
-    plt.figure(figsize=(10, 10))
-    plt.title("Modal constraints to achieve a dark hole contrast of %.2e" % c_target, fontsize=20)
-    plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
-    plt.xlabel("Segment Number", fontsize=20)
-    plt.tick_params(top=True, bottom=True, left=True, right=True,
-                    labelleft=True, labelbottom=True, labelsize=20)
-
-    for i in range(nmodes):
-        plt.plot(coeffs_table[i]*1e3, label='Zernike mode: %s' % i)
-
-    plt.grid()
-    plt.legend(fontsize=15)
-    plt.tight_layout()
-
     if save:
         fname = f'stat_1d_mus_{c_target}'
         plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -477,7 +477,7 @@ def plot_mu_map(instrument, mus, sim_instance, out_dir, c_target, limits=None, f
     """
     Plot the segment requirement map for a specific target contrast.
     :param instrument: string, "LUVOIR", "HiCAT" or "JWST"
-    :param mus: array or list, segment requirements (standard deviations) in nm
+    :param mus: array or list, segment requirements (standard deviations) in nm WFE
     :param sim_instance: class instance of the simulator for "instrument"
     :param out_dir: str, output path to save the figure to if save=True
     :param c_target: float, target contrast for which the segment requirements have been calculated
@@ -1002,9 +1002,9 @@ def natural_keys(text):
 
 def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_dir=None, fname=None):
     """
-    Creates surface deformation maps for localized wavefront aberrations.
+    Creates surface deformation maps (not WFE) for localized wavefront aberrations.
 
-    The input mode coefficients 'mus' need to be grouped by segment, meaning the array holds
+    The input mode coefficients 'mus' are in units of *WFE* and need to be grouped by segment, meaning the array holds
     the mode coefficients as:
         mode1 on seg1, mode2 on seg1, ..., mode'nmodes' on seg1, mode1 on seg2, mode2 on seg2 and so on.
 
@@ -1013,7 +1013,7 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
     tel : class instance of internal simulator
         the simulator to plot the surface maps for
     mus : 1d array
-        1d array of standard deviations for all modes on each segment, in nm
+        1d array of standard deviations for all modes on each segment, in nm WFE
     num_modes : int
         number of local modes used to poke each segment
     mirror : str
@@ -1028,7 +1028,7 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
         file name for surface maps saved to disk
     """
     if fname is None:
-        fname = f'map_on_{mirror}'
+        fname = f'surface_on_{mirror}'
 
     nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
     coeffs_mumaps = pastis.util.sort_1d_mus_per_actuator(mus, num_modes, tel.nseg)  # in nm
@@ -1038,7 +1038,7 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
         coeffs = coeffs_mumaps[mode]
         if mirror == 'harris_seg_mirror':
             tel.harris_sm.actuators = coeffs * nm_aber / 2
-            mu_maps.append(tel.harris_sm.surface)
+            mu_maps.append(tel.harris_sm.surface)  # in m
         if mirror == 'seg_mirror':
             tel.sm.actuators = coeffs * nm_aber / 2
             mu_maps.append(tel.sm.surface)  # in m
@@ -1050,7 +1050,7 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
         plt.tick_params(top=False, bottom=True, left=True, right=False, labelleft=True, labelbottom=True)
         cbar = plt.colorbar()
         cbar.ax.tick_params(labelsize=10)
-        cbar.set_label("pm", fontsize=10)
+        cbar.set_label("Surface (pm)", fontsize=10)
         plt.tight_layout()
 
         if data_dir is not None:

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1030,8 +1030,8 @@ def plot_multimode_surface_maps(tel, mus, num_modes, c_target, data_dir, mirror,
     coeffs_mumaps = pastis.util.sort_1d_mus_per_actuator(mus, num_modes, tel.nseg)
 
     mu_maps = []
-    for qq in range(num_modes):
-        coeffs = coeffs_mumaps[qq] # in units of nm
+    for mode in range(num_modes):
+        coeffs = coeffs_mumaps[mode] # in units of nm
         if mirror == 'harris_sm':
             tel.harris_sm.actuators = coeffs * nm_aber / 2 # in units of m
             mu_maps.append(tel.harris_sm.surface)

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1030,17 +1030,16 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
     if fname is None:
         fname = f'surface_on_{mirror}'
 
-    nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
     coeffs_mumaps = pastis.util.sort_1d_mus_per_actuator(mus, num_modes, tel.nseg)  # in nm
 
     mu_maps = []
     for mode in range(num_modes):
         coeffs = coeffs_mumaps[mode]
         if mirror == 'harris_seg_mirror':
-            tel.harris_sm.actuators = coeffs * nm_aber / 2
+            tel.harris_sm.actuators = coeffs / 2
             mu_maps.append(tel.harris_sm.surface)  # in m
         if mirror == 'seg_mirror':
-            tel.sm.actuators = coeffs * nm_aber / 2
+            tel.sm.actuators = coeffs / 2
             mu_maps.append(tel.sm.surface)  # in m
 
     plot_norm = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1039,7 +1039,8 @@ def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
         plt.show()
 
 
-def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, data_dir, mirror, save=False):
+def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, data_dir,
+                                   mirror, cmin, cmax, save=False):
     """
     Creates surface deformation tolerance maps for wavefront aberrations.
 
@@ -1057,6 +1058,10 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
         desired dark hole contrast for which the tolerancing is done
     data_dir :  str
         path to save the plot, if save=True
+    cmin : float
+        minimum value for colorbar plot
+    cmax : float
+        minimum value for colorbar plot
     save : bool
         whether to save the plot
     """
@@ -1076,7 +1081,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
 
     plt.figure(figsize=(15, 10))
     plt.subplot2grid(shape=(2, 6), loc=(0, 0), colspan=2)
-    plot_norm1 = TwoSlopeNorm(vcenter=0, vmin=-5, vmax=5)
+    plot_norm1 = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)
     hcipy.imshow_field((mu_maps[0]) * 1e12, norm=plot_norm1, cmap='RdBu')  # nu_map is already in 1e-9 m
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
     cbar = plt.colorbar()
@@ -1084,7 +1089,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     cbar.set_label("$pm$", fontsize=10)
 
     plt.subplot2grid((2, 6), (0, 2), colspan=2)
-    plot_norm2 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
+    plot_norm2 = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)
     hcipy.imshow_field((mu_maps[1]) * 1e12, norm=plot_norm2, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
     cbar = plt.colorbar()
@@ -1092,7 +1097,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     cbar.set_label("$pm$", fontsize=10)
 
     plt.subplot2grid((2, 6), (0, 4), colspan=2)
-    plot_norm3 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
+    plot_norm3 = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)
     hcipy.imshow_field((mu_maps[2]) * 1e12, norm=plot_norm3, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
     cbar = plt.colorbar()
@@ -1100,7 +1105,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     cbar.set_label("$pm$", fontsize=10)
 
     plt.subplot2grid((2, 6), (1, 1), colspan=2)
-    plot_norm4 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
+    plot_norm4 = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)
     hcipy.imshow_field((mu_maps[3]) * 1e12, norm=plot_norm4, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
     cbar = plt.colorbar()
@@ -1108,7 +1113,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     cbar.set_label("$pm$", fontsize=10)
 
     plt.subplot2grid((2, 6), (1, 3), colspan=2)
-    plot_norm5 = TwoSlopeNorm(vcenter=0, vmin=-10, vmax=10)
+    plot_norm5 = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)
     hcipy.imshow_field((mu_maps[4]) * 1e12, norm=plot_norm5, cmap='RdBu')
     plt.tick_params(top=False, bottom=False, left=False, right=False, labelleft=False, labelbottom=False)
     cbar = plt.colorbar()

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1082,8 +1082,7 @@ def plot_zernike_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
         plt.show()
 
 
-def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, data_dir,
-                                   mirror, cmin, cmax, save=False):
+def plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, data_dir, mirror, cmin, cmax, save=False):
     """
     Creates surface deformation tolerance maps for localized wavefront aberrations.
 
@@ -1095,8 +1094,6 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
         the total number of local modes used to poke a segment.
         For a harris segment mirror  it is 5 (taking only thermal basis map).
         For a segmented mirror, it represents the total number of local zernike modes.
-    num_actuators : int
-        total number of dm actuators
     c_target : float
         desired dark hole contrast for which the tolerancing is done
     data_dir :  str

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1030,11 +1030,11 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
     if fname is None:
         fname = f'surface_on_{mirror}'
 
-    coeffs_mumaps = pastis.util.sort_1d_mus_per_actuator(mus, num_modes, tel.nseg)  # in nm
+    mus_per_actuator = pastis.util.sort_1d_mus_per_actuator(mus, num_modes, tel.nseg)  # in nm
 
     mu_maps = []
     for mode in range(num_modes):
-        coeffs = coeffs_mumaps[mode]
+        coeffs = mus_per_actuator[mode]
         if mirror == 'harris_seg_mirror':
             tel.harris_sm.actuators = coeffs / 2
             mu_maps.append(tel.harris_sm.surface)  # in m

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1050,7 +1050,9 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     mus : 1d array
         list of tolerances for individual segments in units of nm
     num_modes : int
-        len of segment level thmodal basis
+        the total number of local modes used to poke a segment.
+        For a harris segment mirror  it is 5 (taking only thermal basis map).
+        For a segmented mirror, it represents the total number of local zernike modes.
     num_actuators : int
         total number of dm actuators
     c_target : float

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1110,7 +1110,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     """
     nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
 
-    coeffs_mumaps = pastis.util.calculate_mu_maps(mus, num_modes, num_actuators, tel.nseg)
+    coeffs_mumaps = pastis.util.sort_1d_mus_per_actuator(mus, num_modes, tel.nseg)
 
     mu_maps = []
     for qq in range(num_modes):

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1017,7 +1017,7 @@ def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
         whether to save the plot, if False, it shows the plot
     """
 
-    harris_coeffs_table = pastis.util.sort_1d_mus(mus, nmodes, nsegments)
+    harris_coeffs_table = pastis.util.sort_1d_mus_per_segment(mus, nmodes, nsegments)
 
     plt.figure(figsize=(10, 10))
     plt.title("Modal constraints to achieve a dark hole contrast of %.2e" % c_target, fontsize=20)
@@ -1059,7 +1059,7 @@ def plot_zernike_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
         whether to save the plot, if False, it shows the plot
     """
 
-    coeffs_table = pastis.util.sort_1d_mus(mus, nmodes, nsegments)
+    coeffs_table = pastis.util.sort_1d_mus_per_segment(mus, nmodes, nsegments)
 
     plt.figure(figsize=(10, 10))
     plt.title("Modal constraints to achieve a dark hole contrast of %.2e" % c_target, fontsize=20)

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -698,24 +698,25 @@ def seg_to_dm_xy(actuator_total, segment):
 
 def sort_1d_mus(mus, nmodes, nsegments):
     """
-    Sorts one dimensional multimode-tolerances values into 'n-multimode' groups,
-    where each group contains tolerance values for all segments for a one kind of aberration mode.
-    (This sorting is in sync with the way the PASTIS matrix is calculated for multimode-segment aberrations.
-    Each segment is poked n types of aberration mode, one mode at a time, and corresponding contrast is calculated)
+    Sorts one-dimensional multi-mode tolerance values into 'nmodes-multimode' groups.
+
+    The resulting array sorts the tolerance values in a 2D array, with the dimensions representing the number of modes
+    and number of segments, respectively. The input tolerance values 'mus' are grouped by segment, meaning it holds
+    the tolerances as: mode1 on seg1, mode2 on seg1, ..., mode'nmodes' on seg1, mode1 on seg2, mode2 on seg2 and so on.
 
     Parameters
     ----------
-    mus : ndarray
-        list of standard deviations for each segment in nm
+    mus : 1d-array
+        1d array of standard deviations for all modes on each segment, in nm
     nmodes : int
-        number of thermal modes
-    nsegments :  int
+        number of individual modes per segment
+    nsegments : int
         number of segments
 
     Returns
     -------
-    coeffs_table : ndarray
-         groups of single-mode tolerance values for all segments.
+    coeffs_table : 2d-array
+        groups of single-mode tolerance values for all segments.
     """
     coeffs_table = np.zeros([nmodes, nsegments])
     for qq in range(nmodes):

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -696,7 +696,7 @@ def seg_to_dm_xy(actuator_total, segment):
     return actuator_pair_x, int(actuator_pair_y)
 
 
-def sort_1d_mus(mus, nmodes, nsegments):
+def sort_1d_mus_per_segment(mus, nmodes, nsegments):
     """
     Sorts one-dimensional multi-mode tolerance values into 'nmodes-multimode' groups.
 

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -728,23 +728,31 @@ def sort_1d_mus_per_segment(mus, nmodes, nsegments):
 
 def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
     """
-    Sorts one dimensional multimode-tolerances values into nmodes-groups of dm actuators settings.
-    Each "dm actuator setting" group contains tolerance values for one kind of aberration mode.
+    Sorts one-dimensional multi-mode tolerance values into an actuator array for the internal simulators.
+
+    The resulting array sorts the mode coefficients into a 2D array, with the dimensions representing the number of
+    input mode and number of actuators, respectively. Each row of the 2D output array (first index) is a valid array to
+    be passed directly to the actuators of a segmented mirror of an internal simulator.
+    Following the convention of the internal simulators, the number of actuators is calculated as the product of local
+    modes times all segments.
+
+    The input mode coefficients 'mus' need to be grouped by segment, meaning the array holds
+    the mode coefficients as:
+        mode1 on seg1, mode2 on seg1, ..., mode'nmodes' on seg1, mode1 on seg2, mode2 on seg2 and so on.
 
     Parameters
     ----------
-    mus : ndarray
-        list of standard deviations for each segment in nm
+    mus : 1d-darray
+        1d array of standard deviations for all modes on each segment, in nm
     nmodes : int
-        number of localized segment level aberration modes
-    nactuators : int
-        total number of dm actuators
-    nsegments :  int
+        number of individual modes per segment
+    nsegments : int
         number of segments
+
     Returns
     -------
-    coeffs_mumaps : ndarray
-        group of single mode dm actuators settings
+    coeffs_mumaps : 2d-darray
+        actuator array whose rows (first index) can be directly passed to the segmented mirror of an internal simulator
     """
     nactuators = nmodes * nsegments
     coeffs_mumaps = np.zeros([nmodes, nactuators])

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -722,9 +722,9 @@ def sort_1d_mus_per_segment(mus, nmodes, nseg):
         groups of single-mode coefficients for all segments.
     """
     coeffs_table = np.zeros([nmodes, nseg])
-    for qq in range(nmodes):
-        for kk in range(nseg):
-            coeffs_table[qq, kk] = mus[qq + kk * nmodes]
+    for mode in range(nmodes):
+        for seg in range(nseg):
+            coeffs_table[mode, seg] = mus[mode + seg * nmodes]
 
     return coeffs_table
 
@@ -761,7 +761,7 @@ def sort_1d_mus_per_actuator(mus, nmodes, nseg):
     nactuators = nmodes * nseg
     coeffs_mumaps = np.zeros([nmodes, nactuators])
 
-    for i, j in zip(np.tile(np.arange(nmodes), nseg), np.arange(nactuators)):
-        coeffs_mumaps[i, j] = mus[j]
+    for mode, act in zip(np.tile(np.arange(nmodes), nseg), np.arange(nactuators)):
+        coeffs_mumaps[mode, act] = mus[act]
 
     return coeffs_mumaps

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -726,7 +726,7 @@ def sort_1d_mus_per_segment(mus, nmodes, nsegments):
     return coeffs_table
 
 
-def calculate_mu_maps(mus, nmodes, nactuators, nsegments):
+def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
     """
     Sorts one dimensional multimode-tolerances values into nmodes-groups of dm actuators settings.
     Each "dm actuator setting" group contains tolerance values for one kind of aberration mode.

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -746,12 +746,10 @@ def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
     coeffs_mumaps : ndarray
         group of single mode dm actuators settings
     """
+    nactuators = nmodes * nsegments
     coeffs_mumaps = np.zeros([nmodes, nactuators])
-    for qq in range(nmodes):
-        coeffs_tmp = np.zeros([nactuators])
-        for kk in range(nsegments):
-            coeffs_tmp[qq + kk * nmodes] = mus[qq + kk * nmodes]  # arranged per modal basis
-        coeffs_mumaps[qq] = coeffs_tmp  # arranged into 'nmodes' groups in units of nm
+
+    for i, j in zip(np.tile(np.arange(nmodes), nsegments), np.arange(nactuators)):
+        coeffs_mumaps[i, j] = mus[j]
 
     return coeffs_mumaps
-

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -1,7 +1,6 @@
 """
 Helper functions for PASTIS.
 """
-
 import glob
 import os
 import datetime

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -696,7 +696,7 @@ def seg_to_dm_xy(actuator_total, segment):
     return actuator_pair_x, int(actuator_pair_y)
 
 
-def sort_1d_mus_per_segment(mus, nmodes, nsegments):
+def sort_1d_mus_per_segment(mus, nmodes, nseg):
     """
     Sorts one-dimensional multi-mode coefficients into 'nmodes-multimode' groups.
 
@@ -713,7 +713,7 @@ def sort_1d_mus_per_segment(mus, nmodes, nsegments):
         1d array of standard deviations for all modes on each segment, in nm
     nmodes : int
         number of individual modes per segment
-    nsegments : int
+    nseg : int
         number of segments
 
     Returns
@@ -721,15 +721,15 @@ def sort_1d_mus_per_segment(mus, nmodes, nsegments):
     coeffs_table : 2d-array
         groups of single-mode coefficients for all segments.
     """
-    coeffs_table = np.zeros([nmodes, nsegments])
+    coeffs_table = np.zeros([nmodes, nseg])
     for qq in range(nmodes):
-        for kk in range(nsegments):
+        for kk in range(nseg):
             coeffs_table[qq, kk] = mus[qq + kk * nmodes]
 
     return coeffs_table
 
 
-def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
+def sort_1d_mus_per_actuator(mus, nmodes, nseg):
     """
     Sorts one-dimensional multi-mode tolerance values into an actuator array for the internal simulators.
 
@@ -749,7 +749,7 @@ def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
         1d array of standard deviations for all modes on each segment, in nm
     nmodes : int
         number of individual modes per segment
-    nsegments : int
+    nseg : int
         number of segments
 
     Returns
@@ -758,10 +758,10 @@ def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
         actuator holding mode coefficients array whose rows (first index) can be directly passed to the actuators of a
         segmented mirror of an internal simulator
     """
-    nactuators = nmodes * nsegments
+    nactuators = nmodes * nseg
     coeffs_mumaps = np.zeros([nmodes, nactuators])
 
-    for i, j in zip(np.tile(np.arange(nmodes), nsegments), np.arange(nactuators)):
+    for i, j in zip(np.tile(np.arange(nmodes), nseg), np.arange(nactuators)):
         coeffs_mumaps[i, j] = mus[j]
 
     return coeffs_mumaps

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -694,3 +694,63 @@ def seg_to_dm_xy(actuator_total, segment):
     actuator_pair_y = (segment-actuator_pair_x)/actuator_total
 
     return actuator_pair_x, int(actuator_pair_y)
+
+
+def sort_1d_mus(mus, nmodes, nsegments):
+    """
+    Sorts one dimensional multimode-tolerances values into 'n-multimode'
+    groups, where each group contains tolerance values for all segments for a single mode.
+    (This sorting is in sync with the way the PASTIS matrix is calculated for multimode-segment aberrations.
+    Each segment is poked n number of times with a given mode, and corresponding contrast is calculated)
+
+    Parameters
+    ----------
+    mus : ndarray
+        list of standard deviations for each segment in nm
+    nmodes : int
+        number of thermal modes
+    nsegments :  int
+        number of segments
+
+    Returns
+    -------
+    coeffs_table : ndarray
+         groups of single-mode tolerance values for all segments.
+    """
+    coeffs_table = np.zeros([nmodes, nsegments])
+    for qq in range(nmodes):
+        for kk in range(nsegments):
+            coeffs_table[qq, kk] = mus[qq + kk * nmodes]
+
+    return coeffs_table
+
+
+def calculate_mu_maps(mus, nmodes, nactuators, nsegments):
+    """
+    Sorts one dimensional multimode-tolerances values into groups of dm actuators settings.
+    Each "dm actuator setting" group contains tolerance values for one aberration mode.
+
+    Parameters
+    ----------
+    mus : ndarray
+        list of standard deviations for each segment in nm
+    nmodes : int
+        number of localized segment modes
+    num_actuators : int
+        total number of dm actuators
+    nsegments :  int
+        number of segments
+    Returns
+    -------
+    coeffs_mumaps : ndarray
+        group of single mode dm actuators settings
+    """
+    coeffs_mumaps = np.zeros([nmodes, nactuators])
+    for qq in range(nmodes):
+        coeffs_tmp = np.zeros([nactuators])
+        for kk in range(nsegments):
+            coeffs_tmp[qq + kk * nmodes] = mus[qq + kk * nmodes]  # arranged per modal basis
+        coeffs_mumaps[qq] = coeffs_tmp  # arranged into 'nmodes' groups in units of nm
+
+    return coeffs_mumaps
+

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -698,11 +698,14 @@ def seg_to_dm_xy(actuator_total, segment):
 
 def sort_1d_mus_per_segment(mus, nmodes, nsegments):
     """
-    Sorts one-dimensional multi-mode tolerance values into 'nmodes-multimode' groups.
+    Sorts one-dimensional multi-mode coefficients into 'nmodes-multimode' groups.
 
-    The resulting array sorts the tolerance values in a 2D array, with the dimensions representing the number of modes
-    and number of segments, respectively. The input tolerance values 'mus' are grouped by segment, meaning it holds
-    the tolerances as: mode1 on seg1, mode2 on seg1, ..., mode'nmodes' on seg1, mode1 on seg2, mode2 on seg2 and so on.
+    The result sorts the mode coefficients in a 2D array, with the dimensions representing the number of modes
+    and number of segments, respectively.
+
+    The input mode coefficients 'mus' need to be grouped by segment, meaning the array holds
+    the mode coefficients as:
+        mode1 on seg1, mode2 on seg1, ..., mode'nmodes' on seg1, mode1 on seg2, mode2 on seg2 and so on.
 
     Parameters
     ----------
@@ -716,7 +719,7 @@ def sort_1d_mus_per_segment(mus, nmodes, nsegments):
     Returns
     -------
     coeffs_table : 2d-array
-        groups of single-mode tolerance values for all segments.
+        groups of single-mode coefficients for all segments.
     """
     coeffs_table = np.zeros([nmodes, nsegments])
     for qq in range(nmodes):
@@ -752,7 +755,8 @@ def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
     Returns
     -------
     coeffs_mumaps : 2d-darray
-        actuator array whose rows (first index) can be directly passed to the segmented mirror of an internal simulator
+        actuator holding mode coefficients array whose rows (first index) can be directly passed to the actuators of a
+        segmented mirror of an internal simulator
     """
     nactuators = nmodes * nsegments
     coeffs_mumaps = np.zeros([nmodes, nactuators])

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -226,7 +226,7 @@ def apply_mode_to_luvoir(pmode, luvoir):
 
     This function first flattens the segmented mirror and then applies all segment coefficients from the input mode
     one by one to the segmented mirror.
-    :param pmode: array, a single PASTIS mode [nseg] or any other segment phase map in NANOMETERS
+    :param pmode: array, a single PASTIS mode [nseg] or any other segment phase map in NANOMETERS WFE
     :param luvoir: LuvoirAPLC
     :return: hcipy.Wavefront of the segmented mirror, hcipy.Wavefront of the detector plane
     """

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -698,10 +698,10 @@ def seg_to_dm_xy(actuator_total, segment):
 
 def sort_1d_mus(mus, nmodes, nsegments):
     """
-    Sorts one dimensional multimode-tolerances values into 'n-multimode'
-    groups, where each group contains tolerance values for all segments for a single mode.
+    Sorts one dimensional multimode-tolerances values into 'n-multimode' groups,
+    where each group contains tolerance values for all segments for a one kind of aberration mode.
     (This sorting is in sync with the way the PASTIS matrix is calculated for multimode-segment aberrations.
-    Each segment is poked n number of times with a given mode, and corresponding contrast is calculated)
+    Each segment is poked n types of aberration mode, one mode at a time, and corresponding contrast is calculated)
 
     Parameters
     ----------
@@ -727,16 +727,16 @@ def sort_1d_mus(mus, nmodes, nsegments):
 
 def calculate_mu_maps(mus, nmodes, nactuators, nsegments):
     """
-    Sorts one dimensional multimode-tolerances values into groups of dm actuators settings.
-    Each "dm actuator setting" group contains tolerance values for one aberration mode.
+    Sorts one dimensional multimode-tolerances values into nmodes-groups of dm actuators settings.
+    Each "dm actuator setting" group contains tolerance values for one kind of aberration mode.
 
     Parameters
     ----------
     mus : ndarray
         list of standard deviations for each segment in nm
     nmodes : int
-        number of localized segment modes
-    num_actuators : int
+        number of localized segment level aberration modes
+    nactuators : int
         total number of dm actuators
     nsegments :  int
         number of segments


### PR DESCRIPTION
This PR generates multimode static tolerance plots for the luvex and luvoir simulator.

I added additional lines to the launcher scripts, plotting.py and util.py, which computes static tolerance maps for Harris thermal modes as well localized zernike modes.

For Segment level aberrations such as Zernike/harris modes, it creates another directory named "mu_maps" inside the parent run where the pdfs of these maps are stored. 

Following is an example of 1-ring-luvex simulator, where 10 tolerance modes are saved for first 10 segment-level zernike modes. Make sure you instantiate the simulator with exact number modes, as you use before plotting

<img width="881" alt="Screen Shot 2022-10-24 at 6 08 30 PM" src="https://user-images.githubusercontent.com/33359812/197639201-38ef80cc-d7c1-4813-9048-fc28447cb9d4.png">

Below is a sample picture of one segment level-zernike mode:
<img width="858" alt="Screen Shot 2022-10-24 at 6 10 52 PM" src="https://user-images.githubusercontent.com/33359812/197639508-1b98a9d6-1f2b-472e-a4a8-7c7dc5328df6.png">


For harris mode:
here is sample of one tolerance map for 5-ring-luvex simulator:

<img width="526" alt="Screen Shot 2022-10-24 at 6 36 20 PM" src="https://user-images.githubusercontent.com/33359812/197642770-a02390a4-41e7-40ac-a8e1-afbaed079083.png">


Also, it plots tolerance values per seg per zernike mode

<img width="650" alt="Screen Shot 2022-10-24 at 7 34 08 PM" src="https://user-images.githubusercontent.com/33359812/197649542-f1e70331-7ec2-45fa-8e5e-3207b0a43c4a.png">


Also for harris mode:
<img width="833" alt="Screen Shot 2022-10-24 at 7 36 31 PM" src="https://user-images.githubusercontent.com/33359812/197649789-1ce36085-11ec-4a4c-bfc0-7916bae76427.png">




