### PR TITLE
Correct scaling of ELT segment positions

### DIFF
--- a/notebooks/ELT/2_test-ELT-sim-class.ipynb
+++ b/notebooks/ELT/2_test-ELT-sim-class.ipynb
@@ -19,7 +19,6 @@
     "import hcipy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import time\n",
     "\n",
     "from pastis.config import CONFIG_PASTIS\n",
     "from pastis.simulators.elt_imaging import ELTHarmoniSPC\n",

--- a/notebooks/ELT/2_test-ELT-sim-class.ipynb
+++ b/notebooks/ELT/2_test-ELT-sim-class.ipynb
@@ -19,6 +19,7 @@
     "import hcipy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "import time\n",
     "\n",
     "from pastis.config import CONFIG_PASTIS\n",
     "from pastis.simulators.elt_imaging import ELTHarmoniSPC\n",
@@ -114,7 +115,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#elt.create_segmented_mirror(2)  # TOOK EXTREMELY LONG TO RUN!! I let it run over night..."
+    "elt.create_segmented_mirror(2)  # TOOK EXTREMELY LONG TO RUN!! I let it run over night..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6e011e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#elt.remove_segmented_mirror()"
    ]
   },
   {
@@ -150,7 +161,7 @@
    "source": [
     "for i in range(seglist.shape[0]):\n",
     "    #elt.set_sm_segment(segid, zernike_number, amplitude)  # m of rms surface\n",
-    "    elt.set_sm_segment(i+1, 1, tip[i]*100000)"
+    "    elt.set_sm_segment(i+1, 1, tip[i])"
    ]
   },
   {
@@ -170,8 +181,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "plt.figure(figsize=(15, 15))\n",
     "phase = inter['seg_mirror'].phase\n",
-    "hcipy.imshow_field(phase, cmap='Reds', origin='lower', mask=elt.aperture)\n",
+    "hcipy.imshow_field(phase, cmap='RdBu', origin='lower', mask=elt.aperture)\n",
     "plt.colorbar()"
    ]
   },

--- a/notebooks/ELT/2_test-ELT-sim-class.ipynb
+++ b/notebooks/ELT/2_test-ELT-sim-class.ipynb
@@ -115,13 +115,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "elt.create_segmented_mirror(2)  # TOOK EXTREMELY LONG TO RUN!! I let it run over night..."
+    "elt.create_segmented_mirror(2)  # TAKES EXTREMELY LONG TO RUN!! About 2 hours for 2 modes."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6e011e8",
+   "id": "2e5a8ec0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,9 +147,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "piston = np.random.uniform(low=1e-10, high=5e-10, size=(aber_segnum,))\n",
-    "tip = np.random.uniform(low=1e-10, high=5e-10, size=(aber_segnum,))\n",
-    "tilt = np.random.uniform(low=1e-10, high=5e-10, size=(aber_segnum,))"
+    "piston = np.random.uniform(low=1e-8, high=1e-7, size=(aber_segnum,))\n",
+    "tip = np.random.uniform(low=1e-8, high=1e-7, size=(aber_segnum,))\n",
+    "tilt = np.random.uniform(low=1e-8, high=1e-7, size=(aber_segnum,))"
    ]
   },
   {
@@ -181,7 +181,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(15, 15))\n",
+    "plt.figure(figsize=(7, 7))\n",
     "phase = inter['seg_mirror'].phase\n",
     "hcipy.imshow_field(phase, cmap='RdBu', origin='lower', mask=elt.aperture)\n",
     "plt.colorbar()"

--- a/pastis/simulators/elt_imaging.py
+++ b/pastis/simulators/elt_imaging.py
@@ -38,6 +38,9 @@ class ELTHarmoniSPC(SegmentedAPLC):
         aper_ind_read = hcipy.read_fits(os.path.join(input_dir, aper_ind_fname))
         aper_ind = hcipy.Field(aper_ind_read.ravel(), pupil_grid)
         seg_pos = load_segment_centers(input_dir, aper_ind_fname, num_seg, diameter=0.98)
+        # The segment positions saved in the indexed aperture file are already scaled to the overall ELT diameter,
+        # so the function above does not have to do that anymore, and we pass it a diameter o ~1. This has been scaled
+        # manually so that the local ode bases overlap as good as possible with the aperture segments.
 
         # Load apodizer
         apod_read = hcipy.read_fits(os.path.join(input_dir, apod_fname))

--- a/pastis/simulators/elt_imaging.py
+++ b/pastis/simulators/elt_imaging.py
@@ -25,7 +25,7 @@ class ELTHarmoniSPC(SegmentedAPLC):
         pxsize = self.spc_dict[spc_design]['pxsize']
         iwa = self.spc_dict[spc_design]['iwa']
         owa = self.spc_dict[spc_design]['owa']
-        seg_flat_to_flat = 1.45   # m
+        seg_diameter_circumscribed = 1.45   # m
 
         pupil_grid = hcipy.make_pupil_grid(dims=pxsize, diameter=diameter)
         lam_over_d = wvln / diameter

--- a/pastis/simulators/elt_imaging.py
+++ b/pastis/simulators/elt_imaging.py
@@ -1,6 +1,5 @@
 import os
 import hcipy
-import numpy as np
 
 from pastis.config import CONFIG_PASTIS
 from pastis.simulators.generic_segmented_telescopes import SegmentedAPLC, load_segment_centers

--- a/pastis/simulators/elt_imaging.py
+++ b/pastis/simulators/elt_imaging.py
@@ -37,7 +37,7 @@ class ELTHarmoniSPC(SegmentedAPLC):
         # Load indexed segmented aperture
         aper_ind_read = hcipy.read_fits(os.path.join(input_dir, aper_ind_fname))
         aper_ind = hcipy.Field(aper_ind_read.ravel(), pupil_grid)
-        seg_pos = load_segment_centers(input_dir, aper_ind_fname, num_seg, diameter)
+        seg_pos = load_segment_centers(input_dir, aper_ind_fname, num_seg, diameter=1)
         seg_diameter_circumscribed = 2 / np.sqrt(3) * seg_flat_to_flat    # m
 
         # Load apodizer

--- a/pastis/simulators/elt_imaging.py
+++ b/pastis/simulators/elt_imaging.py
@@ -37,8 +37,7 @@ class ELTHarmoniSPC(SegmentedAPLC):
         # Load indexed segmented aperture
         aper_ind_read = hcipy.read_fits(os.path.join(input_dir, aper_ind_fname))
         aper_ind = hcipy.Field(aper_ind_read.ravel(), pupil_grid)
-        seg_pos = load_segment_centers(input_dir, aper_ind_fname, num_seg, diameter=1)
-        seg_diameter_circumscribed = 2 / np.sqrt(3) * seg_flat_to_flat    # m
+        seg_pos = load_segment_centers(input_dir, aper_ind_fname, num_seg, diameter=0.98)
 
         # Load apodizer
         apod_read = hcipy.read_fits(os.path.join(input_dir, apod_fname))


### PR DESCRIPTION
This PR fixes two things:
- the circumscribed diameter of the ELT segments
- the size and overlap of the local mode bases on all segments

### Segment size

In hcipiy, the variable used to define the segment size is just called `segment_size` (see here; https://github.com/ehpor/hcipy/blob/2b707bcfa337afc63078a8f798e8b978c9bc7737/hcipy/aperture/realistic.py#L936), and I only figured out now that this refers to the circumscribed, or point-to-point diameter of a segment. This PR fixes this in my code.

### Mode basis overlap

The segment positions saved in the fits file of the ELT indexed aperture are already scaled to the total diameter of the primary mirror, so the function that loads the segment points does not need to scale them again, which is why I set the diameter there to ~1. This yielded a segment basis that was still a bit off compared to the actual aperture:
<img width="541" alt="Screenshot 2023-05-15 at 23 31 12" src="https://github.com/spacetelescope/PASTIS/assets/29508965/c3ed5aee-b646-4ed3-a69f-57a8e952d8ec">

I then manually set the diameter the segments are scaled to to 0.98, which aligns the mode bases with the segments:
<img width="487" alt="Screenshot 2023-05-16 at 20 18 20" src="https://github.com/spacetelescope/PASTIS/assets/29508965/f9125482-1861-4a36-8b06-a35f19edd289">


This fix leaves the segment position scaling in the actual indexed aperture file inconsistent with the other files like LUVOIR, but this was a much faster fix than recreating the files and it only influences the ELT case so I chose to do it this way.