### PR TITLE
Fix path error in tolerance plots.

### DIFF
--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1223,5 +1223,5 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
 
         if data_dir is not None:
             os.makedirs(os.path.join(data_dir, 'mu_maps'), exist_ok=True)
-            fname += f'_mode_{i}.pdf'
-            plt.savefig(os.path.join(data_dir, 'mu_maps', fname))
+            image_name = fname + f'_mode_{i}.pdf'
+            plt.savefig(os.path.join(data_dir, 'mu_maps', image_name))

--- a/pastis/plotting.py
+++ b/pastis/plotting.py
@@ -1222,5 +1222,6 @@ def plot_multimode_surface_maps(tel, mus, num_modes, mirror, cmin, cmax, data_di
         plt.tight_layout()
 
         if data_dir is not None:
+            os.makedirs(os.path.join(data_dir, 'mu_maps'), exist_ok=True)
             fname += f'_mode_{i}.pdf'
             plt.savefig(os.path.join(data_dir, 'mu_maps', fname))


### PR DESCRIPTION
This PR fixes a path error found while generating multimode tolerance plots. It creates a new folder mu_maps inside the parent directory where the data is saved.

Fixes issue #150.