### PR TITLE
Delta-PR no.1 for multi-mode plotting

### DIFF
--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -56,5 +56,4 @@ if __name__ == '__main__':
     ppl.plot_zernike_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
     # ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
     tel = run_matrix.simulator
-    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, tel.sm.num_actuators,
-                                       c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     # If Segmented Zernike Mirror, uncomment the following two lines
     DM = 'seg_mirror' # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    DM_SPEC = 10
+    DM_SPEC = 3
 
     NUM_RINGS = 1
 
@@ -48,12 +48,19 @@ if __name__ == '__main__':
     # Calculate the static tolerances
     c_target = 6.3*1e-11
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
-    np.savetxt(os.path.join(dir_run, 'mus_%.2e_%d.csv' % (c_target, NUM_RINGS)), mus, delimiter=',')
+    np.savetxt(os.path.join(dir_run, f'mus_{c_target:.2e}_{NUM_RINGS:d}.csv'), mus, delimiter=',')
 
-    num_modes = 10 # for harris thermal map or number of localized zernike modes = "DM_SPEC"
+    num_modes = DM_SPEC   # for harris thermal map or number of localized zernike modes = "DM_SPEC"
     nseg = run_matrix.simulator.nseg
 
-    ppl.plot_zernike_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
+    coeffs_table = util.sort_1d_mus_per_segment(mus, num_modes, nseg)
+    mu_list = []
+    label_list = []
+    for i in range(coeffs_table.shape[0]):
+        mu_list.append(coeffs_table[i])
+        label_list.append(f'Zernike mode {i}')
+
+    ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     # ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
     tel = run_matrix.simulator
     ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -67,4 +67,4 @@ if __name__ == '__main__':
 
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
-    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    ppl.plot_multimode_surface_maps(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -11,26 +11,28 @@ from pastis.pastis_analysis import  calculate_segment_constraints
 import pastis.plotting as ppl
 
 if __name__ == '__main__':
+    
+    NUM_RINGS = 1
+    WHICH_DM = 'harris_seg_mirror'   # 'harris_seg_mirror' or 'seg_mirror', or (global) 'zernike_mirror'
+    
     # DM_SPEC = tuple or int, specification for the used DM -
     # for seg_mirror: int, number of local Zernike modes on each segment
     # for harris_seg_mirror: tuple (string, array, bool, bool, bool),
     # absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets (thermal, mechanical, other)
     # for zernike_mirror: int, number of global Zernikes
 
-    # If Harris deformable mirror, uncomment the following lines
-    # DM = 'harris_seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    # fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
-    # pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
-    # DM_SPEC = (fpath, pad_orientations, True, False, False)
+    # If using Harris deformable mirror
+    if WHICH_DM == 'harris_seg_mirror':
+        fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
+        pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
+        DM_SPEC = (fpath, pad_orientations, True, False, False)
 
-    # If Segmented Zernike Mirror, uncomment the following two lines
-    DM = 'seg_mirror' # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    DM_SPEC = 3
-
-    NUM_RINGS = 1
+    # If using Segmented Zernike Mirror
+    if WHICH_DM == 'seg_mirror':
+        DM_SPEC = 3
 
     # First generate a couple of matrices
-    run_matrix = MatrixEfieldHex(which_dm=DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
+    run_matrix = MatrixEfieldHex(which_dm=WHICH_DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
                                  calc_science=True, calc_wfs=True,
                                  initial_path=CONFIG_PASTIS.get('local', 'local_data_path'), norm_one_photon=True)
     run_matrix.calc()
@@ -50,7 +52,7 @@ if __name__ == '__main__':
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
     np.savetxt(os.path.join(dir_run, f'mus_{c_target:.2e}_{NUM_RINGS:d}.csv'), mus, delimiter=',')
 
-    num_modes = DM_SPEC   # for harris thermal map or number of localized zernike modes = "DM_SPEC"
+    num_modes = 5   # for Harris thermal map or number of localized zernike modes = "DM_SPEC"
     nseg = run_matrix.simulator.nseg
 
     coeffs_table = util.sort_1d_mus_per_segment(mus, num_modes, nseg)
@@ -58,9 +60,11 @@ if __name__ == '__main__':
     label_list = []
     for i in range(coeffs_table.shape[0]):
         mu_list.append(coeffs_table[i])
-        label_list.append(f'Zernike mode {i}')
+        if WHICH_DM == 'seg_mirror':
+            label_list.append(f'Zernike mode {i}')
+    if WHICH_DM == 'harris_seg_mirror':
+        label_list = ['Faceplates Silvered', 'Bulk', 'Gradient Radial', 'Gradient X lateral', 'Gradient Z axial']
 
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
-    # ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, dir_run, save=True)
     tel = run_matrix.simulator
     ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -1,14 +1,13 @@
 import os
-import numpy as np
 from astropy.io import fits
+import numpy as np
+
 from pastis.config import CONFIG_PASTIS
 import pastis.util as util
 from pastis.matrix_generation.matrix_from_efields import MatrixEfieldHex
-from pastis.simulators.scda_telescopes import HexRingAPLC
-import hcipy
-import matplotlib.pyplot as plt
-from pastis.pastis_analysis import  calculate_segment_constraints
+from pastis.pastis_analysis import calculate_segment_constraints
 import pastis.plotting as ppl
+
 
 if __name__ == '__main__':
     

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -1,12 +1,13 @@
 import os
 from astropy.io import fits
 import numpy as np
+
 from pastis.config import CONFIG_PASTIS
 import pastis.util as util
 from pastis.matrix_generation.matrix_from_efields import MatrixEfieldLuvoirA
-from pastis.pastis_analysis import  calculate_segment_constraints
-from pastis.simulators.luvoir_imaging import LuvoirA_APLC
+from pastis.pastis_analysis import calculate_segment_constraints
 import pastis.plotting as ppl
+
 
 if __name__ == '__main__':
 

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -54,5 +54,4 @@ if __name__ == '__main__':
     ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, out_dir=dir_run, save=True)
 
     tel = run_matrix.simulator
-    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, tel.sm.num_actuators,
-                                       c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -9,25 +9,29 @@ from pastis.simulators.luvoir_imaging import LuvoirA_APLC
 import pastis.plotting as ppl
 
 if __name__ == '__main__':
+
+    NUM_RINGS = 1
+    WHICH_DM = 'harris_seg_mirror'   # 'harris_seg_mirror' or 'seg_mirror', or (global) 'zernike_mirror'
+
     # DM_SPEC = tuple or int, specification for the used DM -
     # for seg_mirror: int, number of local Zernike modes on each segment
     # for harris_seg_mirror: tuple (string, array, bool, bool, bool),
     # absolute path to Harris spreadsheet, pad orientations, choice of Harris mode sets (thermal, mechanical, other)
     # for zernike_mirror: int, number of global Zernikes
 
-    # If Harris deformable mirror, uncomment the following lines
-    # DM = 'harris_seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    # fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
-    # pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
-    # DM_SPEC = (fpath, pad_orientations, True, False, False)
+    # If using Harris deformable mirror
+    if WHICH_DM == 'harris_seg_mirror':
+        fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
+        pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
+        DM_SPEC = (fpath, pad_orientations, True, False, False)
 
-    # If Segmented Zernike Mirror, uncomment the following lines
-    DM = 'seg_mirror'  # Possible: "seg_mirror", "harris_seg_mirror", "zernike_mirror"
-    DM_SPEC = 5
+    # If using Segmented Zernike Mirror
+    if WHICH_DM == 'seg_mirror':
+        DM_SPEC = 3
 
     APLC_DESIGN = 'small'
     # First generate a couple of matrices
-    run_matrix = MatrixEfieldLuvoirA(which_dm=DM, dm_spec=DM_SPEC, design=APLC_DESIGN,
+    run_matrix = MatrixEfieldLuvoirA(which_dm=WHICH_DM, dm_spec=DM_SPEC, design=APLC_DESIGN,
                                      calc_science=True, calc_wfs=True,
                                      initial_path=CONFIG_PASTIS.get('local', 'local_data_path'),
                                      norm_one_photon=True)
@@ -35,7 +39,7 @@ if __name__ == '__main__':
     dir_run = run_matrix.overall_dir
     print(f'All saved to {dir_run}.')
 
-    # Calculate and save per segment static tolerance
+    # get the automatically saved pastis_matrix
     pastis_matrix = fits.getdata(os.path.join(dir_run, 'matrix_numerical', 'pastis_matrix.fits'))
 
     # get the unaberrated coro_psf after the matrix run
@@ -43,15 +47,24 @@ if __name__ == '__main__':
     dh_mask = np.array(run_matrix.simulator.dh_mask.shaped)
     contrast_floor = util.dh_mean(e0_psf, dh_mask)
 
-    # set the target contrast
+    # Calculate the static tolerances
     c_target = 5.3*1e-11
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
-    np.savetxt(os.path.join(dir_run, 'mu_map_%s.csv' % c_target), mus, delimiter=',')
+    np.savetxt(os.path.join(dir_run, f'mu_map_{c_target:.2e}.csv'), mus, delimiter=',')
 
     num_modes = 5  # for harris thermal map or number of localized zernike modes
     nseg = run_matrix.simulator.nseg
 
-    ppl.plot_thermal_mus(mus, num_modes, nseg, c_target, out_dir=dir_run, save=True)
+    coeffs_table = util.sort_1d_mus_per_segment(mus, num_modes, nseg)
+    mu_list = []
+    label_list = []
+    for i in range(coeffs_table.shape[0]):
+        mu_list.append(coeffs_table[i])
+        if WHICH_DM == 'seg_mirror':
+            label_list.append(f'Zernike mode {i}')
+    if WHICH_DM == 'harris_seg_mirror':
+        label_list = ['Faceplates Silvered', 'Bulk', 'Gradient Radial', 'Gradient X lateral', 'Gradient Z axial']
 
+    ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
     ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -67,4 +67,4 @@ if __name__ == '__main__':
 
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
-    ppl.plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    ppl.plot_multimode_surface_maps(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -11,7 +11,6 @@ import pastis.plotting as ppl
 
 if __name__ == '__main__':
 
-    NUM_RINGS = 1
     WHICH_DM = 'harris_seg_mirror'   # 'harris_seg_mirror' or 'seg_mirror', or (global) 'zernike_mirror'
 
     # DM_SPEC = tuple or int, specification for the used DM -

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -997,48 +997,6 @@ def natural_keys(text):
     return [atoi(c) for c in re.split(r'(\d+)', text)]
 
 
-def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
-    """
-    Plot modal constraints plot for individual segment.
-
-    Parameters
-    ----------
-    mus : ndarray
-        list of standard deviations for each segment in nm
-    nmodes : int
-        number of thermal modes
-    nsegments :  int
-        number of segments
-    c_target : scalar
-        target contrast
-    out_dir : str
-        path to save the plot, if save=True
-    save : bool
-        whether to save the plot, if False, it shows the plot
-    """
-
-    harris_coeffs_table = pastis.util.sort_1d_mus_per_segment(mus, nmodes, nsegments)
-
-    plt.figure(figsize=(10, 10))
-    plt.title("Modal constraints to achieve a dark hole contrast of %.2e" % c_target, fontsize=20)
-    plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
-    plt.xlabel("Segment Number", fontsize=20)
-    plt.tick_params(top=True, bottom=True, left=True, right=True, labelleft=True, labelbottom=True, labelsize=20)
-    plt.plot(harris_coeffs_table[0]*1e3, label="Faceplates Silvered")
-    plt.plot(harris_coeffs_table[1]*1e3, label="Bulk")
-    plt.plot(harris_coeffs_table[2]*1e3, label="Gradiant Radial")
-    plt.plot(harris_coeffs_table[3]*1e3, label="Gradiant X lateral")
-    plt.plot(harris_coeffs_table[4]*1e3, label="Gradient Z axial")
-    plt.grid()
-    plt.legend(fontsize=15)
-    plt.tight_layout()
-    if save:
-        fname = f'stat_1d_mus_{c_target}'
-        plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))
-    else:
-        plt.show()
-
-
 def plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, data_dir, mirror, cmin, cmax, save=False):
     """
     Creates surface deformation tolerance maps for localized wavefront aberrations.

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -997,7 +997,7 @@ def natural_keys(text):
     return [atoi(c) for c in re.split(r'(\d+)', text)]
 
 
-def plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, data_dir, mirror, cmin, cmax, save=False):
+def plot_multimode_surface_maps(tel, mus, num_modes, c_target, data_dir, mirror, cmin, cmax, save=False):
     """
     Creates surface deformation tolerance maps for localized wavefront aberrations.
 

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -435,7 +435,7 @@ def plot_segment_weights(mus, out_dir, c_target, labels=None, fname=None, save=F
     :param mus: array or list of arrays, segment requirements in nm
     :param out_dir: str, output path to save the figure to if save=True
     :param c_target: float, target contrast for which the mode weights have been calculated
-    :param labels: tuple, optional, labels for the different lists of sigmas provided
+    :param labels: list, optional, labels for the different lists of sigmas provided
     :param fname: str, optional, file name to save plot to
     :param save: bool, whether to save to disk or not, default is False
     """
@@ -445,12 +445,15 @@ def plot_segment_weights(mus, out_dir, c_target, labels=None, fname=None, save=F
     # Figure out how many sets of mode coefficients per segment we have
     if isinstance(mus, list):
         sets = len(mus)
-        if labels is None:
-            raise AttributeError('A tuple of labels needs to be defined when more than one set of mus is provided.')
+        if sets > 1:
+            if labels is None:
+                raise AttributeError('A list of labels needs to be defined when more than one set of mus is provided.')
+        elif sets == 1:
+            mus = mus[0]
     elif isinstance(mus, np.ndarray) and mus.ndim == 1:
         sets = 1
     else:
-        raise AttributeError('Segment weights "mus" must be an array of values, or a tuple of such arrays.')
+        raise AttributeError('Segment weights "mus" must be a 1d array of values, or a list of such arrays.')
 
     plt.figure(figsize=(12, 8))
     if sets == 1:

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -428,23 +428,22 @@ def plot_covariance_matrix(covariance_matrix, out_dir, c_target, segment_space=T
         plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))
 
 
-def plot_segment_weights(mus, out_dir, c_target, labels=None, fname_suffix='', save=False):
+def plot_segment_weights(mus, out_dir, c_target, labels=None, fname=None, save=False):
     """
     Plot segment weights against segment index, in units of picometers (converted from input).
-    :param mus: array or list, segment requirements in nm
+
+    :param mus: array or list of arrays, segment requirements in nm
     :param out_dir: str, output path to save the figure to if save=True
     :param c_target: float, target contrast for which the mode weights have been calculated
     :param labels: tuple, optional, labels for the different lists of sigmas provided
-    :param fname_suffix: str, optional, suffix to add to the saved file name
+    :param fname: str, optional, file name to save plot to
     :param save: bool, whether to save to disk or not, default is False
-    :return:
     """
-    fname = f'segment_requirements_{c_target}'
-    if fname_suffix != '':
-        fname += f'_{fname_suffix}'
+    if fname is None:
+        fname = f'segment_requirements_{c_target:.2e}'
 
-    # Figure out how many sets of sigmas we have
-    if isinstance(mus, tuple):
+    # Figure out how many sets of mode coefficients per segment we have
+    if isinstance(mus, list):
         sets = len(mus)
         if labels is None:
             raise AttributeError('A tuple of labels needs to be defined when more than one set of mus is provided.')
@@ -464,6 +463,7 @@ def plot_segment_weights(mus, out_dir, c_target, labels=None, fname_suffix='', s
     plt.tick_params(axis='both', which='both', length=6, width=2, labelsize=30)
     if labels is not None:
         plt.legend(prop={'size': 25}, loc=(0.15, 0.73))
+    plt.grid()
     plt.tight_layout()
 
     if save:
@@ -1032,49 +1032,6 @@ def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
     plt.grid()
     plt.legend(fontsize=15)
     plt.tight_layout()
-    if save:
-        fname = f'stat_1d_mus_{c_target}'
-        plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))
-    else:
-        plt.show()
-
-
-def plot_zernike_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
-    """
-    Plot localized zernike modal constraints plot for individual segment.
-
-    Parameters
-    ----------
-    mus : ndarray
-        list of standard deviations for each segment in nm
-    nmodes : int
-        number of thermal modes
-    nsegments :  int
-        number of segments
-    c_target : scalar
-        target contrast
-    out_dir : str
-        path to save the plot, if save=True
-    save : bool
-        whether to save the plot, if False, it shows the plot
-    """
-
-    coeffs_table = pastis.util.sort_1d_mus_per_segment(mus, nmodes, nsegments)
-
-    plt.figure(figsize=(10, 10))
-    plt.title("Modal constraints to achieve a dark hole contrast of %.2e" % c_target, fontsize=20)
-    plt.ylabel("Weight per segment (in units of pm)", fontsize=15)
-    plt.xlabel("Segment Number", fontsize=20)
-    plt.tick_params(top=True, bottom=True, left=True, right=True,
-                    labelleft=True, labelbottom=True, labelsize=20)
-
-    for i in range(nmodes):
-        plt.plot(coeffs_table[i]*1e3, label='Zernike mode: %s' % i)
-
-    plt.grid()
-    plt.legend(fontsize=15)
-    plt.tight_layout()
-
     if save:
         fname = f'stat_1d_mus_{c_target}'
         plt.savefig(os.path.join(out_dir, '.'.join([fname, 'pdf'])))

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1082,8 +1082,7 @@ def plot_zernike_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
         plt.show()
 
 
-def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target, data_dir,
-                                   mirror, cmin, cmax, save=False):
+def plot_multimode_mus_surface_map(tel, mus, num_modes, c_target, data_dir, mirror, cmin, cmax, save=False):
     """
     Creates surface deformation tolerance maps for localized wavefront aberrations.
 
@@ -1095,8 +1094,6 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
         the total number of local modes used to poke a segment.
         For a harris segment mirror  it is 5 (taking only thermal basis map).
         For a segmented mirror, it represents the total number of local zernike modes.
-    num_actuators : int
-        total number of dm actuators
     c_target : float
         desired dark hole contrast for which the tolerancing is done
     data_dir :  str

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1110,7 +1110,7 @@ def plot_multimode_mus_surface_map(tel, mus, num_modes, num_actuators, c_target,
     """
     nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
 
-    coeffs_mumaps = pastis.util.calculate_mu_maps(mus, num_modes, num_actuators, tel.nseg)
+    coeffs_mumaps = pastis.util.sort_1d_mus_per_actuator(mus, num_modes, tel.nseg)
 
     mu_maps = []
     for qq in range(num_modes):

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1017,7 +1017,7 @@ def plot_thermal_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
         whether to save the plot, if False, it shows the plot
     """
 
-    harris_coeffs_table = pastis.util.sort_1d_mus(mus, nmodes, nsegments)
+    harris_coeffs_table = pastis.util.sort_1d_mus_per_segment(mus, nmodes, nsegments)
 
     plt.figure(figsize=(10, 10))
     plt.title("Modal constraints to achieve a dark hole contrast of %.2e" % c_target, fontsize=20)
@@ -1059,7 +1059,7 @@ def plot_zernike_mus(mus, nmodes, nsegments, c_target, out_dir, save=False):
         whether to save the plot, if False, it shows the plot
     """
 
-    coeffs_table = pastis.util.sort_1d_mus(mus, nmodes, nsegments)
+    coeffs_table = pastis.util.sort_1d_mus_per_segment(mus, nmodes, nsegments)
 
     plt.figure(figsize=(10, 10))
     plt.title("Modal constraints to achieve a dark hole contrast of %.2e" % c_target, fontsize=20)

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -698,24 +698,25 @@ def seg_to_dm_xy(actuator_total, segment):
 
 def sort_1d_mus(mus, nmodes, nsegments):
     """
-    Sorts one dimensional multimode-tolerances values into 'n-multimode' groups,
-    where each group contains tolerance values for all segments for a one kind of aberration mode.
-    (This sorting is in sync with the way the PASTIS matrix is calculated for multimode-segment aberrations.
-    Each segment is poked n types of aberration mode, one mode at a time, and corresponding contrast is calculated)
+    Sorts one-dimensional multi-mode tolerance values into 'nmodes-multimode' groups.
+
+    The resulting array sorts the tolerance values in a 2D array, with the dimensions representing the number of modes
+    and number of segments, respectively. The input tolerance values 'mus' are grouped by segment, meaning it holds
+    the tolerances as: mode1 on seg1, mode2 on seg1, ..., mode'nmodes' on seg1, mode1 on seg2, mode2 on seg2 and so on.
 
     Parameters
     ----------
-    mus : ndarray
-        list of standard deviations for each segment in nm
+    mus : 1d-array
+        1d array of standard deviations for all modes on each segment, in nm
     nmodes : int
-        number of thermal modes
-    nsegments :  int
+        number of individual modes per segment
+    nsegments : int
         number of segments
 
     Returns
     -------
-    coeffs_table : ndarray
-         groups of single-mode tolerance values for all segments.
+    coeffs_table : 2d-array
+        groups of single-mode tolerance values for all segments.
     """
     coeffs_table = np.zeros([nmodes, nsegments])
     for qq in range(nmodes):

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -696,7 +696,7 @@ def seg_to_dm_xy(actuator_total, segment):
     return actuator_pair_x, int(actuator_pair_y)
 
 
-def sort_1d_mus(mus, nmodes, nsegments):
+def sort_1d_mus_per_segment(mus, nmodes, nsegments):
     """
     Sorts one-dimensional multi-mode tolerance values into 'nmodes-multimode' groups.
 

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -728,23 +728,31 @@ def sort_1d_mus_per_segment(mus, nmodes, nsegments):
 
 def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
     """
-    Sorts one dimensional multimode-tolerances values into nmodes-groups of dm actuators settings.
-    Each "dm actuator setting" group contains tolerance values for one kind of aberration mode.
+    Sorts one-dimensional multi-mode tolerance values into an actuator array for the internal simulators.
+
+    The resulting array sorts the mode coefficients into a 2D array, with the dimensions representing the number of
+    input mode and number of actuators, respectively. Each row of the 2D output array (first index) is a valid array to
+    be passed directly to the actuators of a segmented mirror of an internal simulator.
+    Following the convention of the internal simulators, the number of actuators is calculated as the product of local
+    modes times all segments.
+
+    The input mode coefficients 'mus' need to be grouped by segment, meaning the array holds
+    the mode coefficients as:
+        mode1 on seg1, mode2 on seg1, ..., mode'nmodes' on seg1, mode1 on seg2, mode2 on seg2 and so on.
 
     Parameters
     ----------
-    mus : ndarray
-        list of standard deviations for each segment in nm
+    mus : 1d-darray
+        1d array of standard deviations for all modes on each segment, in nm
     nmodes : int
-        number of localized segment level aberration modes
-    nactuators : int
-        total number of dm actuators
-    nsegments :  int
+        number of individual modes per segment
+    nsegments : int
         number of segments
+
     Returns
     -------
-    coeffs_mumaps : ndarray
-        group of single mode dm actuators settings
+    coeffs_mumaps : 2d-darray
+        actuator array whose rows (first index) can be directly passed to the segmented mirror of an internal simulator
     """
     nactuators = nmodes * nsegments
     coeffs_mumaps = np.zeros([nmodes, nactuators])

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -722,9 +722,9 @@ def sort_1d_mus_per_segment(mus, nmodes, nseg):
         groups of single-mode coefficients for all segments.
     """
     coeffs_table = np.zeros([nmodes, nseg])
-    for qq in range(nmodes):
-        for kk in range(nseg):
-            coeffs_table[qq, kk] = mus[qq + kk * nmodes]
+    for mode in range(nmodes):
+        for seg in range(nseg):
+            coeffs_table[mode, seg] = mus[mode + seg * nmodes]
 
     return coeffs_table
 
@@ -761,7 +761,7 @@ def sort_1d_mus_per_actuator(mus, nmodes, nseg):
     nactuators = nmodes * nseg
     coeffs_mumaps = np.zeros([nmodes, nactuators])
 
-    for i, j in zip(np.tile(np.arange(nmodes), nseg), np.arange(nactuators)):
-        coeffs_mumaps[i, j] = mus[j]
+    for mode, act in zip(np.tile(np.arange(nmodes), nseg), np.arange(nactuators)):
+        coeffs_mumaps[mode, act] = mus[act]
 
     return coeffs_mumaps

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -726,7 +726,7 @@ def sort_1d_mus_per_segment(mus, nmodes, nsegments):
     return coeffs_table
 
 
-def calculate_mu_maps(mus, nmodes, nactuators, nsegments):
+def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
     """
     Sorts one dimensional multimode-tolerances values into nmodes-groups of dm actuators settings.
     Each "dm actuator setting" group contains tolerance values for one kind of aberration mode.

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -746,12 +746,10 @@ def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
     coeffs_mumaps : ndarray
         group of single mode dm actuators settings
     """
+    nactuators = nmodes * nsegments
     coeffs_mumaps = np.zeros([nmodes, nactuators])
-    for qq in range(nmodes):
-        coeffs_tmp = np.zeros([nactuators])
-        for kk in range(nsegments):
-            coeffs_tmp[qq + kk * nmodes] = mus[qq + kk * nmodes]  # arranged per modal basis
-        coeffs_mumaps[qq] = coeffs_tmp  # arranged into 'nmodes' groups in units of nm
+
+    for i, j in zip(np.tile(np.arange(nmodes), nsegments), np.arange(nactuators)):
+        coeffs_mumaps[i, j] = mus[j]
 
     return coeffs_mumaps
-

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -1,7 +1,6 @@
 """
 Helper functions for PASTIS.
 """
-
 import glob
 import os
 import datetime

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -696,7 +696,7 @@ def seg_to_dm_xy(actuator_total, segment):
     return actuator_pair_x, int(actuator_pair_y)
 
 
-def sort_1d_mus_per_segment(mus, nmodes, nsegments):
+def sort_1d_mus_per_segment(mus, nmodes, nseg):
     """
     Sorts one-dimensional multi-mode coefficients into 'nmodes-multimode' groups.
 
@@ -713,7 +713,7 @@ def sort_1d_mus_per_segment(mus, nmodes, nsegments):
         1d array of standard deviations for all modes on each segment, in nm
     nmodes : int
         number of individual modes per segment
-    nsegments : int
+    nseg : int
         number of segments
 
     Returns
@@ -721,15 +721,15 @@ def sort_1d_mus_per_segment(mus, nmodes, nsegments):
     coeffs_table : 2d-array
         groups of single-mode coefficients for all segments.
     """
-    coeffs_table = np.zeros([nmodes, nsegments])
+    coeffs_table = np.zeros([nmodes, nseg])
     for qq in range(nmodes):
-        for kk in range(nsegments):
+        for kk in range(nseg):
             coeffs_table[qq, kk] = mus[qq + kk * nmodes]
 
     return coeffs_table
 
 
-def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
+def sort_1d_mus_per_actuator(mus, nmodes, nseg):
     """
     Sorts one-dimensional multi-mode tolerance values into an actuator array for the internal simulators.
 
@@ -749,7 +749,7 @@ def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
         1d array of standard deviations for all modes on each segment, in nm
     nmodes : int
         number of individual modes per segment
-    nsegments : int
+    nseg : int
         number of segments
 
     Returns
@@ -758,10 +758,10 @@ def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
         actuator holding mode coefficients array whose rows (first index) can be directly passed to the actuators of a
         segmented mirror of an internal simulator
     """
-    nactuators = nmodes * nsegments
+    nactuators = nmodes * nseg
     coeffs_mumaps = np.zeros([nmodes, nactuators])
 
-    for i, j in zip(np.tile(np.arange(nmodes), nsegments), np.arange(nactuators)):
+    for i, j in zip(np.tile(np.arange(nmodes), nseg), np.arange(nactuators)):
         coeffs_mumaps[i, j] = mus[j]
 
     return coeffs_mumaps

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -698,11 +698,14 @@ def seg_to_dm_xy(actuator_total, segment):
 
 def sort_1d_mus_per_segment(mus, nmodes, nsegments):
     """
-    Sorts one-dimensional multi-mode tolerance values into 'nmodes-multimode' groups.
+    Sorts one-dimensional multi-mode coefficients into 'nmodes-multimode' groups.
 
-    The resulting array sorts the tolerance values in a 2D array, with the dimensions representing the number of modes
-    and number of segments, respectively. The input tolerance values 'mus' are grouped by segment, meaning it holds
-    the tolerances as: mode1 on seg1, mode2 on seg1, ..., mode'nmodes' on seg1, mode1 on seg2, mode2 on seg2 and so on.
+    The result sorts the mode coefficients in a 2D array, with the dimensions representing the number of modes
+    and number of segments, respectively.
+
+    The input mode coefficients 'mus' need to be grouped by segment, meaning the array holds
+    the mode coefficients as:
+        mode1 on seg1, mode2 on seg1, ..., mode'nmodes' on seg1, mode1 on seg2, mode2 on seg2 and so on.
 
     Parameters
     ----------
@@ -716,7 +719,7 @@ def sort_1d_mus_per_segment(mus, nmodes, nsegments):
     Returns
     -------
     coeffs_table : 2d-array
-        groups of single-mode tolerance values for all segments.
+        groups of single-mode coefficients for all segments.
     """
     coeffs_table = np.zeros([nmodes, nsegments])
     for qq in range(nmodes):
@@ -752,7 +755,8 @@ def sort_1d_mus_per_actuator(mus, nmodes, nsegments):
     Returns
     -------
     coeffs_mumaps : 2d-darray
-        actuator array whose rows (first index) can be directly passed to the segmented mirror of an internal simulator
+        actuator holding mode coefficients array whose rows (first index) can be directly passed to the actuators of a
+        segmented mirror of an internal simulator
     """
     nactuators = nmodes * nsegments
     coeffs_mumaps = np.zeros([nmodes, nactuators])


### PR DESCRIPTION
I suggest some changes in this PR that will make #141 slimmer while preserving all its new features.

In this PR, I:
- cleaned out and clarified the docstrings of all new functions
- simplified the new util functions that sort mode coefficients values in various ways
- removed showing of plots if not saved, otherwise there is no way to run the code silently. A `plt.show()` can always be set outside the plotting function itself if needed.
- consolidated `plot_zernike_mus()` with the already existing function `plot_segment_weights()` that does exactly that
- consolidated `plot_thermal_mus()` with the already existing function `plot_segment_weights()` that does exactly that

I also noticed that the thermal Harris mode map plotting does not work for Luvex launcher on the latest commit of #141 (9fcd41193700d53f320f4f683d5d6963dff2a663), or it is unclear how to set up the launcher for that. But we can work on this after we merge this PR into #141, and then I can do the second delta-PR, which will also implement a barebones analysis to be called from the launchers.

Note how this PR is not going into `develop` but into another branch, so there are no tests, just want your eyes on this before merging @ananyasahoo1904 