### PR TITLE
Simplify pytests

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - configparser
   - flake8
   - jupyter
-  - matplotlib
+  - matplotlib<=3.5
   - numpy
   - openpyxl
   - pandas

--- a/pastis/config_pastis.ini
+++ b/pastis/config_pastis.ini
@@ -193,7 +193,7 @@ lyot_stop_ratio = 0.95
 
 [HexRingTelescope]
 ; aberration for matrix calculation, in NANOMETERS
-calibration_aberration = 100000.
+calibration_aberration = 1.
 ; log10 limits of PASTIS validity in nm WFE
 valid_range_lower = -4
 valid_range_upper = 4

--- a/pastis/tests/data/pastis_matrices/Hex2_efield_coron_imag.fits
+++ b/pastis/tests/data/pastis_matrices/Hex2_efield_coron_imag.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39bbf77176043015e8c82fd3f9b65a9c572c0f341a09d7bc5c4d384488ab879c
+size 2013120

--- a/pastis/tests/data/pastis_matrices/Hex2_efield_coron_real.fits
+++ b/pastis/tests/data/pastis_matrices/Hex2_efield_coron_real.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bccadd1cc198999b77861ff9755100d2182beb414544c78be9558dd63904a246
+size 2013120

--- a/pastis/tests/data/pastis_matrices/Hex2_matrix_piston-only.fits
+++ b/pastis/tests/data/pastis_matrices/Hex2_matrix_piston-only.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:066042aaf40578b4213f3ae720b8061e5789870bb94eb7ba31e2514cee1f442a
+size 8640

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -28,7 +28,7 @@ contrast_matrix_path = os.path.join(test_data_dir, 'data', 'pastis_matrices',
 CONTRAST_MATRIX = fits.getdata(contrast_matrix_path)
 
 # Read the 2-Hex simulator E-fields
-# From data dir: 2023-03-14T16-06-04_hexringtelescope
+# From data dir: 2023-03-14T17-10-12_hexringtelescope
 # Created on commit: 1771fc536b120fb862ff700917069e36135b20a5
 efields_path = os.path.join(test_data_dir, 'data', 'pastis_matrices')
 HEX2_E_FIELDS_REAL = fits.getdata(os.path.join(efields_path, 'Hex2_efield_coron_real.fits'))
@@ -36,7 +36,7 @@ HEX2_E_FIELDS_IMAG = fits.getdata(os.path.join(efields_path, 'Hex2_efield_coron_
 NUM_RINGS = 2
 
 # Read the 2-Hex matrix created from E-fields
-# From data dir: 2023-03-14T16-06-04_hexringtelescope
+# From data dir: 2023-03-14T17-10-12_hexringtelescope
 # Created on commit: 1771fc536b120fb862ff700917069e36135b20a5
 test_data_dir = os.path.join(util.find_package_location(), 'tests')
 matrix_path2 = os.path.join(test_data_dir, 'data', 'pastis_matrices', 'Hex2_matrix_piston-only.fits')

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -26,16 +26,16 @@ contrast_matrix_path = os.path.join(test_data_dir, 'data', 'pastis_matrices',
 CONTRAST_MATRIX = fits.getdata(contrast_matrix_path)
 
 # Read the 2-Hex simulator E-fields
-# From data dir:
-# Created on commit:
+# From data dir: 2023-03-14T16-06-04_hexringtelescope
+# Created on commit: 1771fc536b120fb862ff700917069e36135b20a5
 efields_path = os.path.join(test_data_dir, 'data', 'pastis_matrices')
-HEX2_E_FIELDS_REAL = fits.getdata(os.path.join(efields_path, 'efield_coron_real.fits'))
-HEX2_E_FIELDS_IMAG = fits.getdata(os.path.join(efields_path, 'efield_coron_imag.fits'))
+HEX2_E_FIELDS_REAL = fits.getdata(os.path.join(efields_path, 'Hex2_efield_coron_real.fits'))
+HEX2_E_FIELDS_IMAG = fits.getdata(os.path.join(efields_path, 'Hex2_efield_coron_imag.fits'))
 NUM_RINGS = 2
 
 # Read the 2-Hex matrix created from E-fields
-# From data dir:
-# Created on commit:
+# From data dir: 2023-03-14T16-06-04_hexringtelescope
+# Created on commit: 1771fc536b120fb862ff700917069e36135b20a5
 test_data_dir = os.path.join(util.find_package_location(), 'tests')
 matrix_path2 = os.path.join(test_data_dir, 'data', 'pastis_matrices', 'Hex2_matrix_piston-only.fits')
 HEX2_INTENSITY_MATRIX = fits.getdata(matrix_path2)

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -148,4 +148,4 @@ def test_2hex_efields_matrix_regression(tmpdir):
     assert (new_matrix == new_matrix.T).all(), 'Calculated 2-Hex PASTIS matrix is not symmetric'
 
     # Check that new matrix is equal to previously computed matrix that is known to be correct
-    assert np.allclose(new_matrix, HEX2_INTENSITY_MATRIX, rtol=1e-22, atol=1e-24), 'Calculated 2-Hex PASTIS matrix is wrong.'
+    assert np.allclose(new_matrix, HEX2_INTENSITY_MATRIX, rtol=1e-22, atol=1e-22), 'Calculated 2-Hex PASTIS matrix is wrong.'

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -148,4 +148,4 @@ def test_2hex_efields_matrix_regression(tmpdir):
     assert (new_matrix == new_matrix.T).all(), 'Calculated 2-Hex PASTIS matrix is not symmetric'
 
     # Check that new matrix is equal to previously computed matrix that is known to be correct
-    assert np.allclose(new_matrix, HEX2_INTENSITY_MATRIX, rtol=1e-24, atol=1e-24), 'Calculated 2-Hex PASTIS matrix is wrong.'
+    assert np.allclose(new_matrix, HEX2_INTENSITY_MATRIX, rtol=1e-22, atol=1e-24), 'Calculated 2-Hex PASTIS matrix is wrong.'

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -1,10 +1,12 @@
 import os
 from astropy.io import fits
 import astropy.units as u
+import hcipy
 import numpy as np
 
 from pastis.config import CONFIG_PASTIS
-import pastis.matrix_generation.matrix_building_numerical as matrix_calc
+from pastis.matrix_generation.matrix_building_numerical import pastis_from_contrast_matrix
+from pastis.matrix_generation.matrix_from_efields import MatrixEfieldHex, pastis_matrix_from_efields
 from pastis.simulators.scda_telescopes import HexRingAPLC
 from pastis import util
 
@@ -48,7 +50,7 @@ hex2 = HexRingAPLC(optics_input, NUM_RINGS, sampling)
 
 unaberrated_coro_psf, direct = hex2.calc_psf(ref=True)
 NORM = np.max(direct)
-EFIELD_REF, _inter = hex2.calc_psf(return_intermediate='efields')
+EFIELD_REF, _inter = hex2.calc_psf(return_intermediate='efield')
 
 
 def test_semi_analytic_matrix_from_contrast_matrix():
@@ -136,10 +138,10 @@ def test_2hex_efields_matrix_regression(tmpdir):
     WHICH_DM = 'seg_mirror'
     DM_SPEC = 1
 
-    new_matrix_calc = matrix_calc.MatrixEfieldHex(which_dm=WHICH_DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
-                                                  calc_science=True, calc_wfs=False,
-                                                  initial_path=CONFIG_PASTIS.get('local', 'local_data_path'),
-                                                  norm_one_photon=True)
+    new_matrix_calc = MatrixEfieldHex(which_dm=WHICH_DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
+                                      calc_science=True, calc_wfs=False,
+                                      initial_path=CONFIG_PASTIS.get('local', 'local_data_path'),
+                                      norm_one_photon=True)
     new_matrix_calc.calc()
     new_matrix = new_matrix_calc.matrix_pastis
 

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -139,7 +139,7 @@ def test_2hex_efields_matrix_regression(tmpdir):
 
     new_matrix_calc = MatrixEfieldHex(which_dm=WHICH_DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
                                       calc_science=True, calc_wfs=False,
-                                      initial_path=CONFIG_PASTIS.get('local', 'local_data_path'),
+                                      initial_path=tmpdir,
                                       norm_one_photon=True)
     new_matrix_calc.calc()
     new_matrix = new_matrix_calc.matrix_pastis

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -48,9 +48,9 @@ optics_input = os.path.join(util.find_repo_location(), 'data', 'SCDA')
 sampling = CONFIG_PASTIS.getfloat('HexRingTelescope', 'sampling')
 hex2 = HexRingAPLC(optics_input, NUM_RINGS, sampling)
 
-unaberrated_coro_psf, direct = hex2.calc_psf(ref=True)
+unaberrated_coro_psf, direct = hex2.calc_psf(ref=True, norm_one_photon=True)
 NORM = np.max(direct)
-EFIELD_REF, _inter = hex2.calc_psf(return_intermediate='efield')
+EFIELD_REF, _inter = hex2.calc_psf(return_intermediate='efield', norm_one_photon=True)
 
 
 def test_semi_analytic_matrix_from_contrast_matrix():

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -3,7 +3,9 @@ from astropy.io import fits
 import astropy.units as u
 import numpy as np
 
+from pastis.config import CONFIG_PASTIS
 import pastis.matrix_generation.matrix_building_numerical as matrix_calc
+from pastis.simulators.scda_telescopes import HexRingAPLC
 from pastis import util
 
 
@@ -13,7 +15,7 @@ from pastis import util
 test_data_dir = os.path.join(util.find_package_location(), 'tests')
 matrix_path = os.path.join(test_data_dir, 'data', 'pastis_matrices', 'LUVOIR_small_matrix_piston-only.fits')
 LUVOIR_INTENSITY_MATRIX_SMALL = fits.getdata(matrix_path)
-NSEG = LUVOIR_INTENSITY_MATRIX_SMALL.shape[0]
+NSEG_LUVOIR = LUVOIR_INTENSITY_MATRIX_SMALL.shape[0]
 
 # Read the LUVOIR-A small APLC contrast matrix
 # From data dir: 2021-03-21T19-15-50_luvoir-small
@@ -23,9 +25,34 @@ contrast_matrix_path = os.path.join(test_data_dir, 'data', 'pastis_matrices',
                                     'contrast_matrix_LUVOIR_small_piston-only.fits')
 CONTRAST_MATRIX = fits.getdata(contrast_matrix_path)
 
+# Read the 2-Hex simulator E-fields
+# From data dir:
+# Created on commit:
+efields_path = os.path.join(test_data_dir, 'data', 'pastis_matrices')
+HEX2_E_FIELDS_REAL = fits.getdata(os.path.join(efields_path, 'efield_coron_real.fits'))
+HEX2_E_FIELDS_IMAG = fits.getdata(os.path.join(efields_path, 'efield_coron_imag.fits'))
+NUM_RINGS = 2
+
+# Read the 2-Hex matrix created from E-fields
+# From data dir:
+# Created on commit:
+test_data_dir = os.path.join(util.find_package_location(), 'tests')
+matrix_path2 = os.path.join(test_data_dir, 'data', 'pastis_matrices', 'Hex2_matrix_piston-only.fits')
+HEX2_INTENSITY_MATRIX = fits.getdata(matrix_path2)
+NMODES_HEX2 = HEX2_INTENSITY_MATRIX.shape[0]
+
+# Set up 2-Hex simulator instance and its basic properties
+optics_input = os.path.join(util.find_repo_location(), 'data', 'SCDA')
+sampling = CONFIG_PASTIS.getfloat('HexRingTelescope', 'sampling')
+hex2 = HexRingAPLC(optics_input, NUM_RINGS, sampling)
+
+unaberrated_coro_psf, direct = hex2.calc_psf(ref=True)
+NORM = np.max(direct)
+EFIELD_REF, _inter = hex2.calc_psf(return_intermediate='efields')
+
 
 def test_semi_analytic_matrix_from_contrast_matrix():
-    """Test that the analytical calculation of the semi-analytical PASTIS matrix calculation is correct."""
+    """Test that the analytical calculation of the semi-analytical PASTIS matrix calculation from intensity images is correct."""
 
     # Create seglist and drop in calibration aberration the matrices in tests/data have been created with
     seglist = util.get_segment_list('LUVOIR')
@@ -33,7 +60,7 @@ def test_semi_analytic_matrix_from_contrast_matrix():
 
     ### Test the case in which the coronagraph floor is constant across all matrix measurements
 
-    # Hard-code the contrast floor the matrix was generated with
+    # Hard-code the contrast floor the matrix was generated with (LUVOIR small)
     coro_floor = 4.2376360700565846e-11
     # Calculate the PASTIS matrix under assumption of a CONSTANT coronagraph floor
     pastis_matrix_constant = matrix_calc.pastis_from_contrast_matrix(CONTRAST_MATRIX, seglist, wfe_aber, coro_floor)
@@ -44,11 +71,11 @@ def test_semi_analytic_matrix_from_contrast_matrix():
 
     # Construct random coro floor matrix
     coro_floor_state = np.random.RandomState()
-    coro_floor_matrix_full = coro_floor_state.normal(loc=0, scale=1, size=(NSEG, NSEG)) * coro_floor
+    coro_floor_matrix_full = coro_floor_state.normal(loc=0, scale=1, size=(NSEG_LUVOIR, NSEG_LUVOIR)) * coro_floor
     random_coro_floor_matrix = np.triu(coro_floor_matrix_full)
 
     # Subtract the original contrast floor from the contrast matrix
-    constant_coro_floor_matrix = np.ones((NSEG, NSEG)) * coro_floor
+    constant_coro_floor_matrix = np.ones((NSEG_LUVOIR, NSEG_LUVOIR)) * coro_floor
     contrast_matrix_subtracted = CONTRAST_MATRIX - np.triu(constant_coro_floor_matrix)
 
     # Add the random c0 matrix to subtracted contrast matrix
@@ -60,6 +87,19 @@ def test_semi_analytic_matrix_from_contrast_matrix():
     assert np.allclose(pastis_matrix_drift, LUVOIR_INTENSITY_MATRIX_SMALL, rtol=1e-8, atol=1e-24), 'Calculated LUVOIR small PASTIS matrix is wrong.'
 
 
+def test_semi_analytic_matrix_from_efields():
+    """Test that the analytical calculation of the semi-analytical PASTIS matrix calculation from electric fields is correct."""
+    wfe_aber = 1e-9    # m
+
+    # Recombine complex E-fields
+    E_FIELDS = HEX2_E_FIELDS_REAL + 1j * HEX2_E_FIELDS_IMAG
+
+    # Calculate the PASTIS matrix under assumption of a CONSTANT coronagraph floor
+    pastis_matrix_constant = matrix_calc.pastis_matrix_from_efields(E_FIELDS, EFIELD_REF, NORM, hex2.dh_mask, wfe_aber)
+    # Compare to PASTIS matrix in the tests folder
+    assert np.allclose(pastis_matrix_constant, HEX2_INTENSITY_MATRIX, rtol=1e-8, atol=1e-24), 'Calculated 2-Hex PASTIS matrix is wrong.'
+
+
 def test_pastis_forward_model():
     """Test that the PASTIS matrix propagates aberrations correctly
     This is essentially a test for the hockey stick curve, inside its valid range."""
@@ -69,37 +109,43 @@ def test_pastis_forward_model():
     relative_tolerances = [1e-3, 1e-2, 1e-1]
     absolute_tolerances = [1e-15, 1e-9, 1e-8]
 
-    # Calculate coronagraph floor, direct PSF peak normalization factor, and return E2E sim instance
-    contrast_floor, norm, luvoir_sim = matrix_calc.calculate_unaberrated_contrast_and_normalization('LUVOIR', 'small')
+    # Known from aberration-free image (2-Hex simulator)
+    contrast_floor = 4.1713373582172286e-11
 
     for rms, rel_tol, abs_tol in zip(rms_values, relative_tolerances, absolute_tolerances):
         # Create random aberration coefficients on segments, scaled to total rms
-        aber = util.create_random_rms_values(NSEG, rms)
+        aber = util.create_random_rms_values(NMODES_HEX2, rms)
 
         # Contrast from PASTIS propagation
-        contrasts_matrix = (util.pastis_contrast(aber, LUVOIR_INTENSITY_MATRIX_SMALL) + contrast_floor)
+        contrasts_matrix = (util.pastis_contrast(aber, HEX2_INTENSITY_MATRIX) + contrast_floor)
 
         # Contrast from E2E propagator
-        for nb_seg in range(NSEG):
-            luvoir_sim.set_segment(nb_seg + 1, aber[nb_seg].to(u.m).value / 2, 0, 0)
-        psf_luvoir = luvoir_sim.calc_psf()
-        psf_luvoir /= norm
-        contrasts_e2e = (util.dh_mean(psf_luvoir, luvoir_sim.dh_mask))
+        for nb_seg in range(NMODES_HEX2):
+            hex2.set_segment(nb_seg, aber[nb_seg].to(u.m).value / 2, 0, 0)
+        psf_2hex = hex2.calc_psf()
+        psf_2hex /= NORM
+        contrasts_e2e = (util.dh_mean(psf_2hex, hex2.dh_mask))
 
         assert np.isclose(contrasts_matrix, contrasts_e2e, rtol=rel_tol, atol=abs_tol), f'Calculated contrasts from PASTIS and E2E are not the same for rms={rms} and rtol={rel_tol}.'
 
 
-def test_luvoir_intensity_matrix_regression(tmpdir):
-    """Check multiprocessed matrix calculation against previously calculated matrix"""
+def test_2hex_efields_matrix_regression(tmpdir):
+    """Check matrix calculation against previously calculated matrix"""
 
-    # Calculate new LUVOIR small PASTIS matrix
-    new_matrix_calc = matrix_calc.MatrixIntensityLuvoirA(design='small', savepsfs=False, saveopds=False, initial_path=tmpdir)
+    # Calculate new 2-Hex PASTIS matrix from E-fields
+    WHICH_DM = 'seg_mirror'
+    DM_SPEC = 1
+
+    new_matrix_calc = matrix_calc.MatrixEfieldHex(which_dm=WHICH_DM, dm_spec=DM_SPEC, num_rings=NUM_RINGS,
+                                                  calc_science=True, calc_wfs=False,
+                                                  initial_path=CONFIG_PASTIS.get('local', 'local_data_path'),
+                                                  norm_one_photon=True)
     new_matrix_calc.calc()
     new_matrix = new_matrix_calc.matrix_pastis
 
     # Check that the calculated PASTIS matrix is symmetric
-    assert (new_matrix == new_matrix.T).all(), 'Calculated LUVOIR small PASTIS matrix is not symmetric'
+    assert (new_matrix == new_matrix.T).all(), 'Calculated 2-Hex PASTIS matrix is not symmetric'
 
     # Check that new matrix is equal to previously computed matrix that is known to be correct, down to numerical noise
     # on the order of 1e-23
-    assert np.allclose(new_matrix, LUVOIR_INTENSITY_MATRIX_SMALL, rtol=1e-8, atol=1e-24), 'Calculated LUVOIR small PASTIS matrix is wrong.'
+    assert np.allclose(new_matrix, HEX2_INTENSITY_MATRIX, rtol=1e-8, atol=1e-24), 'Calculated 2-Hex PASTIS matrix is wrong.'

--- a/pastis/tests/test_pastis_matrix.py
+++ b/pastis/tests/test_pastis_matrix.py
@@ -40,7 +40,7 @@ NUM_RINGS = 2
 test_data_dir = os.path.join(util.find_package_location(), 'tests')
 matrix_path2 = os.path.join(test_data_dir, 'data', 'pastis_matrices', 'Hex2_matrix_piston-only.fits')
 HEX2_INTENSITY_MATRIX = fits.getdata(matrix_path2)
-NMODES_HEX2 = HEX2_INTENSITY_MATRIX.shape[0]
+NSEG_HEX2 = 3 * NUM_RINGS * (NUM_RINGS + 1) + 1
 
 # Set up 2-Hex simulator instance and its basic properties
 optics_input = os.path.join(util.find_repo_location(), 'data', 'SCDA')
@@ -115,15 +115,15 @@ def test_pastis_forward_model():
 
     for rms, rel_tol, abs_tol in zip(rms_values, relative_tolerances, absolute_tolerances):
         # Create random aberration coefficients on segments, scaled to total rms
-        aber = util.create_random_rms_values(NMODES_HEX2, rms)
+        aber = util.create_random_rms_values(NSEG_HEX2, rms)
 
         # Contrast from PASTIS propagation
         contrasts_matrix = (util.pastis_contrast(aber, HEX2_INTENSITY_MATRIX) + contrast_floor)
 
         # Contrast from E2E propagator
-        for nb_seg in range(NMODES_HEX2):
+        for nb_seg in range(NSEG_HEX2):
             hex2.set_segment(nb_seg, aber[nb_seg].to(u.m).value / 2, 0, 0)
-        psf_2hex = hex2.calc_psf()
+        psf_2hex = hex2.calc_psf(norm_one_photon=True)
         psf_2hex /= NORM
         contrasts_e2e = util.dh_mean(psf_2hex, hex2.dh_mask)
 


### PR DESCRIPTION
- Fixes #147
- Sets calibration aberration for Hexring telescopes to 1 nm per single segment (see below)
- Pins matplotlib version to <=3.5 (see #155)

This PR gets rid of the full calculation of the 120-segment LUVOIR-A PASTIS matrix from intensities for a regression test. It is replaced with a PASTIS matrix calculation for the 2-Hex telescope, and from E-fields. This test now runs in a couple of minutes instead of 45 minutes to an hour.

I kept the LUVOIR matrix test files for now to be able to run the test that checks the calculation of the PASTIS matrix from a contrast matrix calculated form intensities. I might revisit this in the future, although the LUVOIR files are also needed for the PASTIS analysis tests.

---------

This PR also fixes the calibration aberration for the HexRing telescopes to 1 nm. A 1 nm piston WFE on a 19-segment aperture (2 rings) converts to a global WFE rms of 0.23 nm. (0.1 nm on a single segment yields a global WFE rms of 0.023 nm, 10 nm on one segment is 2.23 nm globally and 100 on one segment 22.94 nm globally.)

A 0.23 nm global rms WFE falls close to the knee of the hockey stick curve below, generated for a 2-Hex telescope with a sub 1e-10 APLC like on this repo. The x-axis shows the global WFE rms, the y-axis the normalized intensity in a circular DH from 3.4 to 12 $\lambda/D$.
![Screenshot 2023-03-14 at 14 58 26](https://user-images.githubusercontent.com/29508965/225246892-55639cb1-0056-492c-800f-64b4058aa888.png)

I looked at what the different calibration aberrations do to the matrix diagonal - in principle, the matrix should turn out exactly the same for no matter which amount of calibration aberration since it gets normalized anyway. However, as we can see in the plot below, a calibration aberration that is too large does not work as we start going into phase wrapping on the individual segments. This is hard to determine when applying a completely random phase map on all segments, so it's best to stick to a small calibration aberration in any case.
Below, the x-axis shows the local aberration modes for which the matrix is created. Here, this is piston, tip and tilt on the 2-Hex telescope with 19 segments total (I use a piston-only matrix for the pytests). The y-axis shows the contrast contribution of each individual mode, here in contrast/nm**2.
The differently colored lines corrsepond to the matrix diagonal when calibrated with different amplitudes of WFE calibration aberration. The lines for 0.1 nm, 1 nm and 10 nm (applied on a single segment when building the PASTIS matrix) are overlapping.
![Screenshot 2023-03-14 at 15 25 03](https://user-images.githubusercontent.com/29508965/225258230-f7d33404-6d5f-4d31-9a31-245624ef3578.png)
