### PR TITLE
Suppress fontTools.subset logs in pastis logging

### DIFF
--- a/pastis/util.py
+++ b/pastis/util.py
@@ -723,6 +723,9 @@ def setup_pastis_logging(experiment_path, name):
     log.info("LOG SETUP: Experiment log will save messages of {} or higher to {}".format(logging.getLevelName(experiment_hander.level),
                                                                                          experiment_logfile_path))
 
+    # Suppress fontTools.subset logs
+    logging.getLogger('fontTools.subset').level = logging.WARN
+
 
 class PDF(fpdf.FPDF):
     """Subclass from fpdf.FPDF to be able to add a header and footer."""


### PR DESCRIPTION
See title. These have been taking over the logs for a while now and it's very annoying.

I don't know what caused these to start popping up, but there's enough documentation to understand how to deal with it:
https://pyfpdf.github.io/fpdf2/Logging.html

Tested and works.