### PR TITLE
Minor improvement in SM generation

### DIFF
--- a/notebooks/compare_sm_mode_bases.ipynb
+++ b/notebooks/compare_sm_mode_bases.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a8c7082b",
+   "metadata": {},
+   "source": [
+    "# Compare SM mode bases\n",
+    "\n",
+    "Compare two hcipy mode bases that have been saved to asdf files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d862b0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asdf\n",
+    "import os\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import hcipy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fadf159",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original_file = asdf.open('original.asdf')\n",
+    "other_file = asdf.open('basis.asdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffed89b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original_file.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16eb1f9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original = original_file['mode_basis']['transformation_matrix']\n",
+    "other = other_file['mode_basis']['transformation_matrix']\n",
+    "\n",
+    "print(original.shape)\n",
+    "print(other.shape)\n",
+    "\n",
+    "dim = int(np.sqrt(original.shape[0]))\n",
+    "\n",
+    "assert original.shape == other.shape, \"Not same shape\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "502a5a4f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = 37\n",
+    "diff = original[:, index].reshape(dim, dim) - other[:, index].reshape(dim, dim)\n",
+    "\n",
+    "plt.imshow(diff)\n",
+    "plt.colorbar()\n",
+    "\n",
+    "print(np.sum(diff))\n",
+    "print(np.min(diff))\n",
+    "print(np.max(diff))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c555678",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.sum(original - other)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c87edc6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(original[:, -3].reshape(dim, dim), cmap='RdBu')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6adeabc1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pastis/simulators/generic_segmented_telescopes.py
+++ b/pastis/simulators/generic_segmented_telescopes.py
@@ -664,7 +664,7 @@ class SegmentedTelescope(Telescope):
                                                                   starting_mode=1, radial_cutoff=False)
         # # For all Zernikes on this first segment, cut them to the actual segment support
         for zernike_num in range(0, n_zernikes):
-            local_zernike_basis._transformation_matrix[:, zernike_num] = seg_evaluated[first_seg] * local_zernike_basis._transformation_matrix[:, zernike_num]
+            local_zernike_basis._transformation_matrix[:, zernike_num] *= seg_evaluated[first_seg]
 
         # Expand the basis of influence functions from one segment to all segments
         for seg_num in range(1, self.nseg):
@@ -674,7 +674,7 @@ class SegmentedTelescope(Telescope):
                                                                           starting_mode=1, radial_cutoff=False)
             # Adjust each transformation matrix again for some reason
             for zernike_num in range(0, n_zernikes):
-                local_zernike_basis_tmp._transformation_matrix[:, zernike_num] = seg_evaluated[seg_num] * local_zernike_basis_tmp._transformation_matrix[:, zernike_num]
+                local_zernike_basis_tmp._transformation_matrix[:, zernike_num] *= seg_evaluated[seg_num]
             local_zernike_basis.extend(local_zernike_basis_tmp)  # extend our basis with this new segment
 
         self.sm = hcipy.optics.DeformableMirror(local_zernike_basis)

--- a/pastis/simulators/generic_segmented_telescopes.py
+++ b/pastis/simulators/generic_segmented_telescopes.py
@@ -661,7 +661,7 @@ class SegmentedTelescope(Telescope):
         local_zernike_basis = hcipy.mode_basis.make_zernike_basis(n_zernikes,
                                                                   self.segment_circumscribed_diameter,
                                                                   self.pupil_grid.shifted(-self.seg_pos[first_seg]),
-                                                                  starting_mode=1)
+                                                                  starting_mode=1, radial_cutoff=False)
         # # For all Zernikes on this first segment, cut them to the actual segment support
         for zernike_num in range(0, n_zernikes):
             local_zernike_basis._transformation_matrix[:, zernike_num] = seg_evaluated[first_seg] * local_zernike_basis._transformation_matrix[:, zernike_num]
@@ -671,7 +671,7 @@ class SegmentedTelescope(Telescope):
             local_zernike_basis_tmp = hcipy.mode_basis.make_zernike_basis(n_zernikes,
                                                                           self.segment_circumscribed_diameter,
                                                                           self.pupil_grid.shifted(-self.seg_pos[seg_num]),
-                                                                          starting_mode=1)
+                                                                          starting_mode=1, radial_cutoff=False)
             # Adjust each transformation matrix again for some reason
             for zernike_num in range(0, n_zernikes):
                 local_zernike_basis_tmp._transformation_matrix[:, zernike_num] = seg_evaluated[seg_num] * local_zernike_basis_tmp._transformation_matrix[:, zernike_num]

--- a/pastis/simulators/generic_segmented_telescopes.py
+++ b/pastis/simulators/generic_segmented_telescopes.py
@@ -662,7 +662,8 @@ class SegmentedTelescope(Telescope):
                                                                   self.segment_circumscribed_diameter,
                                                                   self.pupil_grid.shifted(-self.seg_pos[first_seg]),
                                                                   starting_mode=1, radial_cutoff=False)
-        # # For all Zernikes on this first segment, cut them to the actual segment support
+
+        # For all Zernikes on this first segment, cut them to the actual segment support
         for zernike_num in range(0, n_zernikes):
             local_zernike_basis._transformation_matrix[:, zernike_num] *= seg_evaluated[first_seg]
 

--- a/pastis/simulators/generic_segmented_telescopes.py
+++ b/pastis/simulators/generic_segmented_telescopes.py
@@ -672,7 +672,7 @@ class SegmentedTelescope(Telescope):
                                                                           self.segment_circumscribed_diameter,
                                                                           self.pupil_grid.shifted(-self.seg_pos[seg_num]),
                                                                           starting_mode=1, radial_cutoff=False)
-            # Adjust each transformation matrix again for some reason
+            # Cut to segment support
             for zernike_num in range(0, n_zernikes):
                 local_zernike_basis_tmp._transformation_matrix[:, zernike_num] *= seg_evaluated[seg_num]
             local_zernike_basis.extend(local_zernike_basis_tmp)  # extend our basis with this new segment

--- a/pastis/simulators/generic_segmented_telescopes.py
+++ b/pastis/simulators/generic_segmented_telescopes.py
@@ -662,7 +662,7 @@ class SegmentedTelescope(Telescope):
                                                                   self.segment_circumscribed_diameter,
                                                                   self.pupil_grid.shifted(-self.seg_pos[first_seg]),
                                                                   starting_mode=1)
-        # For all Zernikes, adjust their transformation matrix (by doing what?)
+        # # For all Zernikes on this first segment, cut them to the actual segment support
         for zernike_num in range(0, n_zernikes):
             local_zernike_basis._transformation_matrix[:, zernike_num] = seg_evaluated[first_seg] * local_zernike_basis._transformation_matrix[:, zernike_num]
 


### PR DESCRIPTION
I am adding some simplifications and clarifying comments. End goal is to speed up the creation of the segmented mirrors in a simulator, see #160.

The script below speeds up from a runtime of 2.43608 sec to 2.31140 sec in the test script below, which is about 5% faster. This is not much but shaves off a couple of minutes on the really large mirrors.

Testing script used for this work:
```python
import os
import time
import hcipy

from pastis.config import CONFIG_PASTIS
from pastis.simulators.scda_telescopes import HexRingAPLC
from pastis import util


NUM_RINGS = 2
optics_input = os.path.join(util.find_repo_location(), 'data', 'SCDA')
sampling = CONFIG_PASTIS.getfloat('HexRingTelescope', 'sampling')
sim = HexRingAPLC(optics_input, NUM_RINGS, sampling)

t1 = time.perf_counter()

n_zernikes = 2
seg_evaluated = sim._create_evaluated_segment_grid()

# Create a single segment influence function with all Zernikes n_zernikes
# This allows us to have an initial mode basis to extend with all the other segments later on
first_seg = 0  # Create this first influence function on the first segment only
local_zernike_basis = hcipy.mode_basis.make_zernike_basis(n_zernikes,
                                                          sim.segment_circumscribed_diameter,
                                                          sim.pupil_grid.shifted(-sim.seg_pos[first_seg]),
                                                          starting_mode=1, radial_cutoff=False)

# For all Zernikes on this first segment, cut them to the actual segment support
for zernike_num in range(0, n_zernikes):
    local_zernike_basis._transformation_matrix[:, zernike_num] *= seg_evaluated[first_seg]

# Expand the basis of influence functions from one segment to all segments
for seg_num in range(1, sim.nseg):
    local_zernike_basis_tmp = hcipy.mode_basis.make_zernike_basis(n_zernikes,
                                                                  sim.segment_circumscribed_diameter,
                                                                  sim.pupil_grid.shifted(-sim.seg_pos[seg_num]),
                                                                  starting_mode=1, radial_cutoff=False)
    # Cut to segment support
    for zernike_num in range(0, n_zernikes):
        local_zernike_basis_tmp._transformation_matrix[:, zernike_num] *= seg_evaluated[seg_num]
    local_zernike_basis.extend(local_zernike_basis_tmp)  # extend our basis with this new segment

t2 = time.perf_counter()

print(local_zernike_basis.transformation_matrix.shape)
# hcipy.write_mode_basis(local_zernike_basis, 'basis.asdf')
print(f'Elapsed time for SM generation: {t2 - t1}')

```