### PR TITLE
Delta-PR no.2 for multi-mode plotting

### DIFF
--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
         NUM_MODES = 5  # TODO: works only for thermal modes currently
 
     # If using Segmented Zernike Mirror
-    if WHICH_DM == 'seg_mirror':
+    if WHICH_DM in ['seg_mirror', 'zernike_mirror']:
         DM_SPEC = 3
         NUM_MODES = DM_SPEC
 

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -25,10 +25,12 @@ if __name__ == '__main__':
         fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
         pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
         DM_SPEC = (fpath, pad_orientations, True, False, False)
+        NUM_MODES = 5  # TODO: works only for thermal modes currently
 
     # If using Segmented Zernike Mirror
     if WHICH_DM == 'seg_mirror':
         DM_SPEC = 3
+        NUM_MODES = DM_SPEC
 
     # First generate a couple of matrices
     run_matrix = MatrixEfieldHex(which_dm=WHICH_DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
@@ -51,10 +53,8 @@ if __name__ == '__main__':
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
     np.savetxt(os.path.join(dir_run, f'mus_{c_target:.2e}_{NUM_RINGS:d}.csv'), mus, delimiter=',')
 
-    num_modes = 5   # for Harris thermal map or number of localized zernike modes = "DM_SPEC"
     nseg = run_matrix.simulator.nseg
-
-    coeffs_table = util.sort_1d_mus_per_segment(mus, num_modes, nseg)
+    coeffs_table = util.sort_1d_mus_per_segment(mus, NUM_MODES, nseg)
     mu_list = []
     label_list = []
     for i in range(coeffs_table.shape[0]):
@@ -67,4 +67,5 @@ if __name__ == '__main__':
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
     os.makedirs(os.path.join(dir_run, 'mu_maps'), exist_ok=True)
-    ppl.plot_multimode_surface_maps(tel, mus, num_modes, mirror=WHICH_DM, cmin=-5, cmax=5, data_dir=dir_run, fname='stat_mu_maps')
+    ppl.plot_multimode_surface_maps(tel, mus, NUM_MODES, mirror=WHICH_DM, cmin=-5, cmax=5,
+                                    data_dir=dir_run, fname='stat_mu_maps')

--- a/pastis/launchers/run_luvex_efields.py
+++ b/pastis/launchers/run_luvex_efields.py
@@ -66,4 +66,5 @@ if __name__ == '__main__':
 
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
-    ppl.plot_multimode_surface_maps(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    os.makedirs(os.path.join(dir_run, 'mu_maps'), exist_ok=True)
+    ppl.plot_multimode_surface_maps(tel, mus, num_modes, mirror=WHICH_DM, cmin=-5, cmax=5, data_dir=dir_run, fname='stat_mu_maps')

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -67,4 +67,5 @@ if __name__ == '__main__':
 
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
-    ppl.plot_multimode_surface_maps(tel, mus, num_modes, c_target, dir_run, mirror='sm', cmin=-5, cmax=5, save=True)
+    os.makedirs(os.path.join(dir_run, 'mu_maps'), exist_ok=True)
+    ppl.plot_multimode_surface_maps(tel, mus, num_modes, mirror=WHICH_DM, cmin=-5, cmax=5, data_dir=dir_run, fname='stat_mu_maps')

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -24,10 +24,12 @@ if __name__ == '__main__':
         fpath = CONFIG_PASTIS.get('LUVOIR', 'harris_data_path')  # path to Harris spreadsheet
         pad_orientations = np.pi / 2 * np.ones(CONFIG_PASTIS.getint('LUVOIR', 'nb_subapertures'))
         DM_SPEC = (fpath, pad_orientations, True, False, False)
+        NUM_MODES = 5  # TODO: works only for thermal modes currently
 
     # If using Segmented Zernike Mirror
     if WHICH_DM == 'seg_mirror':
         DM_SPEC = 3
+        NUM_MODES = DM_SPEC
 
     APLC_DESIGN = 'small'
     # First generate a couple of matrices
@@ -52,10 +54,8 @@ if __name__ == '__main__':
     mus = calculate_segment_constraints(pastis_matrix, c_target=c_target, coronagraph_floor=contrast_floor)
     np.savetxt(os.path.join(dir_run, f'mu_map_{c_target:.2e}.csv'), mus, delimiter=',')
 
-    num_modes = 5  # for harris thermal map or number of localized zernike modes
     nseg = run_matrix.simulator.nseg
-
-    coeffs_table = util.sort_1d_mus_per_segment(mus, num_modes, nseg)
+    coeffs_table = util.sort_1d_mus_per_segment(mus, NUM_MODES, nseg)
     mu_list = []
     label_list = []
     for i in range(coeffs_table.shape[0]):
@@ -68,4 +68,4 @@ if __name__ == '__main__':
     ppl.plot_segment_weights(mu_list, dir_run, c_target, labels=label_list, fname=f'stat_1d_mus_{c_target:.2e}', save=True)
     tel = run_matrix.simulator
     os.makedirs(os.path.join(dir_run, 'mu_maps'), exist_ok=True)
-    ppl.plot_multimode_surface_maps(tel, mus, num_modes, mirror=WHICH_DM, cmin=-5, cmax=5, data_dir=dir_run, fname='stat_mu_maps')
+    ppl.plot_multimode_surface_maps(tel, mus, NUM_MODES, mirror=WHICH_DM, cmin=-5, cmax=5, data_dir=dir_run, fname='stat_mu_maps')

--- a/pastis/launchers/run_luvoir_efields.py
+++ b/pastis/launchers/run_luvoir_efields.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
         NUM_MODES = 5  # TODO: works only for thermal modes currently
 
     # If using Segmented Zernike Mirror
-    if WHICH_DM == 'seg_mirror':
+    if WHICH_DM in ['seg_mirror', 'zernike_mirror']:
         DM_SPEC = 3
         NUM_MODES = DM_SPEC
 

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1036,10 +1036,10 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
     for mode in range(num_modes):
         coeffs = mus_per_actuator[mode]
         if mirror == 'harris_seg_mirror':
-            tel.harris_sm.actuators = coeffs / 2
+            tel.harris_sm.actuators = coeffs * 1e-9 / 2  # in meters of surface
             mu_maps.append(tel.harris_sm.surface)  # in m
         if mirror == 'seg_mirror':
-            tel.sm.actuators = coeffs / 2
+            tel.sm.actuators = coeffs * 1e-9 / 2  # in meters of surface
             mu_maps.append(tel.sm.surface)  # in m
 
     plot_norm = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -477,7 +477,7 @@ def plot_mu_map(instrument, mus, sim_instance, out_dir, c_target, limits=None, f
     """
     Plot the segment requirement map for a specific target contrast.
     :param instrument: string, "LUVOIR", "HiCAT" or "JWST"
-    :param mus: array or list, segment requirements (standard deviations) in nm
+    :param mus: array or list, segment requirements (standard deviations) in nm WFE
     :param sim_instance: class instance of the simulator for "instrument"
     :param out_dir: str, output path to save the figure to if save=True
     :param c_target: float, target contrast for which the segment requirements have been calculated
@@ -1002,9 +1002,9 @@ def natural_keys(text):
 
 def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_dir=None, fname=None):
     """
-    Creates surface deformation maps for localized wavefront aberrations.
+    Creates surface deformation maps (not WFE) for localized wavefront aberrations.
 
-    The input mode coefficients 'mus' need to be grouped by segment, meaning the array holds
+    The input mode coefficients 'mus' are in units of *WFE* and need to be grouped by segment, meaning the array holds
     the mode coefficients as:
         mode1 on seg1, mode2 on seg1, ..., mode'nmodes' on seg1, mode1 on seg2, mode2 on seg2 and so on.
 
@@ -1013,7 +1013,7 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
     tel : class instance of internal simulator
         the simulator to plot the surface maps for
     mus : 1d array
-        1d array of standard deviations for all modes on each segment, in nm
+        1d array of standard deviations for all modes on each segment, in nm WFE
     num_modes : int
         number of local modes used to poke each segment
     mirror : str
@@ -1028,7 +1028,7 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
         file name for surface maps saved to disk
     """
     if fname is None:
-        fname = f'map_on_{mirror}'
+        fname = f'surface_on_{mirror}'
 
     nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
     coeffs_mumaps = pastis.util.sort_1d_mus_per_actuator(mus, num_modes, tel.nseg)  # in nm
@@ -1038,7 +1038,7 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
         coeffs = coeffs_mumaps[mode]
         if mirror == 'harris_seg_mirror':
             tel.harris_sm.actuators = coeffs * nm_aber / 2
-            mu_maps.append(tel.harris_sm.surface)
+            mu_maps.append(tel.harris_sm.surface)  # in m
         if mirror == 'seg_mirror':
             tel.sm.actuators = coeffs * nm_aber / 2
             mu_maps.append(tel.sm.surface)  # in m
@@ -1050,7 +1050,7 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
         plt.tick_params(top=False, bottom=True, left=True, right=False, labelleft=True, labelbottom=True)
         cbar = plt.colorbar()
         cbar.ax.tick_params(labelsize=10)
-        cbar.set_label("pm", fontsize=10)
+        cbar.set_label("Surface (pm)", fontsize=10)
         plt.tight_layout()
 
         if data_dir is not None:

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1030,17 +1030,16 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
     if fname is None:
         fname = f'surface_on_{mirror}'
 
-    nm_aber = CONFIG_PASTIS.getfloat('LUVOIR', 'calibration_aberration') * 1e-9
     coeffs_mumaps = pastis.util.sort_1d_mus_per_actuator(mus, num_modes, tel.nseg)  # in nm
 
     mu_maps = []
     for mode in range(num_modes):
         coeffs = coeffs_mumaps[mode]
         if mirror == 'harris_seg_mirror':
-            tel.harris_sm.actuators = coeffs * nm_aber / 2
+            tel.harris_sm.actuators = coeffs / 2
             mu_maps.append(tel.harris_sm.surface)  # in m
         if mirror == 'seg_mirror':
-            tel.sm.actuators = coeffs * nm_aber / 2
+            tel.sm.actuators = coeffs / 2
             mu_maps.append(tel.sm.surface)  # in m
 
     plot_norm = TwoSlopeNorm(vcenter=0, vmin=cmin, vmax=cmax)

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1030,11 +1030,11 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
     if fname is None:
         fname = f'surface_on_{mirror}'
 
-    coeffs_mumaps = pastis.util.sort_1d_mus_per_actuator(mus, num_modes, tel.nseg)  # in nm
+    mus_per_actuator = pastis.util.sort_1d_mus_per_actuator(mus, num_modes, tel.nseg)  # in nm
 
     mu_maps = []
     for mode in range(num_modes):
-        coeffs = coeffs_mumaps[mode]
+        coeffs = mus_per_actuator[mode]
         if mirror == 'harris_seg_mirror':
             tel.harris_sm.actuators = coeffs / 2
             mu_maps.append(tel.harris_sm.surface)  # in m

--- a/pastis/util.py
+++ b/pastis/util.py
@@ -226,7 +226,7 @@ def apply_mode_to_luvoir(pmode, luvoir):
 
     This function first flattens the segmented mirror and then applies all segment coefficients from the input mode
     one by one to the segmented mirror.
-    :param pmode: array, a single PASTIS mode [nseg] or any other segment phase map in NANOMETERS
+    :param pmode: array, a single PASTIS mode [nseg] or any other segment phase map in NANOMETERS WFE
     :param luvoir: LuvoirAPLC
     :return: hcipy.Wavefront of the segmented mirror, hcipy.Wavefront of the detector plane
     """


### PR DESCRIPTION
This is a follow-up to #142 and a delta-PR into #141.

In this PR:
- The multi-mode plotting functions is way more useful than just for tolerances, so I made it less specific to that by removing any reference to tolerance values. 
- I simplified the saving keyword to reduce one function variable, I intend to do this for other functions in the repo too.
- I clarified which of the input and output variables are in units of surface and which in units of WFE.
- I removed the `nm_aber` factor in the mode plotting as this was just an arbitrary scale factor. It happens to me one currently, but since this parameter is only used as an input to the matrix generation, it should not be used as a unit check in other places. See also https://github.com/spacetelescope/PASTIS/pull/141#discussion_r1008935479.
- I unified the file output names and file structure to what the repo has been doing for the analysis so far. I am willing to change this if there is a reason, otherwise I would like to keep this consistent to be able to run re-analyses without hickups.

I have not put the analysis in an external script yet, I will do that in a separate PR and after #141 is merged. This will be done in #144.

@asahooexo please have a look and test various telescope cases. I only had time to test for a 1-Hex telescope and that works fine, with the same outputs like before.
